### PR TITLE
record: error if CNAME record addresses don't end in periods

### DIFF
--- a/record.go
+++ b/record.go
@@ -3,6 +3,8 @@ package namecheap
 import (
 	"bytes"
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform/helper/hashcode"
 )
 
@@ -34,6 +36,10 @@ func (c *Client) ReadRecord(domain string, hashId int) (*Record, error) {
 }
 
 func (c *Client) UpdateRecord(domain string, hashId int, record *Record) error {
+	if strings.EqualFold(record.RecordType, "CNAME") && !strings.HasSuffix(record.Address, ".") {
+		return fmt.Errorf("CNAME record to %s needs to end with a period '.'", record.Address)
+	}
+
 	allRecords, err := c.GetHosts(domain)
 	if err != nil {
 		return err

--- a/record_test.go
+++ b/record_test.go
@@ -2,7 +2,7 @@ package namecheap
 
 import (
 	// "strconv"
-	// "strings"
+	"strings"
 	"testing"
 	// "github.com/motain/gocheck"
 )
@@ -40,6 +40,20 @@ func TestRecord__ReadRecord(t *testing.T) {
 
 // 	c.Assert(err, gocheck.IsNil)
 // }
+
+func TestRecord__UpdateRecordInvalid(t *testing.T) {
+	err := testClient.UpdateRecord("example.com", 0, &Record{
+		Name:       "foo",
+		Address:    "foo.corp.com",
+		RecordType: "CNAME",
+	})
+	if err == nil {
+		t.Error("expected error")
+	}
+	if !strings.Contains(err.Error(), "needs to end with a period") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
 
 // func (s *S) Test_UpdateRecord(c *gocheck.C) {
 // 	testServer.Response(200, nil, recordCreateExample)


### PR DESCRIPTION
This returns an error with the namecheap API anyway, so let's avoid
the round trips.

Issue: https://github.com/adamdecaf/terraform-provider-namecheap/issues/24 