### PR TITLE
fix: Use publicsuffix for parsing domains

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/adamdecaf/namecheap
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.3.0
+	golang.org/x/net v0.0.0-20191009170851-d66e71096ffb
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,7 @@ golang.org/x/net v0.0.0-20190502183928-7f726cade0ab/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191009170851-d66e71096ffb h1:TR699M2v0qoKTOHxeLgp6zPqaQNs74f01a/ob9W0qko=
 golang.org/x/net v0.0.0-20191009170851-d66e71096ffb/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/host.go
+++ b/host.go
@@ -3,6 +3,7 @@ package namecheap
 import (
 	"bytes"
 	"fmt"
+	"golang.org/x/net/publicsuffix"
 	"strconv"
 	"strings"
 )
@@ -20,17 +21,14 @@ var (
 
 func (c *Client) SetHosts(domain string, records []Record) ([]Record, error) {
 	var ret RecordsCreateResult
-	var domainSplit = strings.Split(domain, ".")
-
-	if len(domainSplit) != 2 {
-		return nil, fmt.Errorf("Domain %q does not contain SLD and TLD", domainSplit)
-	}
+	var eTLD, _ = publicsuffix.PublicSuffix(domain)
+	var SLD = strings.TrimSuffix(domain, "."+eTLD)
 
 	var numberOfRecords = len(records)
 	params := map[string]string{
 		"Command": "namecheap.domains.dns.setHosts",
-		"SLD":     domainSplit[0],
-		"TLD":     domainSplit[1],
+		"SLD":     SLD,
+		"TLD":     eTLD,
 	}
 	itr := 0
 	for itr < numberOfRecords {
@@ -83,11 +81,13 @@ func (c *Client) SetHosts(domain string, records []Record) ([]Record, error) {
 // GetRecords retrieves all the records for the given domain.
 func (c *Client) GetHosts(domain string) ([]Record, error) {
 	var recordsResponse RecordsResponse
-	var domainSplit = strings.Split(domain, ".")
+	var eTLD, _ = publicsuffix.PublicSuffix(domain)
+	var SLD = strings.TrimSuffix(domain, "."+eTLD)
+
 	params := map[string]string{
 		"Command": "namecheap.domains.dns.getHosts",
-		"SLD":     domainSplit[0],
-		"TLD":     domainSplit[1],
+		"SLD":     SLD,
+		"TLD":     eTLD,
 	}
 	req, err := c.NewRequest(params)
 	if err != nil {

--- a/host_test.go
+++ b/host_test.go
@@ -3,6 +3,7 @@ package namecheap
 import (
 	// "github.com/pearkes/dnsimple/testutil"
 	// "strings"
+	"fmt"
 	"testing"
 )
 
@@ -36,24 +37,32 @@ func TestHost__GetHosts(t *testing.T) {
 	}
 }
 
-// func (s *S) Test_SetHosts(c *gocheck.C) {
-// 	testServer.Response(200, nil, hostSetExample)
-// 	var records []Record
+func TestHost__SetHosts(t *testing.T) {
+	if !clientEnabled {
+		t.Skip("namecheap credentials not configured")
+	}
 
-// 	record := Record{
-// 		HostName:   "foobar",
-// 		RecordType: "CNAME",
-// 		Address:    "test.domain.",
-// 	}
+	var records []Record
 
-// 	records = append(records, record)
+	// record := Record{
+	// 	Name:   "www",
+	// 	RecordType: "CNAME",
+	// 	Address:    "example.com",
+	// TTL: 1800,
+	// }
 
-// 	_, err := s.client.SetHosts("example.com", records)
+	records = append(records, *testRecord)
 
-// 	_ = testServer.WaitRequest()
+	testClient.SetHosts(testDomain, records)
 
-// 	c.Assert(err, gocheck.IsNil)
-// }
+	NewRecords, err := testClient.SetHosts(testDomain, records)
+
+	fmt.Printf("%v\n", NewRecords)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
 
 // func (s *S) Test_SetHosts_fail(c *gocheck.C) {
 // 	testServer.Response(200, nil, hostExampleError)


### PR DESCRIPTION
Fixes #13 by using publicsuffic for domain parsing

As mentioned in the original ticket, I'm not too great with golang, so this may not be immediately suitable, but I have passing tests on my local machine.

On the subject of tests, I've uncommented and updated what was the `Test_SetHosts` function. It seems to interfere with the other tests, so it may need running twice. I've also been running with unstaged changes to reflect the domains I have in my Namecheap sandbox, so it may not pass for you.

There are still references to `domainSplit` in the `ns.go` file, but the `ns_test.go` cases are failing for me locally, so I haven't touched them :man_shrugging: 