### PR TITLE
client: attempt to obtain user IP from Namecheap if not specified

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -57,12 +57,6 @@ func TestClient__fail(t *testing.T) {
 			token:    "",
 			ip:       "127.0.0.1",
 		},
-		{
-			username: "username",
-			apiuser:  "apiuser",
-			token:    "token",
-			ip:       "",
-		},
 	}
 	for i := range cases {
 		_, err := NewClient(cases[i].username, cases[i].apiuser, cases[i].token, cases[i].ip, false)


### PR DESCRIPTION
The PR modifies `namecheap.NewClient` so that it no longer requires explicitly provided IP address and tries to obtain
one from Namecheap's own DynDNS service.

It's still possible to set the IP explicitly and bypass the call to DynDNS service.
