### PR TITLE
chore: CI best practices — triggers, SHA pins, Trivy, Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,29 +2,77 @@ name: CI
 
 on:
   push:
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
+    branches:
+      - "**"
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   check:
+    name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: 1.22
+          go-version-file: go.mod
+
+      - name: Verify module integrity
+        run: go mod verify
+
+      - name: Verify go.mod and go.sum are tidy
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
 
       - name: Check
         run: make check
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v1.60
+          version: v2.8.0
 
       - name: Test
         run: make test
+
+  security:
+    name: Security scan (Trivy)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Trivy vuln + misconfig + secret + license scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,misconfig,secret
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "1"
+          format: table
+          cache: "true"
+
+      - name: Generate CycloneDX SBOM
+        if: ${{ !cancelled() }}
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: cyclonedx
+          output: sbom.cdx.json
+          cache: "true"
+
+      - name: Upload SBOM artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom-cyclonedx
+          path: sbom.cdx.json
+          retention-days: 90

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,12 +13,6 @@ linters:
     - revive
     - staticcheck
     - stylecheck
-    - typecheck
     - unconvert
     - unused
-  fast: false
   disable-all: true
-linters-settings:
-  gosec:
-    excludes:
-      - G402


### PR DESCRIPTION
## Summary

- **CI was not running on PRs** — only push events with path filter triggered it; added `pull_request` and `workflow_dispatch` triggers
- **Action pins** — replaced mutable tags (`@v4`, `@v5`, `@v6`) with commit SHAs
- **golangci-lint** — updated from v6 action / v1.60 linter to v9.2.1 action / v2.8.0 linter
- **Go version** — switched from hardcoded `1.22` to `go-version-file: go.mod`
- **Module hygiene** — added `go mod verify` and `go mod tidy` drift check steps
- **Trivy security scan** — new job: vuln + misconfig + secret scan (CRITICAL/HIGH), CycloneDX SBOM artifact, warm cache via actions/cache@v5 (Node 24)
- **Dependabot** — new `.github/dependabot.yml` for weekly Go module and GitHub Actions updates
- **golangci.yml** — removed `typecheck` (dropped in golangci-lint v2, now built-in), `fast: false` (removed in v2), dead `gosec` settings block

## After merge: branch protection

Once CI is green, configure branch protection on master:
- Require PR review (1 approver)
- Require `Check` and `Security scan (Trivy)` status checks
- No force pushes, dismiss stale reviews

## Test plan

- [ ] CI runs on this PR (pull_request trigger works)
- [ ] Check job passes (lint with v2.8.0, module checks)
- [ ] Security scan job passes (Trivy finds no CRITICAL/HIGH vulns — or flags known ones)
- [ ] SBOM artifact uploaded