### PR TITLE
chore: fix CI triggers, pin action SHAs, add mod checks, Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,21 +2,33 @@ name: CI
 
 on:
   push:
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
+    branches:
+      - "**"
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   check:
+    name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: 1.22
+          go-version-file: go.mod
+
+      - name: Verify module integrity
+        run: go mod verify
+
+      - name: Verify go.mod and go.sum are tidy
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
 
       - name: Check
         run: make check

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,12 +13,6 @@ linters:
     - revive
     - staticcheck
     - stylecheck
-    - typecheck
     - unconvert
     - unused
-  fast: false
   disable-all: true
-linters-settings:
-  gosec:
-    excludes:
-      - G402


### PR DESCRIPTION
## What

- **CI was not running on PRs** — only push events with a path filter triggered it; adds `pull_request` + `workflow_dispatch` triggers
- **`permissions: contents: read`** — least-privilege baseline
- **SHA-pin** `actions/checkout` and `actions/setup-go` (mutable `@v4`/`@v5` tags replaced)
- **`go-version-file: go.mod`** instead of hardcoded `1.22`
- **Module hygiene** — `go mod verify` + `go mod tidy` drift check steps added
- **`.golangci.yml`** — remove `typecheck` (not needed to list explicitly in v1.x either), `fast: false` (unused), dead `gosec` settings block
- **Dependabot** — weekly updates for Go modules and GitHub Actions

golangci-lint stays at v6/v1.60 in this PR — version upgrade is in the next one.

## Test plan
- [ ] CI runs on this PR
- [ ] Check job passes with existing lint version