### PR TITLE
chore: upgrade golangci-lint v1.60 → v2.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,9 @@ jobs:
         run: make check
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v1.60
+          version: v2.8.0
 
       - name: Test
         run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 linters:
   enable:
     - copyloopvar


### PR DESCRIPTION
## What

Stacks on #57.

- Add `version: "2"` to `.golangci.yml` — required by v2, causes `exit-3` without it
- Update action from unpinned `@v6` to SHA-pinned `v9.2.1`
- Update linter version from `v1.60` to `v2.8.0`

## Test plan
- [ ] CI passes (Check job green with v2.8.0)