### PR TITLE
chore: add Trivy security scan job with SBOM artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,39 @@ jobs:
 
       - name: Test
         run: make test
+
+  security:
+    name: Security scan (Trivy)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Trivy vuln + misconfig + secret scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,misconfig,secret
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "1"
+          format: table
+          cache: "true"
+
+      - name: Generate CycloneDX SBOM
+        if: ${{ !cancelled() }}
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: cyclonedx
+          output: sbom.cdx.json
+          cache: "true"
+
+      - name: Upload SBOM artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom-cyclonedx
+          path: sbom.cdx.json
+          retention-days: 90


### PR DESCRIPTION
## What

Stacks on the yaml CVE fix — Trivy scan is clean only after that is merged.

Adds a `Security scan (Trivy)` job:
- Scans for vulns, misconfigs, and secrets (CRITICAL/HIGH, unfixed ignored)
- Produces a CycloneDX SBOM artifact on every run
- Uses `actions/cache@v5` (Node 24) internally via `trivy-action@v0.36.0`

## Test plan
- [ ] Security scan job passes (no HIGH/CRITICAL findings after yaml fix)
- [ ] SBOM artifact uploaded