### PR TITLE
chore: update Go to 1.26.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: v2.12.2
+          install-mode: goinstall
 
       - name: Test
         run: make test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/namecheap/go-namecheap-sdk/v2
 
-go 1.25.0
+go 1.26.3
 
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.2


### PR DESCRIPTION
## Summary

- Go toolchain bumped to **1.26.3** (latest stable in the 1.26.x series)
- Indirect deps (`x/net`, `x/text`) unchanged — their latest releases still declare `go 1.25`, so no version conflict
- golangci-lint switched from `install-mode: binary` to **`install-mode: goinstall`**: no pre-built golangci-lint binary is available yet that is compiled with Go 1.26, so the action now builds golangci-lint from source using the project's own Go 1.26 toolchain, avoiding the "build version lower than target" error

## Test plan

- [ ] CI Check job passes (go vet, golangci-lint compiled with go1.26, unit tests)
- [ ] CI Security scan (Trivy) passes