### PR TITLE
Introduce domains check method

### DIFF
--- a/namecheap/domains_check.go
+++ b/namecheap/domains_check.go
@@ -1,0 +1,57 @@
+package namecheap
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+)
+
+type DomainsCheckResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *DomainsCheckCommandResponse `xml:"CommandResponse"`
+}
+
+type DomainsCheckCommandResponse struct {
+	DomainCheckResults *[]DomainCheckResult `xml:"DomainCheckResult"`
+}
+
+type DomainCheckResult struct {
+	Domain                   *string  `xml:"Domain,attr"`
+	IsAvailable              *bool    `xml:"Available,attr"`
+	IsPremiumName            *bool    `xml:"IsPremiumName,attr"`
+	PremiumRegistrationPrice *float64 `xml:"PremiumRegistrationPrice,attr"`
+	PremiumRenewalPrice      *float64 `xml:"PremiumRenewalPrice,attr"`
+	PremiumRestorePrice      *float64 `xml:"PremiumRestorePrice,attr"`
+	PremiumTransferPrice     *float64 `xml:"PremiumTransferPrice,attr"`
+	IcannFee                 *float64 `xml:"IcannFee,attr"`
+	EapFee                   *float64 `xml:"EapFee,attr"`
+}
+
+// Check returns availability and pricing information for one or more domains.
+// The Namecheap API accepts up to 50 domains per call.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/domains/check/
+func (ds *DomainsService) Check(domains ...string) (*DomainsCheckCommandResponse, error) {
+	var response DomainsCheckResponse
+
+	params := map[string]string{
+		"Command":    "namecheap.domains.check",
+		"DomainList": strings.Join(domains, ","),
+	}
+
+	_, err := ds.client.DoXML(params, &response)
+	if err != nil {
+		return nil, err
+	}
+	if response.Errors != nil && len(*response.Errors) > 0 {
+		apiErr := (*response.Errors)[0]
+
+		return nil, fmt.Errorf("%s (%s)", *apiErr.Message, *apiErr.Number)
+	}
+
+	return response.CommandResponse, nil
+}

--- a/namecheap/domains_check_test.go
+++ b/namecheap/domains_check_test.go
@@ -1,0 +1,180 @@
+package namecheap
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDomainsService_Check(t *testing.T) {
+	fakeResponse := `
+		<?xml version="1.0" encoding="utf-8"?>
+		<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+			<Errors />
+			<Warnings />
+			<RequestedCommand>namecheap.domains.check</RequestedCommand>
+			<CommandResponse Type="namecheap.domains.check">
+				<DomainCheckResult Domain="example.com" Available="true" ErrorNo="0" Description="" IsPremiumName="false" PremiumRegistrationPrice="0" PremiumRenewalPrice="0" PremiumRestorePrice="0" PremiumTransferPrice="0" IcannFee="0" EapFee="0" />
+			</CommandResponse>
+			<Server>PHX01SBAPIEXT06</Server>
+			<GMTTimeDifference>--4:00</GMTTimeDifference>
+			<ExecutionTime>0.417</ExecutionTime>
+		</ApiResponse>
+	`
+
+	t.Run("request_command", func(t *testing.T) {
+		var sentBody url.Values
+
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			query, _ := url.ParseQuery(string(body))
+			sentBody = query
+			_, _ = writer.Write([]byte(fakeResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.Domains.Check("example.com")
+		if err != nil {
+			t.Fatal("Unable to check domain", err)
+		}
+
+		assert.Equal(t, "namecheap.domains.check", sentBody.Get("Command"))
+	})
+
+	t.Run("request_data_single_domain", func(t *testing.T) {
+		var sentBody url.Values
+
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			query, _ := url.ParseQuery(string(body))
+			sentBody = query
+			_, _ = writer.Write([]byte(fakeResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.Domains.Check("example.com")
+		if err != nil {
+			t.Fatal("Unable to check domain", err)
+		}
+
+		assert.Equal(t, "example.com", sentBody.Get("DomainList"))
+	})
+
+	t.Run("request_data_multiple_domains", func(t *testing.T) {
+		multiResponse := `
+			<?xml version="1.0" encoding="utf-8"?>
+			<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+				<Errors />
+				<Warnings />
+				<RequestedCommand>namecheap.domains.check</RequestedCommand>
+				<CommandResponse Type="namecheap.domains.check">
+					<DomainCheckResult Domain="example.com" Available="true" ErrorNo="0" Description="" IsPremiumName="false" PremiumRegistrationPrice="0" PremiumRenewalPrice="0" PremiumRestorePrice="0" PremiumTransferPrice="0" IcannFee="0" EapFee="0" />
+					<DomainCheckResult Domain="example.net" Available="false" ErrorNo="0" Description="" IsPremiumName="false" PremiumRegistrationPrice="0" PremiumRenewalPrice="0" PremiumRestorePrice="0" PremiumTransferPrice="0" IcannFee="0" EapFee="0" />
+				</CommandResponse>
+				<Server>PHX01SBAPIEXT06</Server>
+				<GMTTimeDifference>--4:00</GMTTimeDifference>
+				<ExecutionTime>0.417</ExecutionTime>
+			</ApiResponse>
+		`
+
+		var sentBody url.Values
+
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			query, _ := url.ParseQuery(string(body))
+			sentBody = query
+			_, _ = writer.Write([]byte(multiResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		result, err := client.Domains.Check("example.com", "example.net")
+		if err != nil {
+			t.Fatal("Unable to check domains", err)
+		}
+
+		assert.Equal(t, "example.com,example.net", sentBody.Get("DomainList"))
+		assert.Len(t, *result.DomainCheckResults, 2)
+		assert.Equal(t, "example.com", *(*result.DomainCheckResults)[0].Domain)
+		assert.Equal(t, "example.net", *(*result.DomainCheckResults)[1].Domain)
+	})
+
+	t.Run("correct_parsing_result_attributes", func(t *testing.T) {
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			_, _ = writer.Write([]byte(fakeResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		result, err := client.Domains.Check("example.com")
+		if err != nil {
+			t.Fatal("Unable to check domain", err)
+		}
+
+		first := (*result.DomainCheckResults)[0]
+		assert.Equal(t, "example.com", *first.Domain)
+		assert.Equal(t, true, *first.IsAvailable)
+		assert.Equal(t, false, *first.IsPremiumName)
+		assert.Equal(t, 0.0, *first.PremiumRegistrationPrice)
+		assert.Equal(t, 0.0, *first.PremiumRenewalPrice)
+		assert.Equal(t, 0.0, *first.PremiumRestorePrice)
+		assert.Equal(t, 0.0, *first.PremiumTransferPrice)
+		assert.Equal(t, 0.0, *first.IcannFee)
+		assert.Equal(t, 0.0, *first.EapFee)
+	})
+
+	t.Run("correct_parsing_premium_result_attributes", func(t *testing.T) {
+		premiumFakeResponse := `
+			<?xml version="1.0" encoding="utf-8"?>
+			<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+				<Errors />
+				<Warnings />
+				<RequestedCommand>namecheap.domains.check</RequestedCommand>
+				<CommandResponse Type="namecheap.domains.check">
+					<DomainCheckResult Domain="example.com" Available="true" ErrorNo="0" Description="" IsPremiumName="true" PremiumRegistrationPrice="13000.0000" PremiumRenewalPrice="13000.0000" PremiumRestorePrice="6500.0000" PremiumTransferPrice="13000.0000" IcannFee="0.0000" EapFee="0.0000" />
+				</CommandResponse>
+				<Server>PHX01SBAPIEXT06</Server>
+				<GMTTimeDifference>--4:00</GMTTimeDifference>
+				<ExecutionTime>0.417</ExecutionTime>
+			</ApiResponse>
+		`
+
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			_, _ = writer.Write([]byte(premiumFakeResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		result, err := client.Domains.Check("example.com")
+		if err != nil {
+			t.Fatal("Unable to check domain", err)
+		}
+
+		first := (*result.DomainCheckResults)[0]
+		assert.Equal(t, "example.com", *first.Domain)
+		assert.Equal(t, true, *first.IsAvailable)
+		assert.Equal(t, true, *first.IsPremiumName)
+		assert.Equal(t, 13000.0, *first.PremiumRegistrationPrice)
+		assert.Equal(t, 13000.0, *first.PremiumRenewalPrice)
+		assert.Equal(t, 6500.0, *first.PremiumRestorePrice)
+		assert.Equal(t, 13000.0, *first.PremiumTransferPrice)
+		assert.Equal(t, 0.0, *first.IcannFee)
+		assert.Equal(t, 0.0, *first.EapFee)
+	})
+}


### PR DESCRIPTION
Rebased and updated version of #50 by @misantron.

## Changes from original PR

- **Rebased onto master** — dropped the stale CI matrix commit (master already has a better CI with SHA-pinned actions, Trivy, and go-version-file)
- **Multi-domain support** — `Check` now accepts variadic `domains ...string` matching the API's `DomainList` parameter (comma-separated, up to 50 domains per call); signature stays backwards-compatible for single-domain callers
- **Response struct** — `DomainCheckResult` changed to `DomainCheckResults *[]DomainCheckResult` to correctly handle multiple results from one call
- **Doc comment** added with link to Namecheap API reference
- **Tests updated** — new `request_data_multiple_domains` sub-test covering two-domain request and response parsing; existing sub-tests updated to index into the results slice