### PR TITLE
ci: add CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: '0 3 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (go)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@0e150e40762c1253b364a04b0fc9f2cc14effff2 # main
+        with:
+          languages: go
+          build-mode: autobuild
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@0e150e40762c1253b364a04b0fc9f2cc14effff2 # main
+        with:
+          category: /language:go


### PR DESCRIPTION
Adds GitHub CodeQL code scanning for Go.

- Runs on every push to master, every PR, and on a weekly Monday schedule
- Uses `go-version-file: go.mod` to match the CI Go version
- SHA-pinned actions consistent with the rest of the CI
- Grants `security-events: write` permission required to upload SARIF results

This completes the security feature set alongside the already-enabled Dependabot updates and secret scanning.