### PR TITLE
docs: fix import path and package prefix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,9 @@ $ go get github.com/namecheap/go-namecheap-sdk/v2
 ### Usage
 
 ```go
-import (
-    "github.com/namecheap/go-namecheap-sdk/v2"
-)
+import "github.com/namecheap/go-namecheap-sdk/v2/namecheap"
 
-client := NewClient(&ClientOptions{
+client := namecheap.NewClient(&namecheap.ClientOptions{
     UserName:   "UserName",
     ApiUser:    "ApiUser",
     ApiKey:     "ApiKey",


### PR DESCRIPTION
Fixes #52.

The README usage example had two bugs:

- Import path was `github.com/namecheap/go-namecheap-sdk/v2` (the module root, which contains no `.go` files) instead of `github.com/namecheap/go-namecheap-sdk/v2/namecheap`
- `NewClient` and `ClientOptions` were referenced without the `namecheap.` package qualifier, making the snippet non-compilable