### PR TITLE
feat: add GetEmailForwarding and SetEmailForwarding to DomainsDNSService

### DIFF
--- a/namecheap/domains_dns.go
+++ b/namecheap/domains_dns.go
@@ -1,10 +1,12 @@
 package namecheap
 
 // DomainsDNSService includes the following methods:
+// DomainsDNSService.GetEmailForwarding - returns email forwarding rules for the requested domain
 // DomainsDNSService.GetHosts - retrieves DNS host record settings for the requested domain
 // DomainsDNSService.GetList - gets a list of DNS servers associated with the requested domain
 // DomainsDNSService.SetCustom - sets domain to use custom DNS servers
 // DomainsDNSService.SetDefault - sets domain to use our default DNS servers
+// DomainsDNSService.SetEmailForwarding - configures email forwarding rules for the requested domain
 // DomainsDNSService.SetHosts - sets DNS host records settings for the requested domain
 //
 // Namecheap doc: https://www.namecheap.com/support/api/methods/domains-dns/

--- a/namecheap/domains_dns_get_email_forwarding.go
+++ b/namecheap/domains_dns_get_email_forwarding.go
@@ -1,0 +1,54 @@
+package namecheap
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+type DomainsDNSGetEmailForwardingResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *DomainsDNSGetEmailForwardingCommandResponse `xml:"CommandResponse"`
+}
+
+type DomainsDNSGetEmailForwardingCommandResponse struct {
+	DomainEmailForwardingResult *DomainEmailForwardingResult `xml:"DomainEmailForwardingResult"`
+}
+
+type DomainEmailForwardingResult struct {
+	Domain   *string        `xml:"Domain,attr"`
+	Forwards *[]EmailForward `xml:"Forward"`
+}
+
+// EmailForward represents a single email forwarding rule: an alias mailbox and its destination.
+type EmailForward struct {
+	Mailbox   string `xml:"mailbox,attr"`
+	ForwardTo string `xml:"ForwardTo,attr"`
+}
+
+// GetEmailForwarding returns the email forwarding rules configured for the domain.
+// The domain must use Namecheap default DNS (FreeDNS).
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/domains-dns/get-email-forwarding/
+func (dds *DomainsDNSService) GetEmailForwarding(domain string) (*DomainsDNSGetEmailForwardingCommandResponse, error) {
+	var response DomainsDNSGetEmailForwardingResponse
+
+	params := map[string]string{
+		"Command":    "namecheap.domains.dns.getEmailForwarding",
+		"DomainName": domain,
+	}
+
+	_, err := dds.client.DoXML(params, &response)
+	if err != nil {
+		return nil, err
+	}
+	if response.Errors != nil && len(*response.Errors) > 0 {
+		apiErr := (*response.Errors)[0]
+		return nil, fmt.Errorf("%s (%s)", *apiErr.Message, *apiErr.Number)
+	}
+
+	return response.CommandResponse, nil
+}

--- a/namecheap/domains_dns_get_email_forwarding.go
+++ b/namecheap/domains_dns_get_email_forwarding.go
@@ -15,11 +15,11 @@ type DomainsDNSGetEmailForwardingResponse struct {
 }
 
 type DomainsDNSGetEmailForwardingCommandResponse struct {
-	DomainEmailForwardingResult *DomainEmailForwardingResult `xml:"DomainEmailForwardingResult"`
+	DomainDNSGetEmailForwardingResult *DomainDNSGetEmailForwardingResult `xml:"DomainEmailForwardingResult"`
 }
 
-type DomainEmailForwardingResult struct {
-	Domain   *string        `xml:"Domain,attr"`
+type DomainDNSGetEmailForwardingResult struct {
+	Domain   *string         `xml:"Domain,attr"`
 	Forwards *[]EmailForward `xml:"Forward"`
 }
 

--- a/namecheap/domains_dns_get_email_forwarding_test.go
+++ b/namecheap/domains_dns_get_email_forwarding_test.go
@@ -87,10 +87,10 @@ func TestDomainsDNSService_GetEmailForwarding(t *testing.T) {
 			t.Fatal("Unable to get email forwarding", err)
 		}
 
-		assert.Equal(t, "example.com", *result.DomainEmailForwardingResult.Domain)
-		assert.Len(t, *result.DomainEmailForwardingResult.Forwards, 2)
+		assert.Equal(t, "example.com", *result.DomainDNSGetEmailForwardingResult.Domain)
+		assert.Len(t, *result.DomainDNSGetEmailForwardingResult.Forwards, 2)
 
-		forwards := *result.DomainEmailForwardingResult.Forwards
+		forwards := *result.DomainDNSGetEmailForwardingResult.Forwards
 		assert.Equal(t, "info", forwards[0].Mailbox)
 		assert.Equal(t, "user@gmail.com", forwards[0].ForwardTo)
 		assert.Equal(t, "support", forwards[1].Mailbox)
@@ -126,8 +126,8 @@ func TestDomainsDNSService_GetEmailForwarding(t *testing.T) {
 			t.Fatal("Unable to get email forwarding", err)
 		}
 
-		assert.Equal(t, "example.com", *result.DomainEmailForwardingResult.Domain)
-		assert.Nil(t, result.DomainEmailForwardingResult.Forwards)
+		assert.Equal(t, "example.com", *result.DomainDNSGetEmailForwardingResult.Domain)
+		assert.Nil(t, result.DomainDNSGetEmailForwardingResult.Forwards)
 	})
 
 	t.Run("server_respond_with_error", func(t *testing.T) {

--- a/namecheap/domains_dns_get_email_forwarding_test.go
+++ b/namecheap/domains_dns_get_email_forwarding_test.go
@@ -1,0 +1,160 @@
+package namecheap
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDomainsDNSService_GetEmailForwarding(t *testing.T) {
+	fakeResponse := `
+		<?xml version="1.0" encoding="utf-8"?>
+		<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+			<Errors />
+			<Warnings />
+			<RequestedCommand>namecheap.domains.dns.getEmailForwarding</RequestedCommand>
+			<CommandResponse Type="namecheap.domains.dns.getEmailForwarding">
+				<DomainEmailForwardingResult Domain="example.com">
+					<Forward mailbox="info" ForwardTo="user@gmail.com" />
+					<Forward mailbox="support" ForwardTo="support@company.com" />
+				</DomainEmailForwardingResult>
+			</CommandResponse>
+			<Server>PHX01SBAPIEXT06</Server>
+			<GMTTimeDifference>--4:00</GMTTimeDifference>
+			<ExecutionTime>0.123</ExecutionTime>
+		</ApiResponse>
+	`
+
+	t.Run("request_command", func(t *testing.T) {
+		var sentBody url.Values
+
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			query, _ := url.ParseQuery(string(body))
+			sentBody = query
+			_, _ = writer.Write([]byte(fakeResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainsDNS.GetEmailForwarding("example.com")
+		if err != nil {
+			t.Fatal("Unable to get email forwarding", err)
+		}
+
+		assert.Equal(t, "namecheap.domains.dns.getEmailForwarding", sentBody.Get("Command"))
+	})
+
+	t.Run("request_data_domain", func(t *testing.T) {
+		var sentBody url.Values
+
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			query, _ := url.ParseQuery(string(body))
+			sentBody = query
+			_, _ = writer.Write([]byte(fakeResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainsDNS.GetEmailForwarding("example.com")
+		if err != nil {
+			t.Fatal("Unable to get email forwarding", err)
+		}
+
+		assert.Equal(t, "example.com", sentBody.Get("DomainName"))
+	})
+
+	t.Run("correct_parsing_forwarding_rules", func(t *testing.T) {
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			_, _ = writer.Write([]byte(fakeResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		result, err := client.DomainsDNS.GetEmailForwarding("example.com")
+		if err != nil {
+			t.Fatal("Unable to get email forwarding", err)
+		}
+
+		assert.Equal(t, "example.com", *result.DomainEmailForwardingResult.Domain)
+		assert.Len(t, *result.DomainEmailForwardingResult.Forwards, 2)
+
+		forwards := *result.DomainEmailForwardingResult.Forwards
+		assert.Equal(t, "info", forwards[0].Mailbox)
+		assert.Equal(t, "user@gmail.com", forwards[0].ForwardTo)
+		assert.Equal(t, "support", forwards[1].Mailbox)
+		assert.Equal(t, "support@company.com", forwards[1].ForwardTo)
+	})
+
+	t.Run("empty_forwarding_list", func(t *testing.T) {
+		emptyResponse := `
+			<?xml version="1.0" encoding="utf-8"?>
+			<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+				<Errors />
+				<Warnings />
+				<RequestedCommand>namecheap.domains.dns.getEmailForwarding</RequestedCommand>
+				<CommandResponse Type="namecheap.domains.dns.getEmailForwarding">
+					<DomainEmailForwardingResult Domain="example.com" />
+				</CommandResponse>
+				<Server>PHX01SBAPIEXT06</Server>
+				<GMTTimeDifference>--4:00</GMTTimeDifference>
+				<ExecutionTime>0.123</ExecutionTime>
+			</ApiResponse>
+		`
+
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			_, _ = writer.Write([]byte(emptyResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		result, err := client.DomainsDNS.GetEmailForwarding("example.com")
+		if err != nil {
+			t.Fatal("Unable to get email forwarding", err)
+		}
+
+		assert.Equal(t, "example.com", *result.DomainEmailForwardingResult.Domain)
+		assert.Nil(t, result.DomainEmailForwardingResult.Forwards)
+	})
+
+	t.Run("server_respond_with_error", func(t *testing.T) {
+		errorResponse := `
+			<?xml version="1.0" encoding="utf-8"?>
+			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+				<Errors>
+					<Error Number="2019166">Domain is not associated with your account</Error>
+				</Errors>
+				<Warnings />
+				<RequestedCommand>namecheap.domains.dns.getEmailForwarding</RequestedCommand>
+				<CommandResponse />
+				<Server>PHX01SBAPIEXT06</Server>
+				<GMTTimeDifference>--4:00</GMTTimeDifference>
+				<ExecutionTime>0.123</ExecutionTime>
+			</ApiResponse>
+		`
+
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			_, _ = writer.Write([]byte(errorResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainsDNS.GetEmailForwarding("example.com")
+		assert.EqualError(t, err, "Domain is not associated with your account (2019166)")
+	})
+}

--- a/namecheap/domains_dns_set_email_forwarding.go
+++ b/namecheap/domains_dns_set_email_forwarding.go
@@ -1,0 +1,56 @@
+package namecheap
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strconv"
+)
+
+type DomainsDNSSetEmailForwardingResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *DomainsDNSSetEmailForwardingCommandResponse `xml:"CommandResponse"`
+}
+
+type DomainsDNSSetEmailForwardingCommandResponse struct {
+	DomainEmailForwardingResult *DomainsDNSSetEmailForwardingResult `xml:"DomainEmailForwardingResult"`
+}
+
+type DomainsDNSSetEmailForwardingResult struct {
+	Domain    *string `xml:"Domain,attr"`
+	IsSuccess *bool   `xml:"IsSuccess,attr"`
+}
+
+// SetEmailForwarding configures email forwarding rules for the domain, replacing all existing rules.
+// The domain must use Namecheap default DNS (FreeDNS).
+// Each EmailForward maps a local mailbox alias (e.g. "info") to a destination address.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/domains-dns/set-email-forwarding/
+func (dds *DomainsDNSService) SetEmailForwarding(domain string, forwards []EmailForward) (*DomainsDNSSetEmailForwardingCommandResponse, error) {
+	var response DomainsDNSSetEmailForwardingResponse
+
+	params := map[string]string{
+		"Command":    "namecheap.domains.dns.setEmailForwarding",
+		"DomainName": domain,
+	}
+
+	for i, fwd := range forwards {
+		n := strconv.Itoa(i + 1)
+		params["mailbox"+n] = fwd.Mailbox
+		params["ForwardTo"+n] = fwd.ForwardTo
+	}
+
+	_, err := dds.client.DoXML(params, &response)
+	if err != nil {
+		return nil, err
+	}
+	if response.Errors != nil && len(*response.Errors) > 0 {
+		apiErr := (*response.Errors)[0]
+		return nil, fmt.Errorf("%s (%s)", *apiErr.Message, *apiErr.Number)
+	}
+
+	return response.CommandResponse, nil
+}

--- a/namecheap/domains_dns_set_email_forwarding.go
+++ b/namecheap/domains_dns_set_email_forwarding.go
@@ -16,10 +16,10 @@ type DomainsDNSSetEmailForwardingResponse struct {
 }
 
 type DomainsDNSSetEmailForwardingCommandResponse struct {
-	DomainEmailForwardingResult *DomainsDNSSetEmailForwardingResult `xml:"DomainEmailForwardingResult"`
+	DomainDNSSetEmailForwardingResult *DomainDNSSetEmailForwardingResult `xml:"DomainEmailForwardingResult"`
 }
 
-type DomainsDNSSetEmailForwardingResult struct {
+type DomainDNSSetEmailForwardingResult struct {
 	Domain    *string `xml:"Domain,attr"`
 	IsSuccess *bool   `xml:"IsSuccess,attr"`
 }

--- a/namecheap/domains_dns_set_email_forwarding_test.go
+++ b/namecheap/domains_dns_set_email_forwarding_test.go
@@ -1,0 +1,206 @@
+package namecheap
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDomainsDNSService_SetEmailForwarding(t *testing.T) {
+	fakeResponse := `
+		<?xml version="1.0" encoding="utf-8"?>
+		<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+			<Errors />
+			<Warnings />
+			<RequestedCommand>namecheap.domains.dns.setEmailForwarding</RequestedCommand>
+			<CommandResponse Type="namecheap.domains.dns.setEmailForwarding">
+				<DomainEmailForwardingResult Domain="example.com" IsSuccess="true" />
+			</CommandResponse>
+			<Server>PHX01SBAPIEXT06</Server>
+			<GMTTimeDifference>--4:00</GMTTimeDifference>
+			<ExecutionTime>0.123</ExecutionTime>
+		</ApiResponse>
+	`
+
+	t.Run("request_command", func(t *testing.T) {
+		var sentBody url.Values
+
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			query, _ := url.ParseQuery(string(body))
+			sentBody = query
+			_, _ = writer.Write([]byte(fakeResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainsDNS.SetEmailForwarding("example.com", []EmailForward{
+			{Mailbox: "info", ForwardTo: "user@gmail.com"},
+		})
+		if err != nil {
+			t.Fatal("Unable to set email forwarding", err)
+		}
+
+		assert.Equal(t, "namecheap.domains.dns.setEmailForwarding", sentBody.Get("Command"))
+	})
+
+	t.Run("request_data_domain", func(t *testing.T) {
+		var sentBody url.Values
+
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			query, _ := url.ParseQuery(string(body))
+			sentBody = query
+			_, _ = writer.Write([]byte(fakeResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainsDNS.SetEmailForwarding("example.com", []EmailForward{
+			{Mailbox: "info", ForwardTo: "user@gmail.com"},
+		})
+		if err != nil {
+			t.Fatal("Unable to set email forwarding", err)
+		}
+
+		assert.Equal(t, "example.com", sentBody.Get("DomainName"))
+	})
+
+	t.Run("request_data_single_forward", func(t *testing.T) {
+		var sentBody url.Values
+
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			query, _ := url.ParseQuery(string(body))
+			sentBody = query
+			_, _ = writer.Write([]byte(fakeResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainsDNS.SetEmailForwarding("example.com", []EmailForward{
+			{Mailbox: "info", ForwardTo: "user@gmail.com"},
+		})
+		if err != nil {
+			t.Fatal("Unable to set email forwarding", err)
+		}
+
+		assert.Equal(t, "info", sentBody.Get("mailbox1"))
+		assert.Equal(t, "user@gmail.com", sentBody.Get("ForwardTo1"))
+		assert.Empty(t, sentBody.Get("mailbox2"))
+	})
+
+	t.Run("request_data_multiple_forwards", func(t *testing.T) {
+		var sentBody url.Values
+
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			query, _ := url.ParseQuery(string(body))
+			sentBody = query
+			_, _ = writer.Write([]byte(fakeResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainsDNS.SetEmailForwarding("example.com", []EmailForward{
+			{Mailbox: "info", ForwardTo: "user@gmail.com"},
+			{Mailbox: "support", ForwardTo: "support@company.com"},
+			{Mailbox: "billing", ForwardTo: "billing@company.com"},
+		})
+		if err != nil {
+			t.Fatal("Unable to set email forwarding", err)
+		}
+
+		assert.Equal(t, "info", sentBody.Get("mailbox1"))
+		assert.Equal(t, "user@gmail.com", sentBody.Get("ForwardTo1"))
+		assert.Equal(t, "support", sentBody.Get("mailbox2"))
+		assert.Equal(t, "support@company.com", sentBody.Get("ForwardTo2"))
+		assert.Equal(t, "billing", sentBody.Get("mailbox3"))
+		assert.Equal(t, "billing@company.com", sentBody.Get("ForwardTo3"))
+	})
+
+	t.Run("correct_parsing_result", func(t *testing.T) {
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			_, _ = writer.Write([]byte(fakeResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		result, err := client.DomainsDNS.SetEmailForwarding("example.com", []EmailForward{
+			{Mailbox: "info", ForwardTo: "user@gmail.com"},
+		})
+		if err != nil {
+			t.Fatal("Unable to set email forwarding", err)
+		}
+
+		assert.Equal(t, "example.com", *result.DomainEmailForwardingResult.Domain)
+		assert.Equal(t, true, *result.DomainEmailForwardingResult.IsSuccess)
+	})
+
+	t.Run("request_data_empty_forwards", func(t *testing.T) {
+		var sentBody url.Values
+
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			query, _ := url.ParseQuery(string(body))
+			sentBody = query
+			_, _ = writer.Write([]byte(fakeResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainsDNS.SetEmailForwarding("example.com", []EmailForward{})
+		if err != nil {
+			t.Fatal("Unable to set email forwarding", err)
+		}
+
+		assert.Equal(t, "example.com", sentBody.Get("DomainName"))
+		assert.Empty(t, sentBody.Get("mailbox1"))
+	})
+
+	t.Run("server_respond_with_error", func(t *testing.T) {
+		errorResponse := `
+			<?xml version="1.0" encoding="utf-8"?>
+			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+				<Errors>
+					<Error Number="2019166">Domain is not associated with your account</Error>
+				</Errors>
+				<Warnings />
+				<RequestedCommand>namecheap.domains.dns.setEmailForwarding</RequestedCommand>
+				<CommandResponse />
+				<Server>PHX01SBAPIEXT06</Server>
+				<GMTTimeDifference>--4:00</GMTTimeDifference>
+				<ExecutionTime>0.123</ExecutionTime>
+			</ApiResponse>
+		`
+
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			_, _ = writer.Write([]byte(errorResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainsDNS.SetEmailForwarding("example.com", []EmailForward{
+			{Mailbox: "info", ForwardTo: "user@gmail.com"},
+		})
+		assert.EqualError(t, err, "Domain is not associated with your account (2019166)")
+	})
+}

--- a/namecheap/domains_dns_set_email_forwarding_test.go
+++ b/namecheap/domains_dns_set_email_forwarding_test.go
@@ -147,8 +147,10 @@ func TestDomainsDNSService_SetEmailForwarding(t *testing.T) {
 			t.Fatal("Unable to set email forwarding", err)
 		}
 
-		assert.Equal(t, "example.com", *result.DomainEmailForwardingResult.Domain)
-		assert.Equal(t, true, *result.DomainEmailForwardingResult.IsSuccess)
+		assert.Equal(t, "example.com", *result.DomainDNSSetEmailForwardingResult.Domain)
+		if assert.NotNil(t, result.DomainDNSSetEmailForwardingResult.IsSuccess) {
+			assert.True(t, *result.DomainDNSSetEmailForwardingResult.IsSuccess)
+		}
 	})
 
 	t.Run("request_data_empty_forwards", func(t *testing.T) {


### PR DESCRIPTION
Closes #41.

## Summary

Implements the two missing `domains.dns` email forwarding endpoints:

- **`DomainsDNS.GetEmailForwarding(domain string)`** — wraps `namecheap.domains.dns.getEmailForwarding`. Returns a list of `EmailForward` rules (mailbox alias → destination address) configured for the domain.
- **`DomainsDNS.SetEmailForwarding(domain string, forwards []EmailForward)`** — wraps `namecheap.domains.dns.setEmailForwarding`. Replaces all existing forwarding rules. Forwards are passed as numbered params (`mailbox1`/`ForwardTo1` … `mailboxN`/`ForwardToN`).

Both methods require the domain to use Namecheap default DNS (FreeDNS), consistent with the note on `SetDefault`.

The shared `EmailForward` struct (defined in `domains_dns_get_email_forwarding.go`) uses plain `string` fields for ergonomic construction:

```go
result, err := client.DomainsDNS.GetEmailForwarding("example.com")

_, err = client.DomainsDNS.SetEmailForwarding("example.com", []namecheap.EmailForward{
    {Mailbox: "info",    ForwardTo: "user@gmail.com"},
    {Mailbox: "support", ForwardTo: "support@company.com"},
})
```

## Test plan

- [x] `TestDomainsDNSService_GetEmailForwarding` — 5 sub-tests: command param, DomainName param, result parsing (2 rules), empty list, API error
- [x] `TestDomainsDNSService_SetEmailForwarding` — 7 sub-tests: command param, DomainName param, single forward params, multiple forward numbered params, result parsing, empty forwards slice, API error
- [x] `make check` (go vet) passes
- [x] `make test` (unit + race detector) passes