### PR TITLE
fix: nil-safe String() methods across DNS/Domain types

### DIFF
--- a/namecheap/domains_dns_get_hosts.go
+++ b/namecheap/domains_dns_get_hosts.go
@@ -39,8 +39,8 @@ type DomainsDNSHostRecordDetailed struct {
 }
 
 func (d DomainsDNSHostRecordDetailed) String() string {
-	return fmt.Sprintf("{HostId: %d, Name: %s, Type: %s, Address: %s, MXPref: %d, TTL: %d, AssociatedAppTitle: %s, FriendlyName: %s, IsActive: %t, IsDDNSEnabled: %t}",
-		*d.HostId, *d.Name, *d.Type, *d.Address, *d.MXPref, *d.TTL, *d.AssociatedAppTitle, *d.FriendlyName, *d.IsActive, *d.IsDDNSEnabled)
+	return fmt.Sprintf("{HostId: %v, Name: %v, Type: %v, Address: %v, MXPref: %v, TTL: %v, AssociatedAppTitle: %v, FriendlyName: %v, IsActive: %v, IsDDNSEnabled: %v}",
+		deref(d.HostId), deref(d.Name), deref(d.Type), deref(d.Address), deref(d.MXPref), deref(d.TTL), deref(d.AssociatedAppTitle), deref(d.FriendlyName), deref(d.IsActive), deref(d.IsDDNSEnabled))
 }
 
 // GetHosts retrieves DNS host record settings for the requested domain.

--- a/namecheap/domains_dns_get_hosts_test.go
+++ b/namecheap/domains_dns_get_hosts_test.go
@@ -260,3 +260,30 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 		assert.EqualError(t, err, "Invalid Address (2050900)")
 	})
 }
+
+func TestDomainsDNSHostRecordDetailed_String(t *testing.T) {
+	t.Run("with_all_fields", func(t *testing.T) {
+		d := DomainsDNSHostRecordDetailed{
+			HostId:             Int(877748),
+			Name:               String("host33"),
+			Type:               String("MX"),
+			Address:            String("addr.domain.com."),
+			MXPref:             Int(10),
+			TTL:                Int(1800),
+			AssociatedAppTitle: String(""),
+			FriendlyName:       String(""),
+			IsActive:           Bool(true),
+			IsDDNSEnabled:      Bool(false),
+		}
+		result := d.String()
+		assert.Contains(t, result, "877748")
+		assert.Contains(t, result, "host33")
+		assert.Contains(t, result, "MX")
+		assert.Contains(t, result, "addr.domain.com.")
+	})
+
+	t.Run("nil_fields_do_not_panic", func(t *testing.T) {
+		d := DomainsDNSHostRecordDetailed{}
+		assert.NotPanics(t, func() { _ = d.String() })
+	})
+}

--- a/namecheap/domains_dns_get_list.go
+++ b/namecheap/domains_dns_get_list.go
@@ -27,8 +27,8 @@ type DomainDNSGetListResult struct {
 }
 
 func (d DomainDNSGetListResult) String() string {
-	return fmt.Sprintf("{Domain: %s, IsUsingOurDNS: %t, IsPremiumDNS: %t, IsUsingFreeDNS: %t, Nameservers: %v}",
-		*d.Domain, *d.IsUsingOurDNS, *d.IsPremiumDNS, *d.IsUsingFreeDNS, *d.Nameservers,
+	return fmt.Sprintf("{Domain: %v, IsUsingOurDNS: %v, IsPremiumDNS: %v, IsUsingFreeDNS: %v, Nameservers: %v}",
+		deref(d.Domain), deref(d.IsUsingOurDNS), deref(d.IsPremiumDNS), deref(d.IsUsingFreeDNS), deref(d.Nameservers),
 	)
 }
 

--- a/namecheap/domains_dns_get_list_test.go
+++ b/namecheap/domains_dns_get_list_test.go
@@ -221,3 +221,24 @@ func TestDomainsDNSGetList(t *testing.T) {
 		assert.Equal(t, expectedNameservers, result.DomainDNSGetListResult.Nameservers)
 	})
 }
+
+func TestDomainDNSGetListResult_String(t *testing.T) {
+	t.Run("with_all_fields", func(t *testing.T) {
+		ns := []string{"ns1.example.com", "ns2.example.com"}
+		d := DomainDNSGetListResult{
+			Domain:         String("domain.net"),
+			IsUsingOurDNS:  Bool(true),
+			IsPremiumDNS:   Bool(false),
+			IsUsingFreeDNS: Bool(false),
+			Nameservers:    &ns,
+		}
+		result := d.String()
+		assert.Contains(t, result, "domain.net")
+		assert.Contains(t, result, "ns1.example.com")
+	})
+
+	t.Run("nil_fields_do_not_panic", func(t *testing.T) {
+		d := DomainDNSGetListResult{}
+		assert.NotPanics(t, func() { _ = d.String() })
+	})
+}

--- a/namecheap/domains_dns_set_custom.go
+++ b/namecheap/domains_dns_set_custom.go
@@ -25,7 +25,7 @@ type DomainsDNSSetCustomResult struct {
 }
 
 func (d DomainsDNSSetCustomResult) String() string {
-	return fmt.Sprintf("{Domain: %s, Updated: %t}", *d.Domain, *d.Updated)
+	return fmt.Sprintf("{Domain: %v, Updated: %v}", deref(d.Domain), deref(d.Updated))
 }
 
 // SetCustom sets domain to use custom DNS servers

--- a/namecheap/domains_dns_set_custom_test.go
+++ b/namecheap/domains_dns_set_custom_test.go
@@ -138,3 +138,20 @@ func TestDomainsDNSSetCustom(t *testing.T) {
 		})
 	}
 }
+
+func TestDomainsDNSSetCustomResult_String(t *testing.T) {
+	t.Run("with_all_fields", func(t *testing.T) {
+		d := DomainsDNSSetCustomResult{
+			Domain:  String("domain.net"),
+			Updated: Bool(true),
+		}
+		result := d.String()
+		assert.Contains(t, result, "domain.net")
+		assert.Contains(t, result, "true")
+	})
+
+	t.Run("nil_fields_do_not_panic", func(t *testing.T) {
+		d := DomainsDNSSetCustomResult{}
+		assert.NotPanics(t, func() { _ = d.String() })
+	})
+}

--- a/namecheap/domains_dns_set_default.go
+++ b/namecheap/domains_dns_set_default.go
@@ -24,7 +24,7 @@ type DomainDNSSetDefaultResult struct {
 }
 
 func (d DomainDNSSetDefaultResult) String() string {
-	return fmt.Sprintf("{Domain: %s, Updated: %t}", *d.Domain, *d.Updated)
+	return fmt.Sprintf("{Domain: %v, Updated: %v}", deref(d.Domain), deref(d.Updated))
 }
 
 // SetDefault sets domain to use our default DNS servers.

--- a/namecheap/domains_dns_set_default_test.go
+++ b/namecheap/domains_dns_set_default_test.go
@@ -87,3 +87,20 @@ func TestDomainsDNSSetDefault(t *testing.T) {
 		assert.Equal(t, true, *result.DomainDNSSetDefaultResult.Updated)
 	})
 }
+
+func TestDomainDNSSetDefaultResult_String(t *testing.T) {
+	t.Run("with_all_fields", func(t *testing.T) {
+		d := DomainDNSSetDefaultResult{
+			Domain:  String("domain.net"),
+			Updated: Bool(true),
+		}
+		result := d.String()
+		assert.Contains(t, result, "domain.net")
+		assert.Contains(t, result, "true")
+	})
+
+	t.Run("nil_fields_do_not_panic", func(t *testing.T) {
+		d := DomainDNSSetDefaultResult{}
+		assert.NotPanics(t, func() { _ = d.String() })
+	})
+}

--- a/namecheap/domains_dns_set_hosts.go
+++ b/namecheap/domains_dns_set_hosts.go
@@ -94,7 +94,7 @@ type DomainDNSSetHostsResult struct {
 }
 
 func (d DomainDNSSetHostsResult) String() string {
-	return fmt.Sprintf("{Domain: %s, IsSuccess: %t}", *d.Domain, *d.IsSuccess)
+	return fmt.Sprintf("{Domain: %v, IsSuccess: %v}", deref(d.Domain), deref(d.IsSuccess))
 }
 
 // SetHosts sets DNS host records settings for the requested domain

--- a/namecheap/domains_dns_set_hosts_test.go
+++ b/namecheap/domains_dns_set_hosts_test.go
@@ -568,3 +568,20 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 		})
 	}
 }
+
+func TestDomainDNSSetHostsResult_String(t *testing.T) {
+	t.Run("with_all_fields", func(t *testing.T) {
+		d := DomainDNSSetHostsResult{
+			Domain:    String("domain.net"),
+			IsSuccess: Bool(true),
+		}
+		result := d.String()
+		assert.Contains(t, result, "domain.net")
+		assert.Contains(t, result, "true")
+	})
+
+	t.Run("nil_fields_do_not_panic", func(t *testing.T) {
+		d := DomainDNSSetHostsResult{}
+		assert.NotPanics(t, func() { _ = d.String() })
+	})
+}

--- a/namecheap/domains_get_list.go
+++ b/namecheap/domains_get_list.go
@@ -44,8 +44,8 @@ type Domain struct {
 }
 
 func (d Domain) String() string {
-	return fmt.Sprintf("{ID: %s, Name: %s, User: %s, Created: %s, Expires: %s, IsExpired: %t, IsLocked: %t, AutoRenew: %t, WhoisGuard: %s, IsPremium: %t, IsOurDNS: %t}",
-		*d.ID, *d.Name, *d.User, *d.Created, d.Expires.Time, *d.IsExpired, *d.IsLocked, *d.AutoRenew, *d.WhoisGuard, *d.IsPremium, *d.IsOurDNS)
+	return fmt.Sprintf("{ID: %v, Name: %v, User: %v, Created: %v, Expires: %v, IsExpired: %v, IsLocked: %v, AutoRenew: %v, WhoisGuard: %v, IsPremium: %v, IsOurDNS: %v}",
+		deref(d.ID), deref(d.Name), deref(d.User), deref(d.Created), deref(d.Expires), deref(d.IsExpired), deref(d.IsLocked), deref(d.AutoRenew), deref(d.WhoisGuard), deref(d.IsPremium), deref(d.IsOurDNS))
 }
 
 // DomainsGetListArgs struct is an input arguments for Client.DomainsGetList function

--- a/namecheap/domains_get_list_test.go
+++ b/namecheap/domains_get_list_test.go
@@ -348,3 +348,33 @@ func TestDomainsGetList(t *testing.T) {
 		assert.EqualError(t, err, "Invalid Address (2050900)")
 	})
 }
+
+func TestDomain_String(t *testing.T) {
+	t.Run("with_all_fields", func(t *testing.T) {
+		createdDate, _ := time.Parse("01/02/2006", "06/02/2021")
+		expiresDate, _ := time.Parse("01/02/2006", "06/02/2022")
+		d := Domain{
+			ID:         String("677625"),
+			Name:       String("domain.com"),
+			User:       String("user"),
+			Created:    &DateTime{createdDate},
+			Expires:    &DateTime{expiresDate},
+			IsExpired:  Bool(false),
+			IsLocked:   Bool(false),
+			AutoRenew:  Bool(true),
+			WhoisGuard: String("ENABLED"),
+			IsPremium:  Bool(false),
+			IsOurDNS:   Bool(false),
+		}
+		result := d.String()
+		assert.Contains(t, result, "677625")
+		assert.Contains(t, result, "domain.com")
+		assert.Contains(t, result, "user")
+		assert.Contains(t, result, "ENABLED")
+	})
+
+	t.Run("nil_fields_do_not_panic", func(t *testing.T) {
+		d := Domain{}
+		assert.NotPanics(t, func() { _ = d.String() })
+	})
+}

--- a/namecheap/ptr.go
+++ b/namecheap/ptr.go
@@ -1,0 +1,10 @@
+package namecheap
+
+// deref returns the dereferenced value of a non-nil pointer as any, or nil for a nil pointer.
+// Useful for fmt.Sprintf(%v) calls that need nil-safe pointer formatting.
+func deref[T any](p *T) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}


### PR DESCRIPTION
## Summary

- Replace pointer dereferences (`*d.Field`) with direct pointer values (`d.Field`) and `%v` format verbs in all affected `String()` methods
- Affected types: `Domain`, `DomainsDNSHostRecordDetailed`, `DomainDNSGetListResult`, `DomainsDNSSetCustomResult`, `DomainDNSSetDefaultResult`, `DomainDNSSetHostsResult`
- Add tests for each `String()` method covering both populated fields and nil fields (the nil case previously panicked)

## Test plan

- [ ] `make format` passes
- [ ] `make check` passes
- [ ] `make lint` passes (0 issues)
- [ ] `make test-unit-quiet` passes — all 6 new `*_String` test functions exercise nil fields without panic

Closes #82