### PR TITLE
fix: DomainsNSService.Delete and Update use correct response types

### DIFF
--- a/namecheap/domains_ns_delete.go
+++ b/namecheap/domains_ns_delete.go
@@ -11,7 +11,7 @@ type NameserversDeleteResponse struct {
 		Message *string `xml:",chardata"`
 		Number  *string `xml:"Number,attr"`
 	} `xml:"Errors>Error"`
-	CommandResponse *NameserversCreateCommandResponse `xml:"CommandResponse"`
+	CommandResponse *NameserversDeleteCommandResponse `xml:"CommandResponse"`
 }
 
 type NameserversDeleteCommandResponse struct {
@@ -24,7 +24,7 @@ type DomainsNSDeleteResult struct {
 	IsSuccess  *bool   `xml:"IsSuccess,attr"`
 }
 
-func (s *DomainsNSService) Delete(sld, tld, nameserver string) (*NameserversCreateCommandResponse, error) {
+func (s *DomainsNSService) Delete(sld, tld, nameserver string) (*NameserversDeleteCommandResponse, error) {
 	var response NameserversDeleteResponse
 
 	params := map[string]string{

--- a/namecheap/domains_ns_delete_test.go
+++ b/namecheap/domains_ns_delete_test.go
@@ -47,6 +47,25 @@ func TestDomainNameserversDelete(t *testing.T) {
 		assert.Equal(t, "namecheap.domains.ns.delete", sentBody.Get("Command"))
 	})
 
+	t.Run("correct_result_fields", func(t *testing.T) {
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(fakeResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		result, err := client.DomainsNS.Delete("domain", "com", "ns1.domain.com")
+		if err != nil {
+			t.Fatal("Unable to delete domain nameserver", err)
+		}
+
+		assert.Equal(t, "domain.com", *result.DomainNameserverDeleteResult.Domain)
+		assert.Equal(t, "ns1.domain.com", *result.DomainNameserverDeleteResult.Nameserver)
+		assert.Equal(t, true, *result.DomainNameserverDeleteResult.IsSuccess)
+	})
+
 	t.Run("server_empty_response", func(t *testing.T) {
 		fakeLocalResponse := ""
 

--- a/namecheap/domains_ns_update.go
+++ b/namecheap/domains_ns_update.go
@@ -11,7 +11,7 @@ type NameserversUpdateResponse struct {
 		Message *string `xml:",chardata"`
 		Number  *string `xml:"Number,attr"`
 	} `xml:"Errors>Error"`
-	CommandResponse *NameserversCreateCommandResponse `xml:"CommandResponse"`
+	CommandResponse *NameserversUpdateCommandResponse `xml:"CommandResponse"`
 }
 
 type NameserversUpdateCommandResponse struct {
@@ -24,7 +24,7 @@ type DomainsNSUpdateResult struct {
 	IsSuccess  *bool   `xml:"IsSuccess,attr"`
 }
 
-func (s *DomainsNSService) Update(sld, tld, nameserver, oldIP, ip string) (*NameserversCreateCommandResponse, error) {
+func (s *DomainsNSService) Update(sld, tld, nameserver, oldIP, ip string) (*NameserversUpdateCommandResponse, error) {
 	var response NameserversUpdateResponse
 
 	params := map[string]string{

--- a/namecheap/domains_ns_update_test.go
+++ b/namecheap/domains_ns_update_test.go
@@ -47,6 +47,25 @@ func TestDomainNameserversUpdate(t *testing.T) {
 		assert.Equal(t, "namecheap.domains.ns.update", sentBody.Get("Command"))
 	})
 
+	t.Run("correct_result_fields", func(t *testing.T) {
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(fakeResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		result, err := client.DomainsNS.Update("domain", "com", "ns1.domain.com", "1.1.1.1", "2.2.2.2")
+		if err != nil {
+			t.Fatal("Unable to update domain nameserver", err)
+		}
+
+		assert.Equal(t, "domain.com", *result.DomainNameserverUpdateResult.Domain)
+		assert.Equal(t, "ns1.domain.com", *result.DomainNameserverUpdateResult.Nameserver)
+		assert.Equal(t, true, *result.DomainNameserverUpdateResult.IsSuccess)
+	})
+
 	t.Run("server_empty_response", func(t *testing.T) {
 		fakeLocalResponse := ""
 


### PR DESCRIPTION
## Summary

- `NameserversDeleteResponse.CommandResponse` was wired to `*NameserversCreateCommandResponse` instead of its own `*NameserversDeleteCommandResponse` type
- `NameserversUpdateResponse.CommandResponse` was wired to `*NameserversCreateCommandResponse` instead of its own `*NameserversUpdateCommandResponse` type
- `DomainsNSService.Delete` and `DomainsNSService.Update` now return their correct specific types instead of the create command response type
- Added `correct_result_fields` subtests to both `domains_ns_delete_test.go` and `domains_ns_update_test.go` to verify response parsing

Closes #75