### PR TITLE
docs: add missing doc comments on exported identifiers

### DIFF
--- a/namecheap/domains_get_info.go
+++ b/namecheap/domains_get_info.go
@@ -35,6 +35,7 @@ type DnsDetails struct { // nolint: stylecheck,revive
 	Nameservers   *[]string `xml:"Nameserver"`
 }
 
+// GetInfo returns detailed information about the requested domain.
 func (ds *DomainsService) GetInfo(domain string) (*DomainsGetInfoCommandResponse, error) {
 	var response DomainsGetInfoResponse
 

--- a/namecheap/domains_ns.go
+++ b/namecheap/domains_ns.go
@@ -1,7 +1,7 @@
 package namecheap
 
 // DomainsNSService includes the following methods:
-// DomainsNSService.getInfo - gets info about a registered nameserver
+// DomainsNSService.GetInfo - gets info about a registered nameserver
 
 // Namecheap doc: https://www.namecheap.com/support/api/methods/domains-ns/
 type DomainsNSService service

--- a/namecheap/domains_ns_create.go
+++ b/namecheap/domains_ns_create.go
@@ -25,6 +25,7 @@ type DomainsNSCreateResult struct {
 	IsSuccess  *bool   `xml:"IsSuccess,attr"`
 }
 
+// Create creates a new nameserver.
 func (s *DomainsNSService) Create(sld, tld, nameserver, ipAddress string) (*NameserversCreateCommandResponse, error) {
 	var response NameserversCreateResponse
 

--- a/namecheap/domains_ns_delete.go
+++ b/namecheap/domains_ns_delete.go
@@ -24,6 +24,7 @@ type DomainsNSDeleteResult struct {
 	IsSuccess  *bool   `xml:"IsSuccess,attr"`
 }
 
+// Delete deletes a nameserver associated with the requested domain.
 func (s *DomainsNSService) Delete(sld, tld, nameserver string) (*NameserversDeleteCommandResponse, error) {
 	var response NameserversDeleteResponse
 

--- a/namecheap/domains_ns_get_info.go
+++ b/namecheap/domains_ns_get_info.go
@@ -27,6 +27,7 @@ type DomainNSInfoResult struct {
 	} `xml:"NameserverStatuses"`
 }
 
+// GetInfo retrieves information about a registered nameserver.
 func (s *DomainsNSService) GetInfo(sld, tld, nameserver string) (*NameserversGetInfoCommandResponse, error) {
 	var response NameserversGetInfoResponse
 

--- a/namecheap/domains_ns_update.go
+++ b/namecheap/domains_ns_update.go
@@ -24,6 +24,7 @@ type DomainsNSUpdateResult struct {
 	IsSuccess  *bool   `xml:"IsSuccess,attr"`
 }
 
+// Update modifies the IP address of a registered nameserver.
 func (s *DomainsNSService) Update(sld, tld, nameserver, oldIP, ip string) (*NameserversUpdateCommandResponse, error) {
 	var response NameserversUpdateResponse
 

--- a/namecheap/namecheap.go
+++ b/namecheap/namecheap.go
@@ -1,3 +1,4 @@
+// Package namecheap provides a Go client for the Namecheap API v1.
 package namecheap
 
 import (


### PR DESCRIPTION
## Summary

- Add package doc comment to `namecheap/namecheap.go`
- Add doc comments to five exported functions: `DomainsService.GetInfo`, `DomainsNSService.Create`, `DomainsNSService.Delete`, `DomainsNSService.GetInfo`, `DomainsNSService.Update`
- Fix typo in `domains_ns.go`: `DomainsNSService.getInfo` → `DomainsNSService.GetInfo`

## Test plan

- [x] `make format` passes
- [x] `make check` passes
- [x] `make lint` — 0 issues
- [x] `make test-unit-quiet` — all tests pass, 88.8% coverage

Closes #81