### PR TITLE
fix: pointer receiver for SetHosts, map not *map from parse helpers

### DIFF
--- a/namecheap/domains_dns_set_hosts.go
+++ b/namecheap/domains_dns_set_hosts.go
@@ -100,7 +100,7 @@ func (d DomainDNSSetHostsResult) String() string {
 // SetHosts sets DNS host records settings for the requested domain
 //
 // Namecheap doc: https://www.namecheap.com/support/api/methods/domains-dns/set-hosts/
-func (dds DomainsDNSService) SetHosts(args *DomainsDNSSetHostsArgs) (*DomainsDNSSetHostsCommandResponse, error) {
+func (dds *DomainsDNSService) SetHosts(args *DomainsDNSSetHostsArgs) (*DomainsDNSSetHostsCommandResponse, error) {
 	var response DomainsDNSSetHostsResponse
 
 	params := map[string]string{
@@ -120,7 +120,7 @@ func (dds DomainsDNSService) SetHosts(args *DomainsDNSSetHostsArgs) (*DomainsDNS
 	}
 
 	// merge parsed arguments with params
-	for k, v := range *parsedArgsMap {
+	for k, v := range parsedArgsMap {
 		params[k] = v
 	}
 
@@ -217,7 +217,7 @@ func validateDomainsDNSSetHostsArgs(args *DomainsDNSSetHostsArgs) error {
 	return nil
 }
 
-func parseDomainsDNSSetHostsArgs(args *DomainsDNSSetHostsArgs) (*map[string]string, error) {
+func parseDomainsDNSSetHostsArgs(args *DomainsDNSSetHostsArgs) (map[string]string, error) {
 	params := map[string]string{}
 
 	parsedDomain, err := ParseDomain(*args.Domain)
@@ -265,7 +265,7 @@ func parseDomainsDNSSetHostsArgs(args *DomainsDNSSetHostsArgs) (*map[string]stri
 		}
 	}
 
-	return &params, nil
+	return params, nil
 }
 
 func isValidEmailType(emailType string) bool {

--- a/namecheap/domains_get_list.go
+++ b/namecheap/domains_get_list.go
@@ -85,7 +85,7 @@ func (ds *DomainsService) GetList(args *DomainsGetListArgs) (*DomainsGetListComm
 	}
 
 	// merge parsed arguments with params
-	for k, v := range *parsedArgsMap {
+	for k, v := range parsedArgsMap {
 		params[k] = v
 	}
 
@@ -101,11 +101,11 @@ func (ds *DomainsService) GetList(args *DomainsGetListArgs) (*DomainsGetListComm
 	return domainsResponse.CommandResponse, nil
 }
 
-func parseDomainsGetListArgs(args *DomainsGetListArgs) (*map[string]string, error) {
+func parseDomainsGetListArgs(args *DomainsGetListArgs) (map[string]string, error) {
 	params := map[string]string{}
 
 	if args == nil {
-		return &params, nil
+		return params, nil
 	}
 
 	if args.ListType != nil {
@@ -144,7 +144,7 @@ func parseDomainsGetListArgs(args *DomainsGetListArgs) (*map[string]string, erro
 		params["SearchTerm"] = *args.SearchTerm
 	}
 
-	return &params, nil
+	return params, nil
 }
 
 func isValidListType(listType string) bool {


### PR DESCRIPTION
## Summary

- Fix `DomainsDNSService.SetHosts` to use a pointer receiver (`*DomainsDNSService`) for consistency with other service methods (closes #78)
- Change `parseDomainsDNSSetHostsArgs` and `parseDomainsGetListArgs` return type from `*map[string]string` to `map[string]string` — maps are reference types; returning a pointer to a map adds unnecessary indirection (closes #79)
- Update callers in both files to drop the dereference (`*parsedArgsMap` → `parsedArgsMap`)

## Test plan

- [ ] `make format` — passes
- [ ] `make check` — passes
- [ ] `make lint` — 0 issues
- [ ] `make test-unit-quiet` — all tests pass (90.6% coverage)

Closes #78
Closes #79