### PR TITLE
docs: fix Go version prerequisite to 1.26.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project overview
 
-Go SDK for the Namecheap API. Module path: `github.com/namecheap/go-namecheap-sdk/v2`. Requires Go 1.22+.
+Go SDK for the Namecheap API. Module path: `github.com/namecheap/go-namecheap-sdk/v2`. Requires Go 1.26.3+.
 
 All source code lives in `namecheap/` package. Vendored dependencies in `vendor/`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ request. Feel free to ask us for help. We'll do our best to guide you and help y
 
 ## Prerequisites
 
-- Go 1.22+
+- Go 1.26.3+
 - [golangci-lint](https://golangci-lint.run/usage/install/#local-installation) — install the same version used in CI
 
 ## Development workflow


### PR DESCRIPTION
CONTRIBUTING.md and CLAUDE.md both stated Go 1.22+ but go.mod requires 1.26.3.