### PR TITLE
feat: add weekly auto-release workflow

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,8 +24,6 @@
     ]
   },
   "plugins": [
-    "claude-md-management",
-    "code-simplifier",
     "gopls-lsp@claude-plugins-official"
   ],
   "enabledPlugins": {

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,67 @@
+name: Auto Release
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  auto-release:
+    name: Auto Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes since last release
+        id: changes
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            echo "No tags found, skipping"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          COMMIT_COUNT=$(git log "${LAST_TAG}..HEAD" --oneline | wc -l | tr -d ' ')
+          echo "Commits since ${LAST_TAG}: ${COMMIT_COUNT}"
+          echo "last_tag=${LAST_TAG}" >> "$GITHUB_OUTPUT"
+          if [ "$COMMIT_COUNT" -eq "0" ]; then
+            echo "No changes since last release, skipping"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Determine next version
+        id: version
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          LAST_TAG="${{ steps.changes.outputs.last_tag }}"
+          VERSION="${LAST_TAG#v}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+          if git log "${LAST_TAG}..HEAD" --format="%s" | grep -q "^feat:"; then
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          else
+            PATCH=$((PATCH + 1))
+          fi
+          NEXT="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "next_version=${NEXT}" >> "$GITHUB_OUTPUT"
+          echo "Next version: ${NEXT}"
+
+      - name: Create release
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.next_version }}" \
+            --target master \
+            --title "${{ steps.version.outputs.next_version }}" \
+            --generate-notes \
+            --notes-start-tag "${{ steps.changes.outputs.last_tag }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project overview
 
-Go SDK for the Namecheap API. Module path: `github.com/namecheap/go-namecheap-sdk/v2`. Requires Go 1.22+.
+Go SDK for the Namecheap API. Module path: `github.com/namecheap/go-namecheap-sdk/v2`. Requires Go 1.26.3+.
 
 All source code lives in `namecheap/` package. Vendored dependencies in `vendor/`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,36 @@ All source code lives in `namecheap/` package. Vendored dependencies in `vendor/
 
 ## Prerequisites
 
-- Go 1.22+
+- Go 1.26.3+
 - golangci-lint
-- gopls (Go language server, required by `gopls-lsp` Claude plugin)
+- gopls (optional — improves navigation; not required)
+
+## Skills
+
+Invoke these golang-skills for specific task types (via the Skill tool):
+
+| Task type | Skill |
+|---|---|
+| Naming identifiers, receivers, initialisms | `golang-skills:go-naming` |
+| Error handling, wrapping, sentinel errors | `golang-skills:go-error-handling` |
+| General style, formatting, nesting, clarity | `golang-skills:go-style-core` |
+| Writing doc comments for exported symbols | `golang-skills:go-documentation` |
+| Writing or reviewing tests | `golang-skills:go-testing` |
+| Linting setup or golangci-lint config | `golang-skills:go-linting` |
+| Code review against community standards | `golang-skills:go-code-review` |
+| Variable/struct/const declarations | `golang-skills:go-declarations` |
+| Interfaces and type assertions | `golang-skills:go-interfaces` |
+| Generics | `golang-skills:go-generics` |
+| Package layout and import organization | `golang-skills:go-packages` |
+| Optional constructor parameters | `golang-skills:go-functional-options` |
+| Goroutines, channels, mutexes | `golang-skills:go-concurrency` |
+| context.Context propagation | `golang-skills:go-context` |
+| Conditionals, loops, switch | `golang-skills:go-control-flow` |
+| Slices, maps, collections | `golang-skills:go-data-structures` |
+| Defensive coding, defer, cleanup | `golang-skills:go-defensive` |
+| Function signatures and return values | `golang-skills:go-functions` |
+| Structured logging with slog | `golang-skills:go-logging` |
+| Performance, benchmarking | `golang-skills:go-performance` |
 
 ## Verification (run in order)
 
@@ -64,19 +91,58 @@ Each API method gets its own file pair: `domains_dns_get_hosts.go` + `domains_dn
 
 ## Go conventions
 
+### Error handling
+
 - Always check and return errors — never ignore them silently.
-- Use `fmt.Errorf` for error wrapping with context.
+- Default to `%w` for wrapping so callers can use `errors.Is`/`errors.As`. Use `%v` only at system boundaries where leaking internal types would be wrong.
+- Place error context before `%w`: `fmt.Errorf("parse domain %q: %w", name, err)`.
+- Do not log and return the same error — choose one. Logging is the caller's responsibility.
+
+### Naming
+
+- All identifiers use MixedCaps (exported) or mixedCaps (unexported) — never underscores except in test files for generated names.
+- Receiver names are 1–2 letter abbreviations derived from the type name and must be consistent across all methods of that type (e.g., `c` for `Client`, `s` for `DomainsService`).
+- No `Get` prefix on getters: use `c.Name()` not `c.GetName()`.
+- Initialisms keep consistent case: `userID`, `HTTPClient`, `apiURL` — never `userId`, `HttpClient`, `apiUrl`.
+- Do not shadow built-ins (`len`, `cap`, `error`, `string`, etc.).
+
+### Documentation
+
+- Every exported top-level name (type, function, method, constant, variable) must have a doc comment.
+- Doc comments start with the name of the thing being described: `// Client is the entry point…`, `// NewClient creates…`.
+- Full sentences: capitalized, ending with a period.
+- Do not add doc comments to unexported symbols unless the logic is non-obvious.
+
+### Style
+
+- Priority order: Clarity > Simplicity > Concision > Maintainability > Consistency.
+- No rigid line length, but keep lines readable; break long lines at semantic boundaries (argument lists, binary operators), not arbitrarily.
+- Prefer early returns over deep nesting — guard clauses at the top of functions.
 - Existing `nolint` directives (`stylecheck`, `revive`) on `ClientOptions` fields are intentional — the API field names match Namecheap's API.
 - Do not add new `nolint` directives without justification.
 
 ## Testing
 
 - Tests are co-located: `*_test.go` next to source files.
-- Use `github.com/stretchr/testify/assert` for assertions.
+- Use `github.com/stretchr/testify/assert` for assertions (existing pattern — do not switch to `cmp.Diff`).
 - Tests use `httptest.NewServer` to mock HTTP responses with fake XML.
 - `setupClient()` in `namecheap_test.go` creates a test client with dummy credentials.
 - Race detection runs via `make test` (includes `go test -race`).
 - Test sub-cases use `t.Run()` for clear naming.
+- Prefer table-driven tests when multiple cases share identical logic.
+
+### Test failure messages
+
+Format: `FuncName(%v) = %v, want %v` — print got before want. Example:
+
+```go
+t.Errorf("ParseDomain(%q) = %v, want %v", input, got, want)
+```
+
+### Test helpers
+
+- Call `t.Helper()` as the first statement in every test helper function so failure lines point to the caller.
+- Use `t.Error` for non-fatal failures (test continues); use `t.Fatal` only when continuing is impossible (setup failure, chained assertions that would panic).
 
 ## Security
 
@@ -84,4 +150,3 @@ Each API method gets its own file pair: `domains_dns_get_hosts.go` + `domains_dn
 - Tests use dummy values (`"user"`, `"token"`, `"10.10.10.10"`).
 - Use `UseSandbox: true` for development/testing against the sandbox API.
 - Do not commit `.env`, `.vault-token`, `*.pem`, `*.key`, or credential files.
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ request. Feel free to ask us for help. We'll do our best to guide you and help y
 
 ## Prerequisites
 
-- Go 1.22+
+- Go 1.26.3+
 - [golangci-lint](https://golangci-lint.run/usage/install/#local-installation) — install the same version used in CI
 
 ## Development workflow


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/auto-release.yml` that runs every Monday at 09:00 UTC (plus `workflow_dispatch` for manual runs)
- Detects commits on `master` since the last tag; skips if there are none
- Bumps MINOR version when any commit subject starts with `feat:`, otherwise bumps PATCH
- Creates a GitHub release with auto-generated notes scoped to commits since the last tag

## Test plan

- [ ] Trigger via `workflow_dispatch` on a branch with commits since `v2.5.1` and verify a new release is created
- [ ] Trigger with no new commits and verify the workflow exits early without creating a release
- [ ] Verify release notes reference the correct range (`--notes-start-tag`)