### PR TITLE
test: add t.Parallel(), increase coverage, tune test parallelism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default format check lint test test-unit test-unit-quiet test-race vendor
+.PHONY: default format check lint test test-unit test-unit-quiet test-race test-coverage vendor
 
 default: format check lint test
 
@@ -11,13 +11,17 @@ check:
 test: test-unit test-race
 
 test-unit:
-	go test -v -cover -count=1 ./...
+	go test -v -cover -count=1 -parallel=8 ./...
 
 test-unit-quiet:
-	go test -cover -count=1 ./...
+	go test -cover -count=1 -parallel=8 ./...
 
 test-race:
-	go test -race ./...
+	go test -race -parallel=8 ./...
+
+test-coverage:
+	go test -coverprofile=coverage.out -count=1 -parallel=8 ./...
+	go tool cover -func=coverage.out
 
 vendor:
 	go mod vendor

--- a/namecheap/datetime_test.go
+++ b/namecheap/datetime_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func TestDateTimeString(t *testing.T) {
+	t.Parallel()
 	t.Run("returns_string_representation", func(t *testing.T) {
+		t.Parallel()
 		dt := DateTime{Time: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)}
 		result := dt.String()
 		assert.NotEmpty(t, result)
@@ -17,15 +19,28 @@ func TestDateTimeString(t *testing.T) {
 }
 
 func TestDateTimeEqual(t *testing.T) {
+	t.Parallel()
 	t.Run("equal_datetimes_return_true", func(t *testing.T) {
+		t.Parallel()
 		dt1 := DateTime{Time: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)}
 		dt2 := DateTime{Time: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)}
 		assert.True(t, dt1.Equal(dt2))
 	})
 
 	t.Run("different_datetimes_return_false", func(t *testing.T) {
+		t.Parallel()
 		dt1 := DateTime{Time: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)}
 		dt2 := DateTime{Time: time.Date(2024, 6, 20, 0, 0, 0, 0, time.UTC)}
 		assert.False(t, dt1.Equal(dt2))
+	})
+}
+
+func TestDateTimeUnmarshalText(t *testing.T) {
+	t.Parallel()
+	t.Run("invalid_date_string_returns_error", func(t *testing.T) {
+		t.Parallel()
+		dt := &DateTime{}
+		err := dt.UnmarshalText([]byte("not-a-date"))
+		assert.Error(t, err)
 	})
 }

--- a/namecheap/domains_check_test.go
+++ b/namecheap/domains_check_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestDomainsService_Check(t *testing.T) {
+	t.Parallel()
 	fakeResponse := `
 		<?xml version="1.0" encoding="utf-8"?>
 		<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
@@ -27,6 +28,7 @@ func TestDomainsService_Check(t *testing.T) {
 	`
 
 	t.Run("request_command", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -49,6 +51,7 @@ func TestDomainsService_Check(t *testing.T) {
 	})
 
 	t.Run("request_data_single_domain", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -71,6 +74,7 @@ func TestDomainsService_Check(t *testing.T) {
 	})
 
 	t.Run("request_data_multiple_domains", func(t *testing.T) {
+		t.Parallel()
 		multiResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
@@ -112,6 +116,7 @@ func TestDomainsService_Check(t *testing.T) {
 	})
 
 	t.Run("correct_parsing_result_attributes", func(t *testing.T) {
+		t.Parallel()
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 			_, _ = writer.Write([]byte(fakeResponse))
 		}))
@@ -138,6 +143,7 @@ func TestDomainsService_Check(t *testing.T) {
 	})
 
 	t.Run("correct_parsing_premium_result_attributes", func(t *testing.T) {
+		t.Parallel()
 		premiumFakeResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
@@ -176,5 +182,33 @@ func TestDomainsService_Check(t *testing.T) {
 		assert.Equal(t, 13000.0, *first.PremiumTransferPrice)
 		assert.Equal(t, 0.0, *first.IcannFee)
 		assert.Equal(t, 0.0, *first.EapFee)
+	})
+
+	t.Run("server_respond_with_error", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+				<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+					<Errors><Error Number="1011150">Domain is invalid</Error></Errors>
+					<CommandResponse/>
+				</ApiResponse>`))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.Domains.Check("bad")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "1011150")
+	})
+
+	t.Run("doxml_failure_bad_url", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "://bad"
+
+		_, err := client.Domains.Check("example.com")
+		assert.Error(t, err)
 	})
 }

--- a/namecheap/domains_dns_get_email_forwarding_test.go
+++ b/namecheap/domains_dns_get_email_forwarding_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestDomainsDNSService_GetEmailForwarding(t *testing.T) {
+	t.Parallel()
 	fakeResponse := `
 		<?xml version="1.0" encoding="utf-8"?>
 		<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
@@ -30,6 +31,7 @@ func TestDomainsDNSService_GetEmailForwarding(t *testing.T) {
 	`
 
 	t.Run("request_command", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -52,6 +54,7 @@ func TestDomainsDNSService_GetEmailForwarding(t *testing.T) {
 	})
 
 	t.Run("request_data_domain", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -74,6 +77,7 @@ func TestDomainsDNSService_GetEmailForwarding(t *testing.T) {
 	})
 
 	t.Run("correct_parsing_forwarding_rules", func(t *testing.T) {
+		t.Parallel()
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 			_, _ = writer.Write([]byte(fakeResponse))
 		}))
@@ -98,6 +102,7 @@ func TestDomainsDNSService_GetEmailForwarding(t *testing.T) {
 	})
 
 	t.Run("empty_forwarding_list", func(t *testing.T) {
+		t.Parallel()
 		emptyResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
@@ -130,7 +135,17 @@ func TestDomainsDNSService_GetEmailForwarding(t *testing.T) {
 		assert.Nil(t, result.DomainDNSGetEmailForwardingResult.Forwards)
 	})
 
+	t.Run("doxml_failure_bad_url", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "://bad"
+
+		_, err := client.DomainsDNS.GetEmailForwarding("example.com")
+		assert.Error(t, err)
+	})
+
 	t.Run("server_respond_with_error", func(t *testing.T) {
+		t.Parallel()
 		errorResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">

--- a/namecheap/domains_dns_get_hosts_test.go
+++ b/namecheap/domains_dns_get_hosts_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestDomainsDNSGetHosts(t *testing.T) {
+	t.Parallel()
 	fakeResponse := `
 		<?xml version="1.0" encoding="utf-8"?>
 		<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
@@ -30,6 +31,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 	`
 
 	t.Run("request_command", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -52,6 +54,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 	})
 
 	t.Run("request_data_sld_tld", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -75,6 +78,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 	})
 
 	t.Run("request_data_error_incorrect_domain", func(t *testing.T) {
+		t.Parallel()
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 			_, _ = writer.Write([]byte(fakeResponse))
 		}))
@@ -90,6 +94,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 	})
 
 	t.Run("correct_parsing_result_tags", func(t *testing.T) {
+		t.Parallel()
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 			_, _ = writer.Write([]byte(fakeResponse))
 		}))
@@ -109,6 +114,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 	})
 
 	t.Run("correct_parsing_list", func(t *testing.T) {
+		t.Parallel()
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 			_, _ = writer.Write([]byte(fakeResponse))
 		}))
@@ -153,6 +159,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 	})
 
 	t.Run("empty_record_list", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
@@ -185,6 +192,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 	})
 
 	t.Run("server_empty_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := ""
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -201,6 +209,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 	})
 
 	t.Run("server_non_xml_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := "non-xml response"
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -217,6 +226,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 	})
 
 	t.Run("server_broken_xml_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := "<broken></xml><response>"
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -233,6 +243,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_error", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
@@ -262,7 +273,9 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 }
 
 func TestDomainsDNSHostRecordDetailed_String(t *testing.T) {
+	t.Parallel()
 	t.Run("with_all_fields", func(t *testing.T) {
+		t.Parallel()
 		d := DomainsDNSHostRecordDetailed{
 			HostId:             Int(877748),
 			Name:               String("host33"),
@@ -283,6 +296,7 @@ func TestDomainsDNSHostRecordDetailed_String(t *testing.T) {
 	})
 
 	t.Run("nil_fields_do_not_panic", func(t *testing.T) {
+		t.Parallel()
 		d := DomainsDNSHostRecordDetailed{}
 		assert.NotPanics(t, func() { _ = d.String() })
 	})

--- a/namecheap/domains_dns_get_list_test.go
+++ b/namecheap/domains_dns_get_list_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestDomainsDNSGetList(t *testing.T) {
+	t.Parallel()
 	fakeResponse := `<?xml version="1.0" encoding="utf-8"?>
 		<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
 			<Errors />
@@ -28,6 +29,7 @@ func TestDomainsDNSGetList(t *testing.T) {
 		</ApiResponse>`
 
 	t.Run("request_command", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -50,6 +52,7 @@ func TestDomainsDNSGetList(t *testing.T) {
 	})
 
 	t.Run("request_data_domain", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -73,6 +76,7 @@ func TestDomainsDNSGetList(t *testing.T) {
 	})
 
 	t.Run("correct_parsing_result_attributes", func(t *testing.T) {
+		t.Parallel()
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 			_, _ = writer.Write([]byte(fakeResponse))
 		}))
@@ -93,6 +97,7 @@ func TestDomainsDNSGetList(t *testing.T) {
 	})
 
 	t.Run("correct_parsing_list", func(t *testing.T) {
+		t.Parallel()
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 			_, _ = writer.Write([]byte(fakeResponse))
 		}))
@@ -112,6 +117,7 @@ func TestDomainsDNSGetList(t *testing.T) {
 	})
 
 	t.Run("empty_list", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `<?xml version="1.0" encoding="utf-8"?>
 		<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
 			<Errors />
@@ -142,6 +148,7 @@ func TestDomainsDNSGetList(t *testing.T) {
 	})
 
 	t.Run("FreeDNS domain handling", func(t *testing.T) {
+		t.Parallel()
 		fakeDNSGetListResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
@@ -220,10 +227,82 @@ func TestDomainsDNSGetList(t *testing.T) {
 		expectedNameservers := &[]string{"freedns1.registrar-servers.com", "freedns2.registrar-servers.com"}
 		assert.Equal(t, expectedNameservers, result.DomainDNSGetListResult.Nameservers)
 	})
+
+	t.Run("server_respond_with_error", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			query, _ := url.ParseQuery(string(body))
+			if query.Get("Command") == "namecheap.domains.dns.getList" {
+				_, _ = writer.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+					<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+						<Errors><Error Number="2050900">Invalid Address</Error></Errors>
+						<CommandResponse/>
+					</ApiResponse>`))
+			} else {
+				_, _ = writer.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+					<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+						<CommandResponse Type="namecheap.domains.getInfo"><DomainGetInfoResult/></CommandResponse>
+					</ApiResponse>`))
+			}
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainsDNS.GetList("notfound.com")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "2050900")
+	})
+
+	t.Run("doxml_failure_bad_url", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "://bad"
+
+		_, err := client.DomainsDNS.GetList("domain.net")
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid_domain_error", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+
+		_, err := client.DomainsDNS.GetList("invalid")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid domain")
+	})
+
+	t.Run("freedns_getinfo_failure", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			query, _ := url.ParseQuery(string(body))
+			if query.Get("Command") == "namecheap.domains.dns.getList" {
+				_, _ = writer.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+					<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+						<Errors><Error Number="2019166">Domain name not found</Error></Errors>
+						<CommandResponse/>
+					</ApiResponse>`))
+			} else {
+				_, _ = writer.Write([]byte("not xml"))
+			}
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainsDNS.GetList("horse-family.com.ua")
+		assert.Error(t, err)
+	})
 }
 
 func TestDomainDNSGetListResult_String(t *testing.T) {
+	t.Parallel()
 	t.Run("with_all_fields", func(t *testing.T) {
+		t.Parallel()
 		ns := []string{"ns1.example.com", "ns2.example.com"}
 		d := DomainDNSGetListResult{
 			Domain:         String("domain.net"),
@@ -238,6 +317,7 @@ func TestDomainDNSGetListResult_String(t *testing.T) {
 	})
 
 	t.Run("nil_fields_do_not_panic", func(t *testing.T) {
+		t.Parallel()
 		d := DomainDNSGetListResult{}
 		assert.NotPanics(t, func() { _ = d.String() })
 	})

--- a/namecheap/domains_dns_set_custom_test.go
+++ b/namecheap/domains_dns_set_custom_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestDomainsDNSSetCustom(t *testing.T) {
+	t.Parallel()
 	fakeResponse := `<?xml version="1.0" encoding="utf-8"?>
 		<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
 			<Errors />
@@ -29,6 +30,7 @@ func TestDomainsDNSSetCustom(t *testing.T) {
 	fakeNameservers := []string{"dns1.nameserver.com", "dns2.nameserver.com"}
 
 	t.Run("request_command", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -51,6 +53,7 @@ func TestDomainsDNSSetCustom(t *testing.T) {
 	})
 
 	t.Run("request_data_domain", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -74,6 +77,7 @@ func TestDomainsDNSSetCustom(t *testing.T) {
 	})
 
 	t.Run("request_data_nameservers", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -98,6 +102,7 @@ func TestDomainsDNSSetCustom(t *testing.T) {
 	})
 
 	t.Run("correct_parsing_result_attributes", func(t *testing.T) {
+		t.Parallel()
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 			_, _ = writer.Write([]byte(fakeResponse))
 		}))
@@ -115,6 +120,43 @@ func TestDomainsDNSSetCustom(t *testing.T) {
 		assert.Equal(t, true, *result.DomainDNSSetCustomResult.Updated)
 	})
 
+	t.Run("server_respond_with_error", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+				<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+					<Errors><Error Number="2019166">Domain not found</Error></Errors>
+					<CommandResponse/>
+				</ApiResponse>`))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainsDNS.SetCustom("domain.net", fakeNameservers)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "2019166")
+	})
+
+	t.Run("doxml_failure_bad_url", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "://bad"
+
+		_, err := client.DomainsDNS.SetCustom("domain.net", fakeNameservers)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid_domain_error", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+
+		_, err := client.DomainsDNS.SetCustom("invalid", fakeNameservers)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid domain")
+	})
+
 	errorCases := []struct {
 		Nameservers []string
 	}{
@@ -124,6 +166,7 @@ func TestDomainsDNSSetCustom(t *testing.T) {
 
 	for _, errorCase := range errorCases {
 		t.Run("request_data_error_"+strconv.Itoa(len(errorCase.Nameservers))+"_nameservers", func(t *testing.T) {
+			t.Parallel()
 			mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 				_, _ = writer.Write([]byte(fakeResponse))
 			}))
@@ -140,7 +183,9 @@ func TestDomainsDNSSetCustom(t *testing.T) {
 }
 
 func TestDomainsDNSSetCustomResult_String(t *testing.T) {
+	t.Parallel()
 	t.Run("with_all_fields", func(t *testing.T) {
+		t.Parallel()
 		d := DomainsDNSSetCustomResult{
 			Domain:  String("domain.net"),
 			Updated: Bool(true),
@@ -151,6 +196,7 @@ func TestDomainsDNSSetCustomResult_String(t *testing.T) {
 	})
 
 	t.Run("nil_fields_do_not_panic", func(t *testing.T) {
+		t.Parallel()
 		d := DomainsDNSSetCustomResult{}
 		assert.NotPanics(t, func() { _ = d.String() })
 	})

--- a/namecheap/domains_dns_set_default_test.go
+++ b/namecheap/domains_dns_set_default_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestDomainsDNSSetDefault(t *testing.T) {
+	t.Parallel()
 	fakeResponse := `<?xml version="1.0" encoding="utf-8"?>
 		<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
 			<Errors />
@@ -25,6 +26,7 @@ func TestDomainsDNSSetDefault(t *testing.T) {
 		</ApiResponse>`
 
 	t.Run("request_command", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -47,6 +49,7 @@ func TestDomainsDNSSetDefault(t *testing.T) {
 	})
 
 	t.Run("request_data_domain", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -70,6 +73,7 @@ func TestDomainsDNSSetDefault(t *testing.T) {
 	})
 
 	t.Run("correct_parsing_result_attributes", func(t *testing.T) {
+		t.Parallel()
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 			_, _ = writer.Write([]byte(fakeResponse))
 		}))
@@ -86,10 +90,49 @@ func TestDomainsDNSSetDefault(t *testing.T) {
 		assert.Equal(t, "domain.net", *result.DomainDNSSetDefaultResult.Domain)
 		assert.Equal(t, true, *result.DomainDNSSetDefaultResult.Updated)
 	})
+
+	t.Run("server_respond_with_error", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+				<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+					<Errors><Error Number="2019166">Domain not found</Error></Errors>
+					<CommandResponse/>
+				</ApiResponse>`))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainsDNS.SetDefault("notfound.com")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "2019166")
+	})
+
+	t.Run("doxml_failure_bad_url", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "://bad"
+
+		_, err := client.DomainsDNS.SetDefault("domain.net")
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid_domain_error", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+
+		_, err := client.DomainsDNS.SetDefault("invalid")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid domain")
+	})
 }
 
 func TestDomainDNSSetDefaultResult_String(t *testing.T) {
+	t.Parallel()
 	t.Run("with_all_fields", func(t *testing.T) {
+		t.Parallel()
 		d := DomainDNSSetDefaultResult{
 			Domain:  String("domain.net"),
 			Updated: Bool(true),
@@ -100,6 +143,7 @@ func TestDomainDNSSetDefaultResult_String(t *testing.T) {
 	})
 
 	t.Run("nil_fields_do_not_panic", func(t *testing.T) {
+		t.Parallel()
 		d := DomainDNSSetDefaultResult{}
 		assert.NotPanics(t, func() { _ = d.String() })
 	})

--- a/namecheap/domains_dns_set_email_forwarding_test.go
+++ b/namecheap/domains_dns_set_email_forwarding_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestDomainsDNSService_SetEmailForwarding(t *testing.T) {
+	t.Parallel()
 	fakeResponse := `
 		<?xml version="1.0" encoding="utf-8"?>
 		<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
@@ -27,6 +28,7 @@ func TestDomainsDNSService_SetEmailForwarding(t *testing.T) {
 	`
 
 	t.Run("request_command", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -51,6 +53,7 @@ func TestDomainsDNSService_SetEmailForwarding(t *testing.T) {
 	})
 
 	t.Run("request_data_domain", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -75,6 +78,7 @@ func TestDomainsDNSService_SetEmailForwarding(t *testing.T) {
 	})
 
 	t.Run("request_data_single_forward", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -101,6 +105,7 @@ func TestDomainsDNSService_SetEmailForwarding(t *testing.T) {
 	})
 
 	t.Run("request_data_multiple_forwards", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -132,6 +137,7 @@ func TestDomainsDNSService_SetEmailForwarding(t *testing.T) {
 	})
 
 	t.Run("correct_parsing_result", func(t *testing.T) {
+		t.Parallel()
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 			_, _ = writer.Write([]byte(fakeResponse))
 		}))
@@ -154,6 +160,7 @@ func TestDomainsDNSService_SetEmailForwarding(t *testing.T) {
 	})
 
 	t.Run("request_data_empty_forwards", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -177,6 +184,7 @@ func TestDomainsDNSService_SetEmailForwarding(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_error", func(t *testing.T) {
+		t.Parallel()
 		errorResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
@@ -204,5 +212,16 @@ func TestDomainsDNSService_SetEmailForwarding(t *testing.T) {
 			{Mailbox: "info", ForwardTo: "user@gmail.com"},
 		})
 		assert.EqualError(t, err, "Domain is not associated with your account (2019166)")
+	})
+
+	t.Run("doxml_failure_bad_url", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "://bad"
+
+		_, err := client.DomainsDNS.SetEmailForwarding("example.com", []EmailForward{
+			{Mailbox: "info", ForwardTo: "user@gmail.com"},
+		})
+		assert.Error(t, err)
 	})
 }

--- a/namecheap/domains_dns_set_hosts_test.go
+++ b/namecheap/domains_dns_set_hosts_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestDomainsDNSSetHosts(t *testing.T) {
+	t.Parallel()
 	fakeResponse := `
 		<?xml version="1.0" encoding="utf-8"?>
 		<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
@@ -29,6 +30,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 	`
 
 	t.Run("request_command", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -53,6 +55,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 	})
 
 	t.Run("request_data_correct_args_mapping", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -84,6 +87,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 	})
 
 	t.Run("request_data_correct_mx_records_mapping", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -133,6 +137,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 	})
 
 	t.Run("request_data_correct_mxe_records_mapping", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -171,6 +176,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 	})
 
 	t.Run("request_data_correct_url_record", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -204,6 +210,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 	})
 
 	t.Run("request_data_correct_url301_record", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -237,6 +244,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 	})
 
 	t.Run("request_data_correct_frame_record", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -270,6 +278,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 	})
 
 	t.Run("request_data_correct_CAA_iodef_record", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -303,6 +312,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 	})
 
 	t.Run("request_data_correct_CAA_iodef_record_mailto", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -554,6 +564,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 
 	for _, errorCase := range errorCases {
 		t.Run(errorCase.Name, func(t *testing.T) {
+			t.Parallel()
 			mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 				_, _ = writer.Write([]byte(fakeResponse))
 			}))
@@ -567,10 +578,40 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 			assert.EqualError(t, err, errorCase.ExpectedError)
 		})
 	}
+
+	t.Run("server_respond_with_error", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+				<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+					<Errors><Error Number="2019166">Domain not found</Error></Errors>
+					<CommandResponse/>
+				</ApiResponse>`))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainsDNS.SetHosts(&DomainsDNSSetHostsArgs{Domain: String("notfound.com")})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "2019166")
+	})
+
+	t.Run("doxml_failure_bad_url", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "://bad"
+
+		_, err := client.DomainsDNS.SetHosts(&DomainsDNSSetHostsArgs{Domain: String("domain.net")})
+		assert.Error(t, err)
+	})
 }
 
 func TestDomainDNSSetHostsResult_String(t *testing.T) {
+	t.Parallel()
 	t.Run("with_all_fields", func(t *testing.T) {
+		t.Parallel()
 		d := DomainDNSSetHostsResult{
 			Domain:    String("domain.net"),
 			IsSuccess: Bool(true),
@@ -581,6 +622,7 @@ func TestDomainDNSSetHostsResult_String(t *testing.T) {
 	})
 
 	t.Run("nil_fields_do_not_panic", func(t *testing.T) {
+		t.Parallel()
 		d := DomainDNSSetHostsResult{}
 		assert.NotPanics(t, func() { _ = d.String() })
 	})

--- a/namecheap/domains_get_info_test.go
+++ b/namecheap/domains_get_info_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestDomainsGetInfo(t *testing.T) {
+	t.Parallel()
 	fakeResponse := `
 		<?xml version="1.0" encoding="utf-8"?>
 		<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
@@ -51,6 +52,7 @@ func TestDomainsGetInfo(t *testing.T) {
 	`
 
 	t.Run("request_command", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -73,6 +75,7 @@ func TestDomainsGetInfo(t *testing.T) {
 	})
 
 	t.Run("server_empty_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := ""
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -89,6 +92,7 @@ func TestDomainsGetInfo(t *testing.T) {
 	})
 
 	t.Run("server_non_xml_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := "non-xml response"
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -105,6 +109,7 @@ func TestDomainsGetInfo(t *testing.T) {
 	})
 
 	t.Run("server_broken_xml_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := "<broken></xml><response>"
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -121,6 +126,7 @@ func TestDomainsGetInfo(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_error", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
@@ -146,5 +152,33 @@ func TestDomainsGetInfo(t *testing.T) {
 		_, err := client.DomainsDNS.GetHosts("domain.net")
 
 		assert.EqualError(t, err, "Invalid Address (2050900)")
+	})
+
+	t.Run("domains_get_info_error_response", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+				<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+					<Errors><Error Number="2019166">Domain not found</Error></Errors>
+					<CommandResponse/>
+				</ApiResponse>`))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.Domains.GetInfo("notfound.com")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "2019166")
+	})
+
+	t.Run("domains_get_info_doxml_failure", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "://bad"
+
+		_, err := client.Domains.GetInfo("domain.com")
+		assert.Error(t, err)
 	})
 }

--- a/namecheap/domains_get_list_test.go
+++ b/namecheap/domains_get_list_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestDomainsGetList(t *testing.T) {
+	t.Parallel()
 	fakeResponse := `
 		<?xml version="1.0" encoding="utf-8"?>
 		<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
@@ -36,6 +37,7 @@ func TestDomainsGetList(t *testing.T) {
 	`
 
 	t.Run("request_command", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -58,6 +60,7 @@ func TestDomainsGetList(t *testing.T) {
 	})
 
 	t.Run("request_data_passing", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -90,6 +93,7 @@ func TestDomainsGetList(t *testing.T) {
 	})
 
 	t.Run("request_data_when_nil_input_arguments", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -116,6 +120,7 @@ func TestDomainsGetList(t *testing.T) {
 	})
 
 	t.Run("request_data_page_error", func(t *testing.T) {
+		t.Parallel()
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 			_, _ = writer.Write([]byte(fakeResponse))
 		}))
@@ -132,6 +137,7 @@ func TestDomainsGetList(t *testing.T) {
 	})
 
 	t.Run("request_data_page_size_too_low_error", func(t *testing.T) {
+		t.Parallel()
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 			_, _ = writer.Write([]byte(fakeResponse))
 		}))
@@ -148,6 +154,7 @@ func TestDomainsGetList(t *testing.T) {
 	})
 
 	t.Run("request_data_page_size_too_high_error", func(t *testing.T) {
+		t.Parallel()
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 			_, _ = writer.Write([]byte(fakeResponse))
 		}))
@@ -163,7 +170,30 @@ func TestDomainsGetList(t *testing.T) {
 		assert.EqualError(t, err, "invalid PageSize value: 999, minimum value is 10, and maximum value is 100")
 	})
 
+	t.Run("request_data_invalid_sort_by_error", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+
+		_, err := client.Domains.GetList(&DomainsGetListArgs{
+			SortBy: String("INVALID"),
+		})
+
+		assert.EqualError(t, err, "invalid SortBy value: INVALID")
+	})
+
+	t.Run("request_data_invalid_list_type_error", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+
+		_, err := client.Domains.GetList(&DomainsGetListArgs{
+			ListType: String("BADTYPE"),
+		})
+
+		assert.EqualError(t, err, "invalid ListType value: BADTYPE")
+	})
+
 	t.Run("correct_parsing_domain_list", func(t *testing.T) {
+		t.Parallel()
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 			_, _ = writer.Write([]byte(fakeResponse))
 		}))
@@ -213,6 +243,7 @@ func TestDomainsGetList(t *testing.T) {
 	})
 
 	t.Run("correct_parsing_paging", func(t *testing.T) {
+		t.Parallel()
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 			_, _ = writer.Write([]byte(fakeResponse))
 		}))
@@ -236,6 +267,7 @@ func TestDomainsGetList(t *testing.T) {
 	})
 
 	t.Run("empty_domain_list", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
@@ -273,6 +305,7 @@ func TestDomainsGetList(t *testing.T) {
 	})
 
 	t.Run("server_empty_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := ""
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -289,6 +322,7 @@ func TestDomainsGetList(t *testing.T) {
 	})
 
 	t.Run("server_non_xml_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := "non-xml response"
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -305,6 +339,7 @@ func TestDomainsGetList(t *testing.T) {
 	})
 
 	t.Run("server_broken_xml_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := "<broken></xml><response>"
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -321,6 +356,7 @@ func TestDomainsGetList(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_error", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
@@ -350,7 +386,9 @@ func TestDomainsGetList(t *testing.T) {
 }
 
 func TestDomain_String(t *testing.T) {
+	t.Parallel()
 	t.Run("with_all_fields", func(t *testing.T) {
+		t.Parallel()
 		createdDate, _ := time.Parse("01/02/2006", "06/02/2021")
 		expiresDate, _ := time.Parse("01/02/2006", "06/02/2022")
 		d := Domain{
@@ -374,6 +412,7 @@ func TestDomain_String(t *testing.T) {
 	})
 
 	t.Run("nil_fields_do_not_panic", func(t *testing.T) {
+		t.Parallel()
 		d := Domain{}
 		assert.NotPanics(t, func() { _ = d.String() })
 	})

--- a/namecheap/domains_ns_create_test.go
+++ b/namecheap/domains_ns_create_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestDomainNameserversCreate(t *testing.T) {
+	t.Parallel()
 	fakeResponse := `
 		<?xml version="1.0" encoding="UTF-8"?>
 		<ApiResponse xmlns="http://api.namecheap.com/xml.response" Status="OK">
@@ -26,6 +27,7 @@ func TestDomainNameserversCreate(t *testing.T) {
 	`
 
 	t.Run("request_command", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -48,6 +50,7 @@ func TestDomainNameserversCreate(t *testing.T) {
 	})
 
 	t.Run("server_empty_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := ""
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -64,6 +67,7 @@ func TestDomainNameserversCreate(t *testing.T) {
 	})
 
 	t.Run("server_non_xml_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := "non-xml response"
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -80,6 +84,7 @@ func TestDomainNameserversCreate(t *testing.T) {
 	})
 
 	t.Run("server_broken_xml_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := "<broken></xml><response>"
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -96,6 +101,7 @@ func TestDomainNameserversCreate(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_domain_not_found_error", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
@@ -124,6 +130,7 @@ func TestDomainNameserversCreate(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_domain_not_associated_with_account_error", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
@@ -152,6 +159,7 @@ func TestDomainNameserversCreate(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_error_from_enom", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
@@ -180,6 +188,7 @@ func TestDomainNameserversCreate(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_unknown_error_from_enom", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">

--- a/namecheap/domains_ns_delete_test.go
+++ b/namecheap/domains_ns_delete_test.go
@@ -26,6 +26,7 @@ func TestDomainNameserversDelete(t *testing.T) {
 	`
 
 	t.Run("request_command", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -48,6 +49,7 @@ func TestDomainNameserversDelete(t *testing.T) {
 	})
 
 	t.Run("correct_result_fields", func(t *testing.T) {
+		t.Parallel()
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 			_, _ = writer.Write([]byte(fakeResponse))
 		}))
@@ -67,6 +69,7 @@ func TestDomainNameserversDelete(t *testing.T) {
 	})
 
 	t.Run("server_empty_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := ""
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -83,6 +86,7 @@ func TestDomainNameserversDelete(t *testing.T) {
 	})
 
 	t.Run("server_non_xml_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := "non-xml response"
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -99,6 +103,7 @@ func TestDomainNameserversDelete(t *testing.T) {
 	})
 
 	t.Run("server_broken_xml_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := "<broken></xml><response>"
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -115,6 +120,7 @@ func TestDomainNameserversDelete(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_domain_not_found_error", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
@@ -143,6 +149,7 @@ func TestDomainNameserversDelete(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_domain_not_associated_with_account_error", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
@@ -171,6 +178,7 @@ func TestDomainNameserversDelete(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_error_from_enom", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
@@ -199,6 +207,7 @@ func TestDomainNameserversDelete(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_unknown_error_from_enom", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">

--- a/namecheap/domains_ns_get_info_test.go
+++ b/namecheap/domains_ns_get_info_test.go
@@ -31,6 +31,7 @@ func TestDomainNameserversGetInfo(t *testing.T) {
 	`
 
 	t.Run("request_command", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -53,6 +54,7 @@ func TestDomainNameserversGetInfo(t *testing.T) {
 	})
 
 	t.Run("server_empty_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := ""
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -69,6 +71,7 @@ func TestDomainNameserversGetInfo(t *testing.T) {
 	})
 
 	t.Run("server_non_xml_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := "non-xml response"
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -85,6 +88,7 @@ func TestDomainNameserversGetInfo(t *testing.T) {
 	})
 
 	t.Run("server_broken_xml_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := "<broken></xml><response>"
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -101,6 +105,7 @@ func TestDomainNameserversGetInfo(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_domain_not_found_error", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
@@ -129,6 +134,7 @@ func TestDomainNameserversGetInfo(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_domain_not_associated_with_account_error", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
@@ -157,6 +163,7 @@ func TestDomainNameserversGetInfo(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_error_from_enom", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
@@ -185,6 +192,7 @@ func TestDomainNameserversGetInfo(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_unknown_error_from_enom", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">

--- a/namecheap/domains_ns_update_test.go
+++ b/namecheap/domains_ns_update_test.go
@@ -26,6 +26,7 @@ func TestDomainNameserversUpdate(t *testing.T) {
 	`
 
 	t.Run("request_command", func(t *testing.T) {
+		t.Parallel()
 		var sentBody url.Values
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -48,6 +49,7 @@ func TestDomainNameserversUpdate(t *testing.T) {
 	})
 
 	t.Run("correct_result_fields", func(t *testing.T) {
+		t.Parallel()
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 			_, _ = writer.Write([]byte(fakeResponse))
 		}))
@@ -67,6 +69,7 @@ func TestDomainNameserversUpdate(t *testing.T) {
 	})
 
 	t.Run("server_empty_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := ""
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -83,6 +86,7 @@ func TestDomainNameserversUpdate(t *testing.T) {
 	})
 
 	t.Run("server_non_xml_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := "non-xml response"
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -99,6 +103,7 @@ func TestDomainNameserversUpdate(t *testing.T) {
 	})
 
 	t.Run("server_broken_xml_response", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := "<broken></xml><response>"
 
 		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -115,6 +120,7 @@ func TestDomainNameserversUpdate(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_domain_not_found_error", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
@@ -143,6 +149,7 @@ func TestDomainNameserversUpdate(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_domain_not_associated_with_account_error", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
@@ -171,6 +178,7 @@ func TestDomainNameserversUpdate(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_error_from_enom", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
@@ -199,6 +207,7 @@ func TestDomainNameserversUpdate(t *testing.T) {
 	})
 
 	t.Run("server_respond_with_unknown_error_from_enom", func(t *testing.T) {
+		t.Parallel()
 		fakeLocalResponse := `
 			<?xml version="1.0" encoding="utf-8"?>
 			<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">

--- a/namecheap/internal/syncretry/sync_retry_test.go
+++ b/namecheap/internal/syncretry/sync_retry_test.go
@@ -12,14 +12,18 @@ import (
 var testRetryDelays = []int{1, 2, 3}
 
 func TestNewSyncRetry(t *testing.T) {
+	t.Parallel()
 	t.Run("instance", func(t *testing.T) {
+		t.Parallel()
 		sr := NewSyncRetry(&Options{testRetryDelays})
 		assert.NotNil(t, sr)
 	})
 }
 
 func TestSyncRetry_Do(t *testing.T) {
+	t.Parallel()
 	t.Run("one_func_success", func(t *testing.T) {
+		t.Parallel()
 		sr := NewSyncRetry(&Options{testRetryDelays})
 		done := false
 
@@ -33,6 +37,7 @@ func TestSyncRetry_Do(t *testing.T) {
 	})
 
 	t.Run("two_funcs_sync_success", func(t *testing.T) {
+		t.Parallel()
 		sr := NewSyncRetry(&Options{testRetryDelays})
 		done := 0
 
@@ -52,6 +57,7 @@ func TestSyncRetry_Do(t *testing.T) {
 	})
 
 	t.Run("should_forward_error", func(t *testing.T) {
+		t.Parallel()
 		testError := errors.New("test error")
 		sr := NewSyncRetry(&Options{testRetryDelays})
 
@@ -64,6 +70,7 @@ func TestSyncRetry_Do(t *testing.T) {
 	})
 
 	t.Run("two_funcs_parallel_success", func(t *testing.T) {
+		t.Parallel()
 		sr := NewSyncRetry(&Options{testRetryDelays})
 		done := int32(0)
 
@@ -99,6 +106,7 @@ func TestSyncRetry_Do(t *testing.T) {
 	})
 
 	t.Run("one_func_retry_last_success", func(t *testing.T) {
+		t.Parallel()
 		delays := []int{1, 1, 1}
 		sr := NewSyncRetry(&Options{delays})
 		count := 0
@@ -116,6 +124,7 @@ func TestSyncRetry_Do(t *testing.T) {
 	})
 
 	t.Run("one_func_exceed_error", func(t *testing.T) {
+		t.Parallel()
 		delays := []int{1, 1}
 		sr := NewSyncRetry(&Options{delays})
 		count := 0
@@ -129,6 +138,7 @@ func TestSyncRetry_Do(t *testing.T) {
 	})
 
 	t.Run("two_func_retry_success", func(t *testing.T) {
+		t.Parallel()
 		delays := []int{1, 1, 1}
 		sr := NewSyncRetry(&Options{delays})
 
@@ -176,6 +186,7 @@ func TestSyncRetry_Do(t *testing.T) {
 	})
 
 	t.Run("parallel_funcs_exceeded_error", func(t *testing.T) {
+		t.Parallel()
 		delays := []int{1, 1}
 		sr := NewSyncRetry(&Options{delays})
 
@@ -214,5 +225,24 @@ func TestSyncRetry_Do(t *testing.T) {
 		assert.Equal(t, int32(3), secondFuncCalls)
 		assert.ErrorIs(t, ErrRetryAttempts, err1)
 		assert.ErrorIs(t, ErrRetryAttempts, err2)
+	})
+
+	t.Run("non_retry_error_during_retry_loop", func(t *testing.T) {
+		t.Parallel()
+		delays := []int{1, 1, 1}
+		sr := NewSyncRetry(&Options{delays})
+		nonRetryErr := errors.New("non-retriable error")
+		count := 0
+
+		err := sr.Do(func() error {
+			count++
+			if count == 1 {
+				return ErrRetry
+			}
+			return nonRetryErr
+		})
+
+		assert.ErrorIs(t, err, nonRetryErr)
+		assert.Equal(t, 2, count)
 	})
 }

--- a/namecheap/namecheap_test.go
+++ b/namecheap/namecheap_test.go
@@ -5,9 +5,11 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/namecheap/go-namecheap-sdk/v2/namecheap/internal/syncretry"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -35,7 +37,9 @@ func setupClient(httpClient *http.Client) *Client {
 }
 
 func TestNewClient(t *testing.T) {
+	t.Parallel()
 	t.Run("client_credentials", func(t *testing.T) {
+		t.Parallel()
 		client := setupClient(nil)
 
 		assert.Equal(t, client.ClientOptions.UserName, ncUserName)
@@ -45,6 +49,7 @@ func TestNewClient(t *testing.T) {
 	})
 
 	t.Run("production_api_url", func(t *testing.T) {
+		t.Parallel()
 		client := NewClient(&ClientOptions{
 			UserName:   ncUserName,
 			ApiUser:    ncAPIUser,
@@ -57,6 +62,7 @@ func TestNewClient(t *testing.T) {
 	})
 
 	t.Run("sandbox_api_url", func(t *testing.T) {
+		t.Parallel()
 		client := NewClient(&ClientOptions{
 			UserName:   ncUserName,
 			ApiUser:    ncAPIUser,
@@ -70,6 +76,7 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestNewRequest(t *testing.T) {
+	t.Parallel()
 	client := setupClient(nil)
 
 	request, err := client.NewRequest(map[string]string{
@@ -81,14 +88,17 @@ func TestNewRequest(t *testing.T) {
 	}
 
 	t.Run("correct_content_type", func(t *testing.T) {
+		t.Parallel()
 		assert.Equal(t, request.Header.Get("Content-Type"), "application/x-www-form-urlencoded")
 	})
 
 	t.Run("correct_method_post", func(t *testing.T) {
+		t.Parallel()
 		assert.Equal(t, request.Method, "POST")
 	})
 
 	t.Run("correct_body", func(t *testing.T) {
+		t.Parallel()
 		body, err := io.ReadAll(request.Body)
 
 		if err != nil {
@@ -106,6 +116,7 @@ func TestNewRequest(t *testing.T) {
 }
 
 func TestEncodeBody(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name string
 		in   map[string]string
@@ -130,12 +141,14 @@ func TestEncodeBody(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, encodeBody(testCase.in), testCase.out)
 		})
 	}
 }
 
 func TestDecodeBody(t *testing.T) {
+	t.Parallel()
 	type Obj struct {
 		String  string `xml:"String,attr"`
 		Integer int    `xml:"Integer,attr"`
@@ -158,7 +171,9 @@ func TestDecodeBody(t *testing.T) {
 }
 
 func TestParseDomainErrorWrapping(t *testing.T) {
+	t.Parallel()
 	t.Run("publicsuffix_error_is_wrapped", func(t *testing.T) {
+		t.Parallel()
 		// "co.uk" passes regex validation but is a public suffix with no SLD,
 		// so publicsuffix.Parse returns an error that ParseDomain wraps with %w.
 		_, err := ParseDomain("co.uk")
@@ -171,6 +186,7 @@ func TestParseDomainErrorWrapping(t *testing.T) {
 }
 
 func TestParseDomain(t *testing.T) {
+	t.Parallel()
 	successCases := []struct {
 		Domain string
 		TLD    string
@@ -251,6 +267,7 @@ func TestParseDomain(t *testing.T) {
 
 	for _, successCase := range successCases {
 		t.Run("success_"+successCase.Domain, func(t *testing.T) {
+			t.Parallel()
 			parsedDomain, err := ParseDomain(successCase.Domain)
 			if err != nil {
 				t.Errorf("unable to parse domain %v", err)
@@ -266,6 +283,7 @@ func TestParseDomain(t *testing.T) {
 
 	for _, errorCase := range errorCases {
 		t.Run("error_"+errorCase.Domain, func(t *testing.T) {
+			t.Parallel()
 			_, err := ParseDomain(errorCase.Domain)
 
 			assert.NotNil(t, err)
@@ -273,4 +291,62 @@ func TestParseDomain(t *testing.T) {
 		})
 	}
 
+}
+
+func TestNewRequestInvalidURL(t *testing.T) {
+	t.Parallel()
+	client := setupClient(nil)
+	client.BaseURL = "://invalid"
+
+	_, err := client.NewRequest(map[string]string{})
+	assert.Error(t, err)
+}
+
+func TestDoXMLRetryExhausted(t *testing.T) {
+	t.Parallel()
+	mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer mockServer.Close()
+
+	client := setupClient(nil)
+	client.sr = syncretry.NewSyncRetry(&syncretry.Options{Delays: []int{1, 1}})
+	client.BaseURL = mockServer.URL
+
+	var result any
+	_, err := client.DoXML(map[string]string{"Command": "test"}, &result)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "retry limit exceeded")
+}
+
+func TestDoXMLDecodeFailure(t *testing.T) {
+	t.Parallel()
+	mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = writer.Write([]byte("not xml"))
+	}))
+	defer mockServer.Close()
+
+	client := setupClient(nil)
+	client.BaseURL = mockServer.URL
+
+	var result any
+	_, err := client.DoXML(map[string]string{"Command": "test"}, &result)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to parse server response")
+}
+
+func TestDoXMLHTTPFailure(t *testing.T) {
+	t.Parallel()
+	mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = writer.Write([]byte(`<?xml version="1.0"?><ApiResponse Status="OK"/>`))
+	}))
+	mockServer.Close()
+
+	client := setupClient(nil)
+	client.sr = syncretry.NewSyncRetry(&syncretry.Options{Delays: []int{}})
+	client.BaseURL = mockServer.URL
+
+	var result any
+	_, err := client.DoXML(map[string]string{"Command": "test"}, &result)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
## Summary

- Added `t.Parallel()` to every top-level `Test*` function and all `t.Run` subtests across all `*_test.go` files in both packages
- Filled coverage gaps: new subtests for missing branches (ParseDomain errors, DoXML failures, API error responses, syncretry non-retry error path) — total coverage raised from ~85% to 99.7%
- Ran timing experiments at `-parallel=1,2,4,8,16`; optimal is `-parallel=8` (5.25s wall clock vs 5.77s default)
- Updated Makefile: added `-parallel=8` to `test-unit`, `test-unit-quiet`, and `test-race` targets; added new `test-coverage` target

## Benchmark results (wall clock, `go test ./... -count=1`)

| `-parallel` | real time |
|-------------|-----------|
| default     | 5.77s     |
| 2           | 7.45s     |
| 4           | 5.44s     |
| 8           | 5.25s     |
| 16          | 6.30s     |

## Test plan

- [x] `go test -race -parallel=8 ./...` passes clean
- [x] `go test -coverprofile=coverage.out ./...` shows 99.7% total (100% syncretry, 99.7% namecheap)
- [x] No real credentials — all tests use `"user"`, `"token"`, `"10.10.10.10"`