### PR TITLE
docs: add community standard files to reach 100% health score

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Report a bug or unexpected behavior
+labels: bug
+---
+
+**Go version**
+
+**SDK version**
+
+**What happened?**
+
+**What did you expect to happen?**
+
+**Minimal reproduction**
+
+```go
+// paste code here
+```
+
+**Additional context**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest a new API method or SDK improvement
+labels: enhancement
+---
+
+**Which Namecheap API method or feature does this relate to?**
+
+**What problem does this solve?**
+
+**Proposed API shape (if applicable)**
+
+```go
+// example usage
+```
+
+**Alternatives considered**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- What does this PR do? Why? -->
+
+## Changes
+
+<!-- List the files changed and why -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New API method
+- [ ] Refactor
+- [ ] Documentation
+- [ ] CI / tooling
+
+## Checklist
+
+- [ ] Tests added or updated
+- [ ] `make format && make check && make lint && make test-unit-quiet` passes locally
+- [ ] All commits have a `Signed-off-by:` trailer (`git commit -s`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,171 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.5.1] - 2026-05-28
+
+### Fixed
+
+- `DomainsNSService.Delete` and `Update` returning wrong command-response type (#85, closes #75)
+- `DoXML` body close: replace deferred close with explicit close after decode (#86, closes #74)
+- `ParseDomain` recompiling regex on every call: move to package-level var (#86, closes #76)
+- Error wrapping using `%s`/`%v` instead of `%w`, breaking `errors.Is`/`errors.As` (#86, closes #77)
+- `DomainsDNSService.SetHosts` using value receiver instead of pointer receiver (#89, closes #78)
+- `parseDomainsGetListArgs` and `parseDomainsDNSSetHostsArgs` returning `*map[string]string` unnecessarily (#89, closes #79)
+- `DoXML` and `decodeBody` using `interface{}` instead of `any` (#86, closes #80)
+- `Domain.String()` and related `String()` methods panicking on nil pointer fields (#84, closes #82)
+
+### Added
+
+- Doc comments on exported functions and package (#87, closes #81)
+- Doc comments to `syncretry` package (#88, closes #83)
+- Tests for `DateTime.String()` and `DateTime.Equal()` (previously 0% coverage)
+- Nil-panic tests for all `String()` methods
+- Tests for `DomainsNSService.Delete` and `Update` result parsing
+- Error-wrapping test for `ParseDomain`
+
+## [2.5.0] - 2026-05-28
+
+### Added
+
+- `DomainsDNS.GetEmailForwarding` and `DomainsDNS.SetEmailForwarding` methods (#72)
+- `Domains.Check` method for domain availability checking (#69)
+- CodeQL analysis workflow (#70)
+- Trivy security scan with SBOM artifact (#60)
+- Namecheap APIv2 method reference at `docs/namecheap-api-v2.md` (#73)
+
+### Fixed
+
+- Import path and package prefix in README usage example (#71)
+- `it.com` and other TLD parsing issues via `github.com/weppos/publicsuffix-go` bump (#65)
+
+### Changed
+
+- Go updated to 1.26.3 (#68)
+- `golangci-lint` upgraded from v1.60 to v2.8.0 (#63)
+- GitHub Actions pinned to SHA hashes; Dependabot added (#57)
+- `golang.org/x/net` bumped from 0.34.0 to 0.38.0 (#47)
+- `github.com/stretchr/testify` bumped from 1.7.0 to 1.11.1 (#66)
+
+### Security
+
+- Updated `gopkg.in/yaml.v3` to 3.0.1 (CVE-2022-28948) (#59)
+
+## [2.4.1] - 2025-05-26
+
+### Changed
+
+- Added stricter linters and fixed code to comply (#45)
+
+## [2.4.0] - 2024-11-21
+
+### Added
+
+- `mailto` support for CAA IODEF records (#35)
+
+### Changed
+
+- `go mod tidy` dependency cleanup (#34)
+
+## [2.3.0] - 2024-05-07
+
+### Added
+
+- `DomainsNS.Create` method for nameserver creation (#40)
+- `DomainsNS.Update` method for nameserver updates (#42)
+- `DomainsNS.Delete` method for nameserver deletion (#43)
+
+## [2.2.0] - 2024-03-08
+
+### Added
+
+- `domains.ns.getInfo` API method support (#39)
+
+### Changed
+
+- CI Go version upgraded to 1.22
+- Fixed all CI workflow errors and warnings
+
+## [2.1.0] - 2021-11-29
+
+### Added
+
+- `namecheap.domains.getInfo` API support
+
+### Fixed
+
+- `namecheap.domains.dns.getList` failing for FreeDNS domains
+
+## [2.0.2] - 2021-07-28
+
+### Fixed
+
+- API retry when minutely API limits are exceeded (#28)
+
+## [2.0.1] - 2021-07-14
+
+### Added
+
+- `GMAIL` email type support for `DomainsDNS.SetHosts` (#26)
+- Public constants for DNS record types and email type values (#27)
+
+## [2.0.0] - 2021-07-07
+
+### Added
+
+- Smart validation for `namecheap.domains.dns.setHosts` API command (#25)
+
+### Changed
+
+- Complete rewrite of v1; v2 is not backward compatible with v1
+- Method structure aligned with the official Namecheap API hierarchy
+- Improved domain argument parsing (#13)
+
+## [1.3.0] - 2021-06-04
+
+### Changed
+
+- Package migration
+
+## [1.2.0] - 2021-02-11
+
+### Added
+
+- NS record type support
+- Debug logging for new requests
+
+### Changed
+
+- Removed dependency on Terraform SDK
+- Updated Travis CI config to use Go 1.15
+
+## [1.1.0] - 2019-11-20
+
+### Added
+
+- Domain resolution support
+
+### Changed
+
+- Switched from `hashicorp/terraform` to `hashicorp/terraform-plugin-sdk`
+- Upgraded to Go 1.13
+
+[Unreleased]: https://github.com/namecheap/go-namecheap-sdk/compare/v2.5.1...HEAD
+[2.5.1]: https://github.com/namecheap/go-namecheap-sdk/compare/v2.5.0...v2.5.1
+[2.5.0]: https://github.com/namecheap/go-namecheap-sdk/compare/v2.4.1...v2.5.0
+[2.4.1]: https://github.com/namecheap/go-namecheap-sdk/compare/v2.4.0...v2.4.1
+[2.4.0]: https://github.com/namecheap/go-namecheap-sdk/compare/v2.3.0...v2.4.0
+[2.3.0]: https://github.com/namecheap/go-namecheap-sdk/compare/v2.2.0...v2.3.0
+[2.2.0]: https://github.com/namecheap/go-namecheap-sdk/compare/v2.1.0...v2.2.0
+[2.1.0]: https://github.com/namecheap/go-namecheap-sdk/compare/v2.0.2...v2.1.0
+[2.0.2]: https://github.com/namecheap/go-namecheap-sdk/compare/v2.0.1...v2.0.2
+[2.0.1]: https://github.com/namecheap/go-namecheap-sdk/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/namecheap/go-namecheap-sdk/compare/v1.3.0...v2.0.0
+[1.3.0]: https://github.com/namecheap/go-namecheap-sdk/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/namecheap/go-namecheap-sdk/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/namecheap/go-namecheap-sdk/releases/tag/v1.1.0

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @namecheap/go-sdk-maintainers

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at opensource@namecheap.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest release of `github.com/namecheap/go-namecheap-sdk/v2` receives security fixes.
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Use GitHub's [private vulnerability reporting](https://github.com/namecheap/go-namecheap-sdk/security/advisories/new) to report a vulnerability confidentially. We will acknowledge receipt within 5 business days and aim to release a fix within 30 days for confirmed issues.
+
+Alternatively, email `opensource@namecheap.com` with the subject line `[SECURITY] go-namecheap-sdk`.


### PR DESCRIPTION
## Summary

- Add `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1, enforcement contact: `opensource@namecheap.com`)
- Add `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md`
- Add `.github/pull_request_template.md` with DCO sign-off checklist
- Add `SECURITY.md` pointing to GitHub private vulnerability reporting and `opensource@namecheap.com`
- Add `CODEOWNERS` assigning `@namecheap/go-sdk-maintainers` to all files
- Add `CHANGELOG.md` (Keep a Changelog format) covering all 13 releases from v1.1.0 through v2.5.1

## Motivation

GitHub community health is currently at 50%. These files are the standard set recognized by GitHub's community health checklist and by opensource.guide best practices. No existing files were modified.

## Test plan

- [ ] Verify GitHub community health score increases after merge
- [ ] Confirm issue templates appear when opening a new issue
- [ ] Confirm PR template appears when opening a new pull request
- [ ] Confirm `SECURITY.md` appears in the Security tab