### PR TITLE
Bump golang.org/x/net to v0.56.0 to remediate transitive x/crypto v0.51.0 vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/text v0.37.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
+	golang.org/x/text v0.38.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,10 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/weppos/publicsuffix-go v0.50.3 h1:eT5dcjHQcVDNc0igpFEsGHKIip30feuB2zuuI9eJxiE=
 github.com/weppos/publicsuffix-go v0.50.3/go.mod h1:/rOa781xBykZhHK/I3QeHo92qdDKVmKZKF7s8qAEM/4=
-golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
-golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
-golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
-golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
+golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
+golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=
+golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -14,10 +14,10 @@ github.com/stretchr/testify/assert/yaml
 # github.com/weppos/publicsuffix-go v0.50.3
 ## explicit; go 1.24.0
 github.com/weppos/publicsuffix-go/publicsuffix
-# golang.org/x/net v0.55.0
+# golang.org/x/net v0.56.0
 ## explicit; go 1.25.0
 golang.org/x/net/idna
-# golang.org/x/text v0.37.0
+# golang.org/x/text v0.38.0
 ## explicit; go 1.25.0
 golang.org/x/text/secure/bidirule
 golang.org/x/text/transform


### PR DESCRIPTION
## What
Bumps `golang.org/x/net` **v0.55.0 → v0.56.0** (and `golang.org/x/text` v0.37.0 → v0.38.0, pulled in via MVS).

## Why
`golang.org/x/crypto` is not imported by this module, but it appears in the module graph as a transitive requirement of `golang.org/x/net`. `x/net@v0.55.0`'s go.mod pins it at **`v0.51.0`**, which is affected by a batch of SSH advisories — `CVE-2026-39827` … `CVE-2026-46598` (`GO-2026-5005`…`GO-2026-5033`) — all fixed in `x/crypto v0.52.0`.

`x/net@v0.56.0`'s go.mod references **`x/crypto v0.53.0`** (≥ the v0.52.0 fix), so this bump advances the transitive reference off the vulnerable version.

Because `x/crypto` provides no imported package here, adding an explicit `require golang.org/x/crypto` would be removed by `go mod tidy` (and break `tidy -diff` CI). Bumping the parent module is the durable remediation.

## Verification
- `go mod tidy` — stable (no further changes)
- `go mod vendor` — vendor tree synced (`vendor/modules.txt` updated; no vendored source changes)
- `go build ./...` — OK
- `go vet ./...` — OK
- `go test ./...` — all pass
- `govulncheck ./...` — **No vulnerabilities found**
- Module graph now: `golang.org/x/net@v0.56.0 → golang.org/x/crypto@v0.53.0` (was `@v0.51.0`)