### PR TITLE
feat: add context.Context support to all client and service methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `context.Context` support across all client and service methods. New
+  ctx-first `...WithContext` variants (`Client.NewRequestWithContext`,
+  `Client.DoXMLWithContext`, and every service method such as
+  `Domains.GetInfoWithContext`, `DomainsDNS.SetHostsWithContext`,
+  `DomainsNS.CreateWithContext`, plus `syncretry.SyncRetry.DoContext`) thread a
+  context through the request. Cancelling the context now aborts an in-flight
+  HTTP request, a pending inter-retry sleep, and waiting on the internal retry
+  lock (#110).
+
+### Deprecated
+
+- The existing non-context methods (`Client.NewRequest`, `Client.DoXML`,
+  `syncretry.SyncRetry.Do`, and every service method such as `Domains.GetInfo`,
+  `DomainsDNS.SetHosts`, `DomainsNS.Create`) are deprecated. They now delegate
+  to their `...WithContext` counterparts with `context.Background()` and are
+  slated for removal in v3 (#110).
+
 ## [2.5.1] - 2026-05-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ $ go get github.com/namecheap/go-namecheap-sdk/v2
 ### Usage
 
 ```go
-import "github.com/namecheap/go-namecheap-sdk/v2/namecheap"
+import (
+    "context"
+
+    "github.com/namecheap/go-namecheap-sdk/v2/namecheap"
+)
 
 client := namecheap.NewClient(&namecheap.ClientOptions{
     UserName:   "UserName",
@@ -23,7 +27,17 @@ client := namecheap.NewClient(&namecheap.ClientOptions{
     ClientIp:   "10.10.10.10",
     UseSandbox: false,
 })
+
+// Every call takes a context.Context as its first argument. Cancelling the
+// context aborts the in-flight HTTP request, any pending retry sleep, and
+// waiting on the internal retry lock.
+ctx := context.Background()
 ```
+
+> **Note:** The context-less methods (`Domains.GetInfo`, `DomainsDNS.SetHosts`,
+> `DomainsNS.Create`, `Client.DoXML`, etc.) are deprecated. They delegate to
+> their `...WithContext` counterparts with `context.Background()` and will be
+> removed in v3. Prefer the `...WithContext` variants shown below.
 
 ### Available methods
 
@@ -31,13 +45,13 @@ client := namecheap.NewClient(&namecheap.ClientOptions{
 
 | Method | Description |
 |---|---|
-| `GetList(args)` | List domains for the account |
-| `GetInfo(domain)` | Get detailed info about a domain |
-| `Check(domains...)` | Check availability of one or more domains |
+| `GetListWithContext(ctx, args)` | List domains for the account |
+| `GetInfoWithContext(ctx, domain)` | Get detailed info about a domain |
+| `CheckWithContext(ctx, domains...)` | Check availability of one or more domains |
 
 ```go
 // Check domain availability
-resp, err := client.Domains.Check("example.com", "example.net")
+resp, err := client.Domains.CheckWithContext(ctx, "example.com", "example.net")
 if err != nil {
     log.Fatal(err)
 }
@@ -50,17 +64,17 @@ for _, result := range *resp.DomainCheckResults {
 
 | Method | Description |
 |---|---|
-| `GetList(domain)` | Get the nameservers for a domain |
-| `SetDefault(domain)` | Switch domain to Namecheap default DNS |
-| `SetCustom(domain, nameservers)` | Switch domain to custom nameservers |
-| `GetHosts(domain)` | Get DNS host records |
-| `SetHosts(args)` | Set DNS host records |
-| `GetEmailForwarding(domain)` | Get email forwarding rules |
-| `SetEmailForwarding(domain, forwards)` | Set email forwarding rules |
+| `GetListWithContext(ctx, domain)` | Get the nameservers for a domain |
+| `SetDefaultWithContext(ctx, domain)` | Switch domain to Namecheap default DNS |
+| `SetCustomWithContext(ctx, domain, nameservers)` | Switch domain to custom nameservers |
+| `GetHostsWithContext(ctx, domain)` | Get DNS host records |
+| `SetHostsWithContext(ctx, args)` | Set DNS host records |
+| `GetEmailForwardingWithContext(ctx, domain)` | Get email forwarding rules |
+| `SetEmailForwardingWithContext(ctx, domain, forwards)` | Set email forwarding rules |
 
 ```go
 // Set DNS host records
-resp, err := client.DomainsDNS.SetHosts(&namecheap.DomainsDNSSetHostsArgs{
+resp, err := client.DomainsDNS.SetHostsWithContext(ctx, &namecheap.DomainsDNSSetHostsArgs{
     Domain: namecheap.String("domain.com"),
     Records: &[]namecheap.DomainsDNSHostRecord{
         {
@@ -72,12 +86,12 @@ resp, err := client.DomainsDNS.SetHosts(&namecheap.DomainsDNSSetHostsArgs{
 })
 
 // Get DNS host records
-resp, err := client.DomainsDNS.GetHosts("domain.com")
+resp, err := client.DomainsDNS.GetHostsWithContext(ctx, "domain.com")
 
 // Manage email forwarding
-forwards, err := client.DomainsDNS.GetEmailForwarding("domain.com")
+forwards, err := client.DomainsDNS.GetEmailForwardingWithContext(ctx, "domain.com")
 
-_, err = client.DomainsDNS.SetEmailForwarding("domain.com", []namecheap.EmailForward{
+_, err = client.DomainsDNS.SetEmailForwardingWithContext(ctx, "domain.com", []namecheap.EmailForward{
     {Mailbox: "info", ForwardTo: "user@example.com"},
 })
 ```
@@ -86,17 +100,17 @@ _, err = client.DomainsDNS.SetEmailForwarding("domain.com", []namecheap.EmailFor
 
 | Method | Description |
 |---|---|
-| `Create(sld, tld, nameserver, ip)` | Register a new nameserver |
-| `GetInfo(sld, tld, nameserver)` | Get info about a registered nameserver |
-| `Update(sld, tld, nameserver, oldIP, ip)` | Update a nameserver IP address |
-| `Delete(sld, tld, nameserver)` | Delete a registered nameserver |
+| `CreateWithContext(ctx, sld, tld, nameserver, ip)` | Register a new nameserver |
+| `GetInfoWithContext(ctx, sld, tld, nameserver)` | Get info about a registered nameserver |
+| `UpdateWithContext(ctx, sld, tld, nameserver, oldIP, ip)` | Update a nameserver IP address |
+| `DeleteWithContext(ctx, sld, tld, nameserver)` | Delete a registered nameserver |
 
 ```go
 // Create a custom nameserver
-_, err := client.DomainsNS.Create("domain", "com", "ns1.domain.com", "1.2.3.4")
+_, err := client.DomainsNS.CreateWithContext(ctx, "domain", "com", "ns1.domain.com", "1.2.3.4")
 
 // Delete a nameserver
-_, err = client.DomainsNS.Delete("domain", "com", "ns1.domain.com")
+_, err = client.DomainsNS.DeleteWithContext(ctx, "domain", "com", "ns1.domain.com")
 ```
 
 ### Error handling
@@ -104,7 +118,7 @@ _, err = client.DomainsNS.Delete("domain", "com", "ns1.domain.com")
 API errors (e.g. invalid parameters, quota exceeded) are returned as Go errors with the Namecheap error message and code:
 
 ```go
-resp, err := client.Domains.Check("example.com")
+resp, err := client.Domains.CheckWithContext(ctx, "example.com")
 if err != nil {
     log.Fatal(err) // e.g. "Parameter DomainList is Missing (2011166)"
 }

--- a/namecheap/domains_check.go
+++ b/namecheap/domains_check.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"strings"
@@ -31,11 +32,11 @@ type DomainCheckResult struct {
 	EapFee                   *float64 `xml:"EapFee,attr"`
 }
 
-// Check returns availability and pricing information for one or more domains.
+// CheckWithContext returns availability and pricing information for one or more domains.
 // The Namecheap API accepts up to 50 domains per call.
 //
 // Namecheap doc: https://www.namecheap.com/support/api/methods/domains/check/
-func (ds *DomainsService) Check(domains ...string) (*DomainsCheckCommandResponse, error) {
+func (ds *DomainsService) CheckWithContext(ctx context.Context, domains ...string) (*DomainsCheckCommandResponse, error) {
 	var response DomainsCheckResponse
 
 	params := map[string]string{
@@ -43,7 +44,7 @@ func (ds *DomainsService) Check(domains ...string) (*DomainsCheckCommandResponse
 		"DomainList": strings.Join(domains, ","),
 	}
 
-	_, err := ds.client.DoXML(params, &response)
+	_, err := ds.client.DoXMLWithContext(ctx, params, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -54,4 +55,12 @@ func (ds *DomainsService) Check(domains ...string) (*DomainsCheckCommandResponse
 	}
 
 	return response.CommandResponse, nil
+}
+
+// Check returns availability and pricing information for one or more domains.
+//
+// Deprecated: Check runs without a context. Use CheckWithContext. It is
+// retained for backward compatibility and will be removed in v3.
+func (ds *DomainsService) Check(domains ...string) (*DomainsCheckCommandResponse, error) {
+	return ds.CheckWithContext(context.Background(), domains...)
 }

--- a/namecheap/domains_check_test.go
+++ b/namecheap/domains_check_test.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -42,7 +43,7 @@ func TestDomainsService_Check(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.Domains.Check("example.com")
+		_, err := client.Domains.CheckWithContext(context.Background(), "example.com")
 		if err != nil {
 			t.Fatal("Unable to check domain", err)
 		}
@@ -65,7 +66,7 @@ func TestDomainsService_Check(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.Domains.Check("example.com")
+		_, err := client.Domains.CheckWithContext(context.Background(), "example.com")
 		if err != nil {
 			t.Fatal("Unable to check domain", err)
 		}
@@ -104,7 +105,7 @@ func TestDomainsService_Check(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		result, err := client.Domains.Check("example.com", "example.net")
+		result, err := client.Domains.CheckWithContext(context.Background(), "example.com", "example.net")
 		if err != nil {
 			t.Fatal("Unable to check domains", err)
 		}
@@ -125,7 +126,7 @@ func TestDomainsService_Check(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		result, err := client.Domains.Check("example.com")
+		result, err := client.Domains.CheckWithContext(context.Background(), "example.com")
 		if err != nil {
 			t.Fatal("Unable to check domain", err)
 		}
@@ -167,7 +168,7 @@ func TestDomainsService_Check(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		result, err := client.Domains.Check("example.com")
+		result, err := client.Domains.CheckWithContext(context.Background(), "example.com")
 		if err != nil {
 			t.Fatal("Unable to check domain", err)
 		}
@@ -198,7 +199,7 @@ func TestDomainsService_Check(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.Domains.Check("bad")
+		_, err := client.Domains.CheckWithContext(context.Background(), "bad")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "1011150")
 	})
@@ -208,7 +209,7 @@ func TestDomainsService_Check(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = "://bad"
 
-		_, err := client.Domains.Check("example.com")
+		_, err := client.Domains.CheckWithContext(context.Background(), "example.com")
 		assert.Error(t, err)
 	})
 }

--- a/namecheap/domains_dns_get_email_forwarding.go
+++ b/namecheap/domains_dns_get_email_forwarding.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 )
@@ -29,11 +30,11 @@ type EmailForward struct {
 	ForwardTo string `xml:"ForwardTo,attr"`
 }
 
-// GetEmailForwarding returns the email forwarding rules configured for the domain.
+// GetEmailForwardingWithContext returns the email forwarding rules configured for the domain.
 // The domain must use Namecheap default DNS (FreeDNS).
 //
 // Namecheap doc: https://www.namecheap.com/support/api/methods/domains-dns/get-email-forwarding/
-func (dds *DomainsDNSService) GetEmailForwarding(domain string) (*DomainsDNSGetEmailForwardingCommandResponse, error) {
+func (dds *DomainsDNSService) GetEmailForwardingWithContext(ctx context.Context, domain string) (*DomainsDNSGetEmailForwardingCommandResponse, error) {
 	var response DomainsDNSGetEmailForwardingResponse
 
 	params := map[string]string{
@@ -41,7 +42,7 @@ func (dds *DomainsDNSService) GetEmailForwarding(domain string) (*DomainsDNSGetE
 		"DomainName": domain,
 	}
 
-	_, err := dds.client.DoXML(params, &response)
+	_, err := dds.client.DoXMLWithContext(ctx, params, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -51,4 +52,13 @@ func (dds *DomainsDNSService) GetEmailForwarding(domain string) (*DomainsDNSGetE
 	}
 
 	return response.CommandResponse, nil
+}
+
+// GetEmailForwarding returns the email forwarding rules configured for the domain.
+//
+// Deprecated: GetEmailForwarding runs without a context. Use
+// GetEmailForwardingWithContext. It is retained for backward compatibility and
+// will be removed in v3.
+func (dds *DomainsDNSService) GetEmailForwarding(domain string) (*DomainsDNSGetEmailForwardingCommandResponse, error) {
+	return dds.GetEmailForwardingWithContext(context.Background(), domain)
 }

--- a/namecheap/domains_dns_get_email_forwarding_test.go
+++ b/namecheap/domains_dns_get_email_forwarding_test.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -45,7 +46,7 @@ func TestDomainsDNSService_GetEmailForwarding(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.GetEmailForwarding("example.com")
+		_, err := client.DomainsDNS.GetEmailForwardingWithContext(context.Background(), "example.com")
 		if err != nil {
 			t.Fatal("Unable to get email forwarding", err)
 		}
@@ -68,7 +69,7 @@ func TestDomainsDNSService_GetEmailForwarding(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.GetEmailForwarding("example.com")
+		_, err := client.DomainsDNS.GetEmailForwardingWithContext(context.Background(), "example.com")
 		if err != nil {
 			t.Fatal("Unable to get email forwarding", err)
 		}
@@ -86,7 +87,7 @@ func TestDomainsDNSService_GetEmailForwarding(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		result, err := client.DomainsDNS.GetEmailForwarding("example.com")
+		result, err := client.DomainsDNS.GetEmailForwardingWithContext(context.Background(), "example.com")
 		if err != nil {
 			t.Fatal("Unable to get email forwarding", err)
 		}
@@ -126,7 +127,7 @@ func TestDomainsDNSService_GetEmailForwarding(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		result, err := client.DomainsDNS.GetEmailForwarding("example.com")
+		result, err := client.DomainsDNS.GetEmailForwardingWithContext(context.Background(), "example.com")
 		if err != nil {
 			t.Fatal("Unable to get email forwarding", err)
 		}
@@ -140,7 +141,7 @@ func TestDomainsDNSService_GetEmailForwarding(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = "://bad"
 
-		_, err := client.DomainsDNS.GetEmailForwarding("example.com")
+		_, err := client.DomainsDNS.GetEmailForwardingWithContext(context.Background(), "example.com")
 		assert.Error(t, err)
 	})
 
@@ -169,7 +170,7 @@ func TestDomainsDNSService_GetEmailForwarding(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.GetEmailForwarding("example.com")
+		_, err := client.DomainsDNS.GetEmailForwardingWithContext(context.Background(), "example.com")
 		assert.EqualError(t, err, "Domain is not associated with your account (2019166)")
 	})
 }

--- a/namecheap/domains_dns_get_hosts.go
+++ b/namecheap/domains_dns_get_hosts.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 )
@@ -43,10 +44,10 @@ func (d DomainsDNSHostRecordDetailed) String() string {
 		deref(d.HostId), deref(d.Name), deref(d.Type), deref(d.Address), deref(d.MXPref), deref(d.TTL), deref(d.AssociatedAppTitle), deref(d.FriendlyName), deref(d.IsActive), deref(d.IsDDNSEnabled))
 }
 
-// GetHosts retrieves DNS host record settings for the requested domain.
+// GetHostsWithContext retrieves DNS host record settings for the requested domain.
 //
 // Namecheap doc: https://www.namecheap.com/support/api/methods/domains-dns/get-hosts/
-func (dds *DomainsDNSService) GetHosts(domain string) (*DomainsDNSGetHostsCommandResponse, error) {
+func (dds *DomainsDNSService) GetHostsWithContext(ctx context.Context, domain string) (*DomainsDNSGetHostsCommandResponse, error) {
 	var response DomainsDNSGetHostsResponse
 
 	params := map[string]string{
@@ -61,7 +62,7 @@ func (dds *DomainsDNSService) GetHosts(domain string) (*DomainsDNSGetHostsComman
 	params["SLD"] = parsedDomain.SLD
 	params["TLD"] = parsedDomain.TLD
 
-	_, err = dds.client.DoXML(params, &response)
+	_, err = dds.client.DoXMLWithContext(ctx, params, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -71,4 +72,12 @@ func (dds *DomainsDNSService) GetHosts(domain string) (*DomainsDNSGetHostsComman
 	}
 
 	return response.CommandResponse, nil
+}
+
+// GetHosts retrieves DNS host record settings for the requested domain.
+//
+// Deprecated: GetHosts runs without a context. Use GetHostsWithContext. It is
+// retained for backward compatibility and will be removed in v3.
+func (dds *DomainsDNSService) GetHosts(domain string) (*DomainsDNSGetHostsCommandResponse, error) {
+	return dds.GetHostsWithContext(context.Background(), domain)
 }

--- a/namecheap/domains_dns_get_hosts_test.go
+++ b/namecheap/domains_dns_get_hosts_test.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -45,7 +46,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.GetHosts("domain.net")
+		_, err := client.DomainsDNS.GetHostsWithContext(context.Background(), "domain.net")
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -68,7 +69,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.GetHosts("domain.net")
+		_, err := client.DomainsDNS.GetHostsWithContext(context.Background(), "domain.net")
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -87,7 +88,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.GetHosts("domain")
+		_, err := client.DomainsDNS.GetHostsWithContext(context.Background(), "domain")
 
 		assert.NotNil(t, err)
 		assert.Contains(t, err.Error(), "invalid domain: incorrect format")
@@ -103,7 +104,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		response, err := client.DomainsDNS.GetHosts("domain.net")
+		response, err := client.DomainsDNS.GetHostsWithContext(context.Background(), "domain.net")
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -123,7 +124,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		response, err := client.DomainsDNS.GetHosts("domain.net")
+		response, err := client.DomainsDNS.GetHostsWithContext(context.Background(), "domain.net")
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -183,7 +184,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		response, err := client.DomainsDNS.GetHosts("domain.net")
+		response, err := client.DomainsDNS.GetHostsWithContext(context.Background(), "domain.net")
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -203,7 +204,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.GetHosts("domain.net")
+		_, err := client.DomainsDNS.GetHostsWithContext(context.Background(), "domain.net")
 
 		assert.EqualError(t, err, "unable to parse server response: EOF")
 	})
@@ -220,7 +221,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.GetHosts("domain.net")
+		_, err := client.DomainsDNS.GetHostsWithContext(context.Background(), "domain.net")
 
 		assert.EqualError(t, err, "unable to parse server response: EOF")
 	})
@@ -237,7 +238,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.GetHosts("domain.net")
+		_, err := client.DomainsDNS.GetHostsWithContext(context.Background(), "domain.net")
 
 		assert.EqualError(t, err, "unable to parse server response: expected element type <ApiResponse> but have <broken>")
 	})
@@ -266,7 +267,7 @@ func TestDomainsDNSGetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.GetHosts("domain.net")
+		_, err := client.DomainsDNS.GetHostsWithContext(context.Background(), "domain.net")
 
 		assert.EqualError(t, err, "Invalid Address (2050900)")
 	})

--- a/namecheap/domains_dns_get_list.go
+++ b/namecheap/domains_dns_get_list.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 )
@@ -32,10 +33,10 @@ func (d DomainDNSGetListResult) String() string {
 	)
 }
 
-// GetList gets a list of DNS servers associated with the requested domain
+// GetListWithContext gets a list of DNS servers associated with the requested domain
 //
 // Namecheap doc: https://www.namecheap.com/support/api/methods/domains-dns/get-list/
-func (dds *DomainsDNSService) GetList(domain string) (*DomainsDNSGetListCommandResponse, error) {
+func (dds *DomainsDNSService) GetListWithContext(ctx context.Context, domain string) (*DomainsDNSGetListCommandResponse, error) {
 	var response DomainsDNSGetListResponse
 
 	params := map[string]string{
@@ -50,7 +51,7 @@ func (dds *DomainsDNSService) GetList(domain string) (*DomainsDNSGetListCommandR
 	params["SLD"] = parsedDomain.SLD
 	params["TLD"] = parsedDomain.TLD
 
-	_, err = dds.client.DoXML(params, &response)
+	_, err = dds.client.DoXMLWithContext(ctx, params, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +63,7 @@ func (dds *DomainsDNSService) GetList(domain string) (*DomainsDNSGetListCommandR
 		}
 
 		var domainInfo *DomainsGetInfoCommandResponse
-		domainInfo, err = dds.client.Domains.GetInfo(domain)
+		domainInfo, err = dds.client.Domains.GetInfoWithContext(ctx, domain)
 		if err != nil {
 			return nil, err
 		}
@@ -81,4 +82,12 @@ func (dds *DomainsDNSService) GetList(domain string) (*DomainsDNSGetListCommandR
 	}
 
 	return response.CommandResponse, nil
+}
+
+// GetList gets a list of DNS servers associated with the requested domain.
+//
+// Deprecated: GetList runs without a context. Use GetListWithContext. It is
+// retained for backward compatibility and will be removed in v3.
+func (dds *DomainsDNSService) GetList(domain string) (*DomainsDNSGetListCommandResponse, error) {
+	return dds.GetListWithContext(context.Background(), domain)
 }

--- a/namecheap/domains_dns_get_list_test.go
+++ b/namecheap/domains_dns_get_list_test.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -43,7 +44,7 @@ func TestDomainsDNSGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.GetList("domain.net")
+		_, err := client.DomainsDNS.GetListWithContext(context.Background(), "domain.net")
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -66,7 +67,7 @@ func TestDomainsDNSGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.GetList("domain.net")
+		_, err := client.DomainsDNS.GetListWithContext(context.Background(), "domain.net")
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -85,7 +86,7 @@ func TestDomainsDNSGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		result, err := client.DomainsDNS.GetList("domain.net")
+		result, err := client.DomainsDNS.GetListWithContext(context.Background(), "domain.net")
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -106,7 +107,7 @@ func TestDomainsDNSGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		result, err := client.DomainsDNS.GetList("domain.net")
+		result, err := client.DomainsDNS.GetListWithContext(context.Background(), "domain.net")
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -139,7 +140,7 @@ func TestDomainsDNSGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		result, err := client.DomainsDNS.GetList("domain.net")
+		result, err := client.DomainsDNS.GetListWithContext(context.Background(), "domain.net")
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -214,7 +215,7 @@ func TestDomainsDNSGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		result, err := client.DomainsDNS.GetList("horse-family.com.ua")
+		result, err := client.DomainsDNS.GetListWithContext(context.Background(), "horse-family.com.ua")
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -251,7 +252,7 @@ func TestDomainsDNSGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.GetList("notfound.com")
+		_, err := client.DomainsDNS.GetListWithContext(context.Background(), "notfound.com")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "2050900")
 	})
@@ -261,7 +262,7 @@ func TestDomainsDNSGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = "://bad"
 
-		_, err := client.DomainsDNS.GetList("domain.net")
+		_, err := client.DomainsDNS.GetListWithContext(context.Background(), "domain.net")
 		assert.Error(t, err)
 	})
 
@@ -269,7 +270,7 @@ func TestDomainsDNSGetList(t *testing.T) {
 		t.Parallel()
 		client := setupClient(nil)
 
-		_, err := client.DomainsDNS.GetList("invalid")
+		_, err := client.DomainsDNS.GetListWithContext(context.Background(), "invalid")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid domain")
 	})
@@ -294,7 +295,7 @@ func TestDomainsDNSGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.GetList("horse-family.com.ua")
+		_, err := client.DomainsDNS.GetListWithContext(context.Background(), "horse-family.com.ua")
 		assert.Error(t, err)
 	})
 }

--- a/namecheap/domains_dns_set_custom.go
+++ b/namecheap/domains_dns_set_custom.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"strings"
@@ -28,11 +29,11 @@ func (d DomainsDNSSetCustomResult) String() string {
 	return fmt.Sprintf("{Domain: %v, Updated: %v}", deref(d.Domain), deref(d.Updated))
 }
 
-// SetCustom sets domain to use custom DNS servers
+// SetCustomWithContext sets domain to use custom DNS servers
 // NOTE: Services like URL forwarding, Email forwarding, Dynamic DNS will not work for domains using custom nameservers
 //
 // Namecheap doc: https://www.namecheap.com/support/api/methods/domains-dns/set-custom/
-func (dds *DomainsDNSService) SetCustom(domain string, nameservers []string) (*DomainsDNSSetCustomCommandResponse, error) {
+func (dds *DomainsDNSService) SetCustomWithContext(ctx context.Context, domain string, nameservers []string) (*DomainsDNSSetCustomCommandResponse, error) {
 	var response DomainsDNSSetCustomResponse
 
 	params := map[string]string{
@@ -54,7 +55,7 @@ func (dds *DomainsDNSService) SetCustom(domain string, nameservers []string) (*D
 
 	params["Nameservers"] = *nameserversString
 
-	_, err = dds.client.DoXML(params, &response)
+	_, err = dds.client.DoXMLWithContext(ctx, params, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -64,6 +65,14 @@ func (dds *DomainsDNSService) SetCustom(domain string, nameservers []string) (*D
 	}
 
 	return response.CommandResponse, nil
+}
+
+// SetCustom sets domain to use custom DNS servers.
+//
+// Deprecated: SetCustom runs without a context. Use SetCustomWithContext. It is
+// retained for backward compatibility and will be removed in v3.
+func (dds *DomainsDNSService) SetCustom(domain string, nameservers []string) (*DomainsDNSSetCustomCommandResponse, error) {
+	return dds.SetCustomWithContext(context.Background(), domain, nameservers)
 }
 
 func validateAndParseCustomNameservers(nameservers []string) (*string, error) {

--- a/namecheap/domains_dns_set_custom_test.go
+++ b/namecheap/domains_dns_set_custom_test.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -44,7 +45,7 @@ func TestDomainsDNSSetCustom(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetCustom("domain.net", fakeNameservers)
+		_, err := client.DomainsDNS.SetCustomWithContext(context.Background(), "domain.net", fakeNameservers)
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -67,7 +68,7 @@ func TestDomainsDNSSetCustom(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetCustom("domain.net", fakeNameservers)
+		_, err := client.DomainsDNS.SetCustomWithContext(context.Background(), "domain.net", fakeNameservers)
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -91,7 +92,7 @@ func TestDomainsDNSSetCustom(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetCustom("domain.net", fakeNameservers)
+		_, err := client.DomainsDNS.SetCustomWithContext(context.Background(), "domain.net", fakeNameservers)
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -111,7 +112,7 @@ func TestDomainsDNSSetCustom(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		result, err := client.DomainsDNS.SetCustom("domain.net", fakeNameservers)
+		result, err := client.DomainsDNS.SetCustomWithContext(context.Background(), "domain.net", fakeNameservers)
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -134,7 +135,7 @@ func TestDomainsDNSSetCustom(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetCustom("domain.net", fakeNameservers)
+		_, err := client.DomainsDNS.SetCustomWithContext(context.Background(), "domain.net", fakeNameservers)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "2019166")
 	})
@@ -144,7 +145,7 @@ func TestDomainsDNSSetCustom(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = "://bad"
 
-		_, err := client.DomainsDNS.SetCustom("domain.net", fakeNameservers)
+		_, err := client.DomainsDNS.SetCustomWithContext(context.Background(), "domain.net", fakeNameservers)
 		assert.Error(t, err)
 	})
 
@@ -152,7 +153,7 @@ func TestDomainsDNSSetCustom(t *testing.T) {
 		t.Parallel()
 		client := setupClient(nil)
 
-		_, err := client.DomainsDNS.SetCustom("invalid", fakeNameservers)
+		_, err := client.DomainsDNS.SetCustomWithContext(context.Background(), "invalid", fakeNameservers)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid domain")
 	})
@@ -175,7 +176,7 @@ func TestDomainsDNSSetCustom(t *testing.T) {
 			client := setupClient(nil)
 			client.BaseURL = mockServer.URL
 
-			_, err := client.DomainsDNS.SetCustom("domain.net", errorCase.Nameservers)
+			_, err := client.DomainsDNS.SetCustomWithContext(context.Background(), "domain.net", errorCase.Nameservers)
 
 			assert.EqualError(t, err, "invalid nameservers: must contain minimum two items")
 		})

--- a/namecheap/domains_dns_set_default.go
+++ b/namecheap/domains_dns_set_default.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 )
@@ -27,11 +28,11 @@ func (d DomainDNSSetDefaultResult) String() string {
 	return fmt.Sprintf("{Domain: %v, Updated: %v}", deref(d.Domain), deref(d.Updated))
 }
 
-// SetDefault sets domain to use our default DNS servers.
+// SetDefaultWithContext sets domain to use our default DNS servers.
 // Required for free services like Host record management, URL forwarding, email forwarding, dynamic dns and other value added services.
 //
 // Namecheap doc: https://www.namecheap.com/support/api/methods/domains-dns/set-default/
-func (dds *DomainsDNSService) SetDefault(domain string) (*DomainsDNSSetDefaultCommandResponse, error) {
+func (dds *DomainsDNSService) SetDefaultWithContext(ctx context.Context, domain string) (*DomainsDNSSetDefaultCommandResponse, error) {
 	var response DomainsDNSSetDefaultResponse
 
 	params := map[string]string{
@@ -46,7 +47,7 @@ func (dds *DomainsDNSService) SetDefault(domain string) (*DomainsDNSSetDefaultCo
 	params["SLD"] = parsedDomain.SLD
 	params["TLD"] = parsedDomain.TLD
 
-	_, err = dds.client.DoXML(params, &response)
+	_, err = dds.client.DoXMLWithContext(ctx, params, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -56,4 +57,12 @@ func (dds *DomainsDNSService) SetDefault(domain string) (*DomainsDNSSetDefaultCo
 	}
 
 	return response.CommandResponse, nil
+}
+
+// SetDefault sets domain to use our default DNS servers.
+//
+// Deprecated: SetDefault runs without a context. Use SetDefaultWithContext. It
+// is retained for backward compatibility and will be removed in v3.
+func (dds *DomainsDNSService) SetDefault(domain string) (*DomainsDNSSetDefaultCommandResponse, error) {
+	return dds.SetDefaultWithContext(context.Background(), domain)
 }

--- a/namecheap/domains_dns_set_default_test.go
+++ b/namecheap/domains_dns_set_default_test.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -40,7 +41,7 @@ func TestDomainsDNSSetDefault(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetDefault("domain.net")
+		_, err := client.DomainsDNS.SetDefaultWithContext(context.Background(), "domain.net")
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -63,7 +64,7 @@ func TestDomainsDNSSetDefault(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetDefault("domain.net")
+		_, err := client.DomainsDNS.SetDefaultWithContext(context.Background(), "domain.net")
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -82,7 +83,7 @@ func TestDomainsDNSSetDefault(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		result, err := client.DomainsDNS.SetDefault("domain.net")
+		result, err := client.DomainsDNS.SetDefaultWithContext(context.Background(), "domain.net")
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -105,7 +106,7 @@ func TestDomainsDNSSetDefault(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetDefault("notfound.com")
+		_, err := client.DomainsDNS.SetDefaultWithContext(context.Background(), "notfound.com")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "2019166")
 	})
@@ -115,7 +116,7 @@ func TestDomainsDNSSetDefault(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = "://bad"
 
-		_, err := client.DomainsDNS.SetDefault("domain.net")
+		_, err := client.DomainsDNS.SetDefaultWithContext(context.Background(), "domain.net")
 		assert.Error(t, err)
 	})
 
@@ -123,7 +124,7 @@ func TestDomainsDNSSetDefault(t *testing.T) {
 		t.Parallel()
 		client := setupClient(nil)
 
-		_, err := client.DomainsDNS.SetDefault("invalid")
+		_, err := client.DomainsDNS.SetDefaultWithContext(context.Background(), "invalid")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid domain")
 	})

--- a/namecheap/domains_dns_set_email_forwarding.go
+++ b/namecheap/domains_dns_set_email_forwarding.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"strconv"
@@ -24,12 +25,12 @@ type DomainDNSSetEmailForwardingResult struct {
 	IsSuccess *bool   `xml:"IsSuccess,attr"`
 }
 
-// SetEmailForwarding configures email forwarding rules for the domain, replacing all existing rules.
+// SetEmailForwardingWithContext configures email forwarding rules for the domain, replacing all existing rules.
 // The domain must use Namecheap default DNS (FreeDNS).
 // Each EmailForward maps a local mailbox alias (e.g. "info") to a destination address.
 //
 // Namecheap doc: https://www.namecheap.com/support/api/methods/domains-dns/set-email-forwarding/
-func (dds *DomainsDNSService) SetEmailForwarding(domain string, forwards []EmailForward) (*DomainsDNSSetEmailForwardingCommandResponse, error) {
+func (dds *DomainsDNSService) SetEmailForwardingWithContext(ctx context.Context, domain string, forwards []EmailForward) (*DomainsDNSSetEmailForwardingCommandResponse, error) {
 	var response DomainsDNSSetEmailForwardingResponse
 
 	params := map[string]string{
@@ -43,7 +44,7 @@ func (dds *DomainsDNSService) SetEmailForwarding(domain string, forwards []Email
 		params["ForwardTo"+n] = fwd.ForwardTo
 	}
 
-	_, err := dds.client.DoXML(params, &response)
+	_, err := dds.client.DoXMLWithContext(ctx, params, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -53,4 +54,13 @@ func (dds *DomainsDNSService) SetEmailForwarding(domain string, forwards []Email
 	}
 
 	return response.CommandResponse, nil
+}
+
+// SetEmailForwarding configures email forwarding rules for the domain, replacing all existing rules.
+//
+// Deprecated: SetEmailForwarding runs without a context. Use
+// SetEmailForwardingWithContext. It is retained for backward compatibility and
+// will be removed in v3.
+func (dds *DomainsDNSService) SetEmailForwarding(domain string, forwards []EmailForward) (*DomainsDNSSetEmailForwardingCommandResponse, error) {
+	return dds.SetEmailForwardingWithContext(context.Background(), domain, forwards)
 }

--- a/namecheap/domains_dns_set_email_forwarding_test.go
+++ b/namecheap/domains_dns_set_email_forwarding_test.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -42,7 +43,7 @@ func TestDomainsDNSService_SetEmailForwarding(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetEmailForwarding("example.com", []EmailForward{
+		_, err := client.DomainsDNS.SetEmailForwardingWithContext(context.Background(), "example.com", []EmailForward{
 			{Mailbox: "info", ForwardTo: "user@gmail.com"},
 		})
 		if err != nil {
@@ -67,7 +68,7 @@ func TestDomainsDNSService_SetEmailForwarding(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetEmailForwarding("example.com", []EmailForward{
+		_, err := client.DomainsDNS.SetEmailForwardingWithContext(context.Background(), "example.com", []EmailForward{
 			{Mailbox: "info", ForwardTo: "user@gmail.com"},
 		})
 		if err != nil {
@@ -92,7 +93,7 @@ func TestDomainsDNSService_SetEmailForwarding(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetEmailForwarding("example.com", []EmailForward{
+		_, err := client.DomainsDNS.SetEmailForwardingWithContext(context.Background(), "example.com", []EmailForward{
 			{Mailbox: "info", ForwardTo: "user@gmail.com"},
 		})
 		if err != nil {
@@ -119,7 +120,7 @@ func TestDomainsDNSService_SetEmailForwarding(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetEmailForwarding("example.com", []EmailForward{
+		_, err := client.DomainsDNS.SetEmailForwardingWithContext(context.Background(), "example.com", []EmailForward{
 			{Mailbox: "info", ForwardTo: "user@gmail.com"},
 			{Mailbox: "support", ForwardTo: "support@company.com"},
 			{Mailbox: "billing", ForwardTo: "billing@company.com"},
@@ -146,7 +147,7 @@ func TestDomainsDNSService_SetEmailForwarding(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		result, err := client.DomainsDNS.SetEmailForwarding("example.com", []EmailForward{
+		result, err := client.DomainsDNS.SetEmailForwardingWithContext(context.Background(), "example.com", []EmailForward{
 			{Mailbox: "info", ForwardTo: "user@gmail.com"},
 		})
 		if err != nil {
@@ -174,7 +175,7 @@ func TestDomainsDNSService_SetEmailForwarding(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetEmailForwarding("example.com", []EmailForward{})
+		_, err := client.DomainsDNS.SetEmailForwardingWithContext(context.Background(), "example.com", []EmailForward{})
 		if err != nil {
 			t.Fatal("Unable to set email forwarding", err)
 		}
@@ -208,7 +209,7 @@ func TestDomainsDNSService_SetEmailForwarding(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetEmailForwarding("example.com", []EmailForward{
+		_, err := client.DomainsDNS.SetEmailForwardingWithContext(context.Background(), "example.com", []EmailForward{
 			{Mailbox: "info", ForwardTo: "user@gmail.com"},
 		})
 		assert.EqualError(t, err, "Domain is not associated with your account (2019166)")
@@ -219,7 +220,7 @@ func TestDomainsDNSService_SetEmailForwarding(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = "://bad"
 
-		_, err := client.DomainsDNS.SetEmailForwarding("example.com", []EmailForward{
+		_, err := client.DomainsDNS.SetEmailForwardingWithContext(context.Background(), "example.com", []EmailForward{
 			{Mailbox: "info", ForwardTo: "user@gmail.com"},
 		})
 		assert.Error(t, err)

--- a/namecheap/domains_dns_set_hosts.go
+++ b/namecheap/domains_dns_set_hosts.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"regexp"
@@ -97,10 +98,10 @@ func (d DomainDNSSetHostsResult) String() string {
 	return fmt.Sprintf("{Domain: %v, IsSuccess: %v}", deref(d.Domain), deref(d.IsSuccess))
 }
 
-// SetHosts sets DNS host records settings for the requested domain
+// SetHostsWithContext sets DNS host records settings for the requested domain
 //
 // Namecheap doc: https://www.namecheap.com/support/api/methods/domains-dns/set-hosts/
-func (dds *DomainsDNSService) SetHosts(args *DomainsDNSSetHostsArgs) (*DomainsDNSSetHostsCommandResponse, error) {
+func (dds *DomainsDNSService) SetHostsWithContext(ctx context.Context, args *DomainsDNSSetHostsArgs) (*DomainsDNSSetHostsCommandResponse, error) {
 	var response DomainsDNSSetHostsResponse
 
 	params := map[string]string{
@@ -124,7 +125,7 @@ func (dds *DomainsDNSService) SetHosts(args *DomainsDNSSetHostsArgs) (*DomainsDN
 		params[k] = v
 	}
 
-	_, err = dds.client.DoXML(params, &response)
+	_, err = dds.client.DoXMLWithContext(ctx, params, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -134,6 +135,14 @@ func (dds *DomainsDNSService) SetHosts(args *DomainsDNSSetHostsArgs) (*DomainsDN
 	}
 
 	return response.CommandResponse, nil
+}
+
+// SetHosts sets DNS host records settings for the requested domain.
+//
+// Deprecated: SetHosts runs without a context. Use SetHostsWithContext. It is
+// retained for backward compatibility and will be removed in v3.
+func (dds *DomainsDNSService) SetHosts(args *DomainsDNSSetHostsArgs) (*DomainsDNSSetHostsCommandResponse, error) {
+	return dds.SetHostsWithContext(context.Background(), args)
 }
 
 // nolint: gocyclo

--- a/namecheap/domains_dns_set_hosts_test.go
+++ b/namecheap/domains_dns_set_hosts_test.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -44,7 +45,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetHosts(&DomainsDNSSetHostsArgs{
+		_, err := client.DomainsDNS.SetHostsWithContext(context.Background(), &DomainsDNSSetHostsArgs{
 			Domain: String("domain.net"),
 		})
 		if err != nil {
@@ -69,7 +70,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetHosts(&DomainsDNSSetHostsArgs{
+		_, err := client.DomainsDNS.SetHostsWithContext(context.Background(), &DomainsDNSSetHostsArgs{
 			Domain:    String("domain.net"),
 			EmailType: String(EmailTypeForward),
 			Flag:      UInt8(100),
@@ -101,7 +102,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetHosts(&DomainsDNSSetHostsArgs{
+		_, err := client.DomainsDNS.SetHostsWithContext(context.Background(), &DomainsDNSSetHostsArgs{
 			Domain:    String("domain.net"),
 			EmailType: String("MX"),
 			Records: &[]DomainsDNSHostRecord{
@@ -151,7 +152,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetHosts(&DomainsDNSSetHostsArgs{
+		_, err := client.DomainsDNS.SetHostsWithContext(context.Background(), &DomainsDNSSetHostsArgs{
 			Domain:    String("domain.net"),
 			EmailType: String(EmailTypeMXE),
 			Records: &[]DomainsDNSHostRecord{
@@ -190,7 +191,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetHosts(&DomainsDNSSetHostsArgs{
+		_, err := client.DomainsDNS.SetHostsWithContext(context.Background(), &DomainsDNSSetHostsArgs{
 			Domain: String("domain.net"),
 			Records: &[]DomainsDNSHostRecord{
 				{
@@ -224,7 +225,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetHosts(&DomainsDNSSetHostsArgs{
+		_, err := client.DomainsDNS.SetHostsWithContext(context.Background(), &DomainsDNSSetHostsArgs{
 			Domain: String("domain.net"),
 			Records: &[]DomainsDNSHostRecord{
 				{
@@ -258,7 +259,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetHosts(&DomainsDNSSetHostsArgs{
+		_, err := client.DomainsDNS.SetHostsWithContext(context.Background(), &DomainsDNSSetHostsArgs{
 			Domain: String("domain.net"),
 			Records: &[]DomainsDNSHostRecord{
 				{
@@ -292,7 +293,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetHosts(&DomainsDNSSetHostsArgs{
+		_, err := client.DomainsDNS.SetHostsWithContext(context.Background(), &DomainsDNSSetHostsArgs{
 			Domain: String("domain.net"),
 			Records: &[]DomainsDNSHostRecord{
 				{
@@ -326,7 +327,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetHosts(&DomainsDNSSetHostsArgs{
+		_, err := client.DomainsDNS.SetHostsWithContext(context.Background(), &DomainsDNSSetHostsArgs{
 			Domain: String("domain.net"),
 			Records: &[]DomainsDNSHostRecord{
 				{
@@ -573,7 +574,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 			client := setupClient(nil)
 			client.BaseURL = mockServer.URL
 
-			_, err := client.DomainsDNS.SetHosts(errorCase.Args)
+			_, err := client.DomainsDNS.SetHostsWithContext(context.Background(), errorCase.Args)
 
 			assert.EqualError(t, err, errorCase.ExpectedError)
 		})
@@ -593,7 +594,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.SetHosts(&DomainsDNSSetHostsArgs{Domain: String("notfound.com")})
+		_, err := client.DomainsDNS.SetHostsWithContext(context.Background(), &DomainsDNSSetHostsArgs{Domain: String("notfound.com")})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "2019166")
 	})
@@ -603,7 +604,7 @@ func TestDomainsDNSSetHosts(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = "://bad"
 
-		_, err := client.DomainsDNS.SetHosts(&DomainsDNSSetHostsArgs{Domain: String("domain.net")})
+		_, err := client.DomainsDNS.SetHostsWithContext(context.Background(), &DomainsDNSSetHostsArgs{Domain: String("domain.net")})
 		assert.Error(t, err)
 	})
 }

--- a/namecheap/domains_get_info.go
+++ b/namecheap/domains_get_info.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 )
@@ -35,8 +36,8 @@ type DnsDetails struct { // nolint: stylecheck,revive
 	Nameservers   *[]string `xml:"Nameserver"`
 }
 
-// GetInfo returns detailed information about the requested domain.
-func (ds *DomainsService) GetInfo(domain string) (*DomainsGetInfoCommandResponse, error) {
+// GetInfoWithContext returns detailed information about the requested domain.
+func (ds *DomainsService) GetInfoWithContext(ctx context.Context, domain string) (*DomainsGetInfoCommandResponse, error) {
 	var response DomainsGetInfoResponse
 
 	params := map[string]string{
@@ -45,7 +46,7 @@ func (ds *DomainsService) GetInfo(domain string) (*DomainsGetInfoCommandResponse
 		"HostName":   domain,
 	}
 
-	_, err := ds.client.DoXML(params, &response)
+	_, err := ds.client.DoXMLWithContext(ctx, params, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -56,4 +57,12 @@ func (ds *DomainsService) GetInfo(domain string) (*DomainsGetInfoCommandResponse
 	}
 
 	return response.CommandResponse, nil
+}
+
+// GetInfo returns detailed information about the requested domain.
+//
+// Deprecated: GetInfo runs without a context. Use GetInfoWithContext. It is
+// retained for backward compatibility and will be removed in v3.
+func (ds *DomainsService) GetInfo(domain string) (*DomainsGetInfoCommandResponse, error) {
+	return ds.GetInfoWithContext(context.Background(), domain)
 }

--- a/namecheap/domains_get_info_test.go
+++ b/namecheap/domains_get_info_test.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -66,7 +67,7 @@ func TestDomainsGetInfo(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.Domains.GetInfo("horse-family.com.ua")
+		_, err := client.Domains.GetInfoWithContext(context.Background(), "horse-family.com.ua")
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -86,7 +87,7 @@ func TestDomainsGetInfo(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.GetHosts("horse-family.com.ua")
+		_, err := client.DomainsDNS.GetHostsWithContext(context.Background(), "horse-family.com.ua")
 
 		assert.EqualError(t, err, "unable to parse server response: EOF")
 	})
@@ -103,7 +104,7 @@ func TestDomainsGetInfo(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.GetHosts("domain.net")
+		_, err := client.DomainsDNS.GetHostsWithContext(context.Background(), "domain.net")
 
 		assert.EqualError(t, err, "unable to parse server response: EOF")
 	})
@@ -120,7 +121,7 @@ func TestDomainsGetInfo(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.GetHosts("domain.net")
+		_, err := client.DomainsDNS.GetHostsWithContext(context.Background(), "domain.net")
 
 		assert.EqualError(t, err, "unable to parse server response: expected element type <ApiResponse> but have <broken>")
 	})
@@ -149,7 +150,7 @@ func TestDomainsGetInfo(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsDNS.GetHosts("domain.net")
+		_, err := client.DomainsDNS.GetHostsWithContext(context.Background(), "domain.net")
 
 		assert.EqualError(t, err, "Invalid Address (2050900)")
 	})
@@ -168,7 +169,7 @@ func TestDomainsGetInfo(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.Domains.GetInfo("notfound.com")
+		_, err := client.Domains.GetInfoWithContext(context.Background(), "notfound.com")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "2019166")
 	})
@@ -178,7 +179,7 @@ func TestDomainsGetInfo(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = "://bad"
 
-		_, err := client.Domains.GetInfo("domain.com")
+		_, err := client.Domains.GetInfoWithContext(context.Background(), "domain.com")
 		assert.Error(t, err)
 	})
 }

--- a/namecheap/domains_get_list.go
+++ b/namecheap/domains_get_list.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"strconv"
@@ -66,13 +67,13 @@ type DomainsGetListArgs struct {
 	SortBy *string
 }
 
-// GetList returns a list of domains for the particular user
+// GetListWithContext returns a list of domains for the particular user
 // Returns DomainsGetListCommandResponse with list of user Domain and paging DomainsGetListPaging
 // DomainsGetListArgs is the input arguments. When nil is passed, then nothing will be passed through.
 // In this case revert to the official documentation to check defaults
 //
 // Namecheap doc: https://www.namecheap.com/support/api/methods/domains/get-list/
-func (ds *DomainsService) GetList(args *DomainsGetListArgs) (*DomainsGetListCommandResponse, error) {
+func (ds *DomainsService) GetListWithContext(ctx context.Context, args *DomainsGetListArgs) (*DomainsGetListCommandResponse, error) {
 	var domainsResponse DomainsGetListResponse
 	params := map[string]string{
 		"Command": "namecheap.domains.getList",
@@ -89,7 +90,7 @@ func (ds *DomainsService) GetList(args *DomainsGetListArgs) (*DomainsGetListComm
 		params[k] = v
 	}
 
-	_, err = ds.client.DoXML(params, &domainsResponse)
+	_, err = ds.client.DoXMLWithContext(ctx, params, &domainsResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -99,6 +100,14 @@ func (ds *DomainsService) GetList(args *DomainsGetListArgs) (*DomainsGetListComm
 	}
 
 	return domainsResponse.CommandResponse, nil
+}
+
+// GetList returns a list of domains for the particular user.
+//
+// Deprecated: GetList runs without a context. Use GetListWithContext. It is
+// retained for backward compatibility and will be removed in v3.
+func (ds *DomainsService) GetList(args *DomainsGetListArgs) (*DomainsGetListCommandResponse, error) {
+	return ds.GetListWithContext(context.Background(), args)
 }
 
 func parseDomainsGetListArgs(args *DomainsGetListArgs) (map[string]string, error) {

--- a/namecheap/domains_get_list_test.go
+++ b/namecheap/domains_get_list_test.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -51,7 +52,7 @@ func TestDomainsGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.Domains.GetList(&DomainsGetListArgs{})
+		_, err := client.Domains.GetListWithContext(context.Background(), &DomainsGetListArgs{})
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -74,7 +75,7 @@ func TestDomainsGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.Domains.GetList(&DomainsGetListArgs{
+		_, err := client.Domains.GetListWithContext(context.Background(), &DomainsGetListArgs{
 			ListType:   String("EXPIRING"),
 			SearchTerm: String("search.com"),
 			Page:       Int(2),
@@ -107,7 +108,7 @@ func TestDomainsGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.Domains.GetList(nil)
+		_, err := client.Domains.GetListWithContext(context.Background(), nil)
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -129,7 +130,7 @@ func TestDomainsGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.Domains.GetList(&DomainsGetListArgs{
+		_, err := client.Domains.GetListWithContext(context.Background(), &DomainsGetListArgs{
 			Page: Int(-1),
 		})
 
@@ -146,7 +147,7 @@ func TestDomainsGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.Domains.GetList(&DomainsGetListArgs{
+		_, err := client.Domains.GetListWithContext(context.Background(), &DomainsGetListArgs{
 			PageSize: Int(3),
 		})
 
@@ -163,7 +164,7 @@ func TestDomainsGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.Domains.GetList(&DomainsGetListArgs{
+		_, err := client.Domains.GetListWithContext(context.Background(), &DomainsGetListArgs{
 			PageSize: Int(999),
 		})
 
@@ -174,7 +175,7 @@ func TestDomainsGetList(t *testing.T) {
 		t.Parallel()
 		client := setupClient(nil)
 
-		_, err := client.Domains.GetList(&DomainsGetListArgs{
+		_, err := client.Domains.GetListWithContext(context.Background(), &DomainsGetListArgs{
 			SortBy: String("INVALID"),
 		})
 
@@ -185,7 +186,7 @@ func TestDomainsGetList(t *testing.T) {
 		t.Parallel()
 		client := setupClient(nil)
 
-		_, err := client.Domains.GetList(&DomainsGetListArgs{
+		_, err := client.Domains.GetListWithContext(context.Background(), &DomainsGetListArgs{
 			ListType: String("BADTYPE"),
 		})
 
@@ -202,7 +203,7 @@ func TestDomainsGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		response, err := client.Domains.GetList(&DomainsGetListArgs{})
+		response, err := client.Domains.GetListWithContext(context.Background(), &DomainsGetListArgs{})
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -252,7 +253,7 @@ func TestDomainsGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		response, err := client.Domains.GetList(&DomainsGetListArgs{})
+		response, err := client.Domains.GetListWithContext(context.Background(), &DomainsGetListArgs{})
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -296,7 +297,7 @@ func TestDomainsGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		response, err := client.Domains.GetList(&DomainsGetListArgs{})
+		response, err := client.Domains.GetListWithContext(context.Background(), &DomainsGetListArgs{})
 		if err != nil {
 			t.Fatal("Unable to get domains", err)
 		}
@@ -316,7 +317,7 @@ func TestDomainsGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.Domains.GetList(nil)
+		_, err := client.Domains.GetListWithContext(context.Background(), nil)
 
 		assert.EqualError(t, err, "unable to parse server response: EOF")
 	})
@@ -333,7 +334,7 @@ func TestDomainsGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.Domains.GetList(nil)
+		_, err := client.Domains.GetListWithContext(context.Background(), nil)
 
 		assert.EqualError(t, err, "unable to parse server response: EOF")
 	})
@@ -350,7 +351,7 @@ func TestDomainsGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.Domains.GetList(nil)
+		_, err := client.Domains.GetListWithContext(context.Background(), nil)
 
 		assert.EqualError(t, err, "unable to parse server response: expected element type <ApiResponse> but have <broken>")
 	})
@@ -379,7 +380,7 @@ func TestDomainsGetList(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.Domains.GetList(nil)
+		_, err := client.Domains.GetListWithContext(context.Background(), nil)
 
 		assert.EqualError(t, err, "Invalid Address (2050900)")
 	})

--- a/namecheap/domains_ns_create.go
+++ b/namecheap/domains_ns_create.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 )
@@ -25,8 +26,8 @@ type DomainsNSCreateResult struct {
 	IsSuccess  *bool   `xml:"IsSuccess,attr"`
 }
 
-// Create creates a new nameserver.
-func (s *DomainsNSService) Create(sld, tld, nameserver, ipAddress string) (*NameserversCreateCommandResponse, error) {
+// CreateWithContext creates a new nameserver.
+func (s *DomainsNSService) CreateWithContext(ctx context.Context, sld, tld, nameserver, ipAddress string) (*NameserversCreateCommandResponse, error) {
 	var response NameserversCreateResponse
 
 	params := map[string]string{
@@ -37,7 +38,7 @@ func (s *DomainsNSService) Create(sld, tld, nameserver, ipAddress string) (*Name
 		"IP":         ipAddress,
 	}
 
-	_, err := s.client.DoXML(params, &response)
+	_, err := s.client.DoXMLWithContext(ctx, params, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -48,4 +49,12 @@ func (s *DomainsNSService) Create(sld, tld, nameserver, ipAddress string) (*Name
 	}
 
 	return response.CommandResponse, nil
+}
+
+// Create creates a new nameserver.
+//
+// Deprecated: Create runs without a context. Use CreateWithContext. It is
+// retained for backward compatibility and will be removed in v3.
+func (s *DomainsNSService) Create(sld, tld, nameserver, ipAddress string) (*NameserversCreateCommandResponse, error) {
+	return s.CreateWithContext(context.Background(), sld, tld, nameserver, ipAddress)
 }

--- a/namecheap/domains_ns_create_test.go
+++ b/namecheap/domains_ns_create_test.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -41,7 +42,7 @@ func TestDomainNameserversCreate(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Create("specific-sld", "specific-tld", "ns1.domain.com", "1.1.1.1")
+		_, err := client.DomainsNS.CreateWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com", "1.1.1.1")
 		if err != nil {
 			t.Fatal("Unable to get domain nameserver", err)
 		}
@@ -61,7 +62,7 @@ func TestDomainNameserversCreate(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Create("specific-sld", "specific-tld", "ns1.domain.com", "1.1.1.1")
+		_, err := client.DomainsNS.CreateWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com", "1.1.1.1")
 
 		assert.EqualError(t, err, "unable to parse server response: EOF")
 	})
@@ -78,7 +79,7 @@ func TestDomainNameserversCreate(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Create("specific-sld", "specific-tld", "ns1.domain.com", "1.1.1.1")
+		_, err := client.DomainsNS.CreateWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com", "1.1.1.1")
 
 		assert.EqualError(t, err, "unable to parse server response: EOF")
 	})
@@ -95,7 +96,7 @@ func TestDomainNameserversCreate(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Create("specific-sld", "specific-tld", "ns1.domain.com", "1.1.1.1")
+		_, err := client.DomainsNS.CreateWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com", "1.1.1.1")
 
 		assert.EqualError(t, err, "unable to parse server response: expected element type <ApiResponse> but have <broken>")
 	})
@@ -124,7 +125,7 @@ func TestDomainNameserversCreate(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Create("specific-sld", "specific-tld", "ns1.domain.com", "1.1.1.1")
+		_, err := client.DomainsNS.CreateWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com", "1.1.1.1")
 
 		assert.EqualError(t, err, "Domain not found (2019166)")
 	})
@@ -153,7 +154,7 @@ func TestDomainNameserversCreate(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Create("specific-sld", "specific-tld", "ns1.domain.com", "1.1.1.1")
+		_, err := client.DomainsNS.CreateWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com", "1.1.1.1")
 
 		assert.EqualError(t, err, "Domain is not associated with your account (2016166)")
 	})
@@ -182,7 +183,7 @@ func TestDomainNameserversCreate(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Create("specific-sld", "specific-tld", "ns1.domain.com", "1.1.1.1")
+		_, err := client.DomainsNS.CreateWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com", "1.1.1.1")
 
 		assert.EqualError(t, err, "Error From Enom when Errorcount <> 0 (3031510)")
 	})
@@ -211,7 +212,7 @@ func TestDomainNameserversCreate(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Create("specific-sld", "specific-tld", "ns1.domain.com", "1.1.1.1")
+		_, err := client.DomainsNS.CreateWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com", "1.1.1.1")
 
 		assert.EqualError(t, err, "Unknown error from Enom (3050900)")
 	})

--- a/namecheap/domains_ns_delete.go
+++ b/namecheap/domains_ns_delete.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 )
@@ -24,8 +25,8 @@ type DomainsNSDeleteResult struct {
 	IsSuccess  *bool   `xml:"IsSuccess,attr"`
 }
 
-// Delete deletes a nameserver associated with the requested domain.
-func (s *DomainsNSService) Delete(sld, tld, nameserver string) (*NameserversDeleteCommandResponse, error) {
+// DeleteWithContext deletes a nameserver associated with the requested domain.
+func (s *DomainsNSService) DeleteWithContext(ctx context.Context, sld, tld, nameserver string) (*NameserversDeleteCommandResponse, error) {
 	var response NameserversDeleteResponse
 
 	params := map[string]string{
@@ -35,7 +36,7 @@ func (s *DomainsNSService) Delete(sld, tld, nameserver string) (*NameserversDele
 		"Nameserver": nameserver,
 	}
 
-	_, err := s.client.DoXML(params, &response)
+	_, err := s.client.DoXMLWithContext(ctx, params, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -46,4 +47,12 @@ func (s *DomainsNSService) Delete(sld, tld, nameserver string) (*NameserversDele
 	}
 
 	return response.CommandResponse, nil
+}
+
+// Delete deletes a nameserver associated with the requested domain.
+//
+// Deprecated: Delete runs without a context. Use DeleteWithContext. It is
+// retained for backward compatibility and will be removed in v3.
+func (s *DomainsNSService) Delete(sld, tld, nameserver string) (*NameserversDeleteCommandResponse, error) {
+	return s.DeleteWithContext(context.Background(), sld, tld, nameserver)
 }

--- a/namecheap/domains_ns_delete_test.go
+++ b/namecheap/domains_ns_delete_test.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -40,7 +41,7 @@ func TestDomainNameserversDelete(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Delete("specific-sld", "specific-tld", "ns1.domain.com")
+		_, err := client.DomainsNS.DeleteWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com")
 		if err != nil {
 			t.Fatal("Unable to get domain nameserver", err)
 		}
@@ -58,7 +59,7 @@ func TestDomainNameserversDelete(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		result, err := client.DomainsNS.Delete("domain", "com", "ns1.domain.com")
+		result, err := client.DomainsNS.DeleteWithContext(context.Background(), "domain", "com", "ns1.domain.com")
 		if err != nil {
 			t.Fatal("Unable to delete domain nameserver", err)
 		}
@@ -80,7 +81,7 @@ func TestDomainNameserversDelete(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Delete("specific-sld", "specific-tld", "ns1.domain.com")
+		_, err := client.DomainsNS.DeleteWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com")
 
 		assert.EqualError(t, err, "unable to parse server response: EOF")
 	})
@@ -97,7 +98,7 @@ func TestDomainNameserversDelete(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Delete("specific-sld", "specific-tld", "ns1.domain.com")
+		_, err := client.DomainsNS.DeleteWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com")
 
 		assert.EqualError(t, err, "unable to parse server response: EOF")
 	})
@@ -114,7 +115,7 @@ func TestDomainNameserversDelete(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Delete("specific-sld", "specific-tld", "ns1.domain.com")
+		_, err := client.DomainsNS.DeleteWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com")
 
 		assert.EqualError(t, err, "unable to parse server response: expected element type <ApiResponse> but have <broken>")
 	})
@@ -143,7 +144,7 @@ func TestDomainNameserversDelete(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Delete("specific-sld", "specific-tld", "ns1.domain.com")
+		_, err := client.DomainsNS.DeleteWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com")
 
 		assert.EqualError(t, err, "Domain not found (2019166)")
 	})
@@ -172,7 +173,7 @@ func TestDomainNameserversDelete(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Delete("specific-sld", "specific-tld", "ns1.domain.com")
+		_, err := client.DomainsNS.DeleteWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com")
 
 		assert.EqualError(t, err, "Domain is not associated with your account (2016166)")
 	})
@@ -201,7 +202,7 @@ func TestDomainNameserversDelete(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Delete("specific-sld", "specific-tld", "ns1.domain.com")
+		_, err := client.DomainsNS.DeleteWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com")
 
 		assert.EqualError(t, err, "Error From Enom when Errorcount <> 0 (3031510)")
 	})
@@ -230,7 +231,7 @@ func TestDomainNameserversDelete(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Delete("specific-sld", "specific-tld", "ns1.domain.com")
+		_, err := client.DomainsNS.DeleteWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com")
 
 		assert.EqualError(t, err, "Unknown error from Enom (3050900)")
 	})

--- a/namecheap/domains_ns_get_info.go
+++ b/namecheap/domains_ns_get_info.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 )
@@ -27,8 +28,8 @@ type DomainNSInfoResult struct {
 	} `xml:"NameserverStatuses"`
 }
 
-// GetInfo retrieves information about a registered nameserver.
-func (s *DomainsNSService) GetInfo(sld, tld, nameserver string) (*NameserversGetInfoCommandResponse, error) {
+// GetInfoWithContext retrieves information about a registered nameserver.
+func (s *DomainsNSService) GetInfoWithContext(ctx context.Context, sld, tld, nameserver string) (*NameserversGetInfoCommandResponse, error) {
 	var response NameserversGetInfoResponse
 
 	params := map[string]string{
@@ -38,7 +39,7 @@ func (s *DomainsNSService) GetInfo(sld, tld, nameserver string) (*NameserversGet
 		"Nameserver": nameserver,
 	}
 
-	_, err := s.client.DoXML(params, &response)
+	_, err := s.client.DoXMLWithContext(ctx, params, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -49,4 +50,12 @@ func (s *DomainsNSService) GetInfo(sld, tld, nameserver string) (*NameserversGet
 	}
 
 	return response.CommandResponse, nil
+}
+
+// GetInfo retrieves information about a registered nameserver.
+//
+// Deprecated: GetInfo runs without a context. Use GetInfoWithContext. It is
+// retained for backward compatibility and will be removed in v3.
+func (s *DomainsNSService) GetInfo(sld, tld, nameserver string) (*NameserversGetInfoCommandResponse, error) {
+	return s.GetInfoWithContext(context.Background(), sld, tld, nameserver)
 }

--- a/namecheap/domains_ns_get_info_test.go
+++ b/namecheap/domains_ns_get_info_test.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -45,7 +46,7 @@ func TestDomainNameserversGetInfo(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.GetInfo("specific-sld", "specific-tld", "ns1.domain.com")
+		_, err := client.DomainsNS.GetInfoWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com")
 		if err != nil {
 			t.Fatal("Unable to get domain nameserver", err)
 		}
@@ -65,7 +66,7 @@ func TestDomainNameserversGetInfo(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.GetInfo("specific-sld", "specific-tld", "ns1.domain.com")
+		_, err := client.DomainsNS.GetInfoWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com")
 
 		assert.EqualError(t, err, "unable to parse server response: EOF")
 	})
@@ -82,7 +83,7 @@ func TestDomainNameserversGetInfo(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.GetInfo("specific-sld", "specific-tld", "ns1.domain.com")
+		_, err := client.DomainsNS.GetInfoWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com")
 
 		assert.EqualError(t, err, "unable to parse server response: EOF")
 	})
@@ -99,7 +100,7 @@ func TestDomainNameserversGetInfo(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.GetInfo("specific-sld", "specific-tld", "ns1.domain.com")
+		_, err := client.DomainsNS.GetInfoWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com")
 
 		assert.EqualError(t, err, "unable to parse server response: expected element type <ApiResponse> but have <broken>")
 	})
@@ -128,7 +129,7 @@ func TestDomainNameserversGetInfo(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.GetInfo("specific-sld", "specific-tld", "ns1.domain.com")
+		_, err := client.DomainsNS.GetInfoWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com")
 
 		assert.EqualError(t, err, "Domain not found (2019166)")
 	})
@@ -157,7 +158,7 @@ func TestDomainNameserversGetInfo(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.GetInfo("specific-sld", "specific-tld", "ns1.domain.com")
+		_, err := client.DomainsNS.GetInfoWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com")
 
 		assert.EqualError(t, err, "Domain is not associated with your account (2016166)")
 	})
@@ -186,7 +187,7 @@ func TestDomainNameserversGetInfo(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.GetInfo("specific-sld", "specific-tld", "ns1.domain.com")
+		_, err := client.DomainsNS.GetInfoWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com")
 
 		assert.EqualError(t, err, "Error From Enom when Errorcount <> 0 (3031510)")
 	})
@@ -215,7 +216,7 @@ func TestDomainNameserversGetInfo(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.GetInfo("specific-sld", "specific-tld", "ns1.domain.com")
+		_, err := client.DomainsNS.GetInfoWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com")
 
 		assert.EqualError(t, err, "Unknown error from Enom (3050900)")
 	})

--- a/namecheap/domains_ns_update.go
+++ b/namecheap/domains_ns_update.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 )
@@ -24,8 +25,8 @@ type DomainsNSUpdateResult struct {
 	IsSuccess  *bool   `xml:"IsSuccess,attr"`
 }
 
-// Update modifies the IP address of a registered nameserver.
-func (s *DomainsNSService) Update(sld, tld, nameserver, oldIP, ip string) (*NameserversUpdateCommandResponse, error) {
+// UpdateWithContext modifies the IP address of a registered nameserver.
+func (s *DomainsNSService) UpdateWithContext(ctx context.Context, sld, tld, nameserver, oldIP, ip string) (*NameserversUpdateCommandResponse, error) {
 	var response NameserversUpdateResponse
 
 	params := map[string]string{
@@ -37,7 +38,7 @@ func (s *DomainsNSService) Update(sld, tld, nameserver, oldIP, ip string) (*Name
 		"IP":         ip,
 	}
 
-	_, err := s.client.DoXML(params, &response)
+	_, err := s.client.DoXMLWithContext(ctx, params, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -48,4 +49,12 @@ func (s *DomainsNSService) Update(sld, tld, nameserver, oldIP, ip string) (*Name
 	}
 
 	return response.CommandResponse, nil
+}
+
+// Update modifies the IP address of a registered nameserver.
+//
+// Deprecated: Update runs without a context. Use UpdateWithContext. It is
+// retained for backward compatibility and will be removed in v3.
+func (s *DomainsNSService) Update(sld, tld, nameserver, oldIP, ip string) (*NameserversUpdateCommandResponse, error) {
+	return s.UpdateWithContext(context.Background(), sld, tld, nameserver, oldIP, ip)
 }

--- a/namecheap/domains_ns_update_test.go
+++ b/namecheap/domains_ns_update_test.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -40,7 +41,7 @@ func TestDomainNameserversUpdate(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Update("specific-sld", "specific-tld", "ns1.domain.com", "specific-old-ip", "specific-new-ip")
+		_, err := client.DomainsNS.UpdateWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com", "specific-old-ip", "specific-new-ip")
 		if err != nil {
 			t.Fatal("Unable to get domain nameserver", err)
 		}
@@ -58,7 +59,7 @@ func TestDomainNameserversUpdate(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		result, err := client.DomainsNS.Update("domain", "com", "ns1.domain.com", "1.1.1.1", "2.2.2.2")
+		result, err := client.DomainsNS.UpdateWithContext(context.Background(), "domain", "com", "ns1.domain.com", "1.1.1.1", "2.2.2.2")
 		if err != nil {
 			t.Fatal("Unable to update domain nameserver", err)
 		}
@@ -80,7 +81,7 @@ func TestDomainNameserversUpdate(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Update("specific-sld", "specific-tld", "ns1.domain.com", "specific-old-ip", "specific-new-ip")
+		_, err := client.DomainsNS.UpdateWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com", "specific-old-ip", "specific-new-ip")
 
 		assert.EqualError(t, err, "unable to parse server response: EOF")
 	})
@@ -97,7 +98,7 @@ func TestDomainNameserversUpdate(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Update("specific-sld", "specific-tld", "ns1.domain.com", "specific-old-ip", "specific-new-ip")
+		_, err := client.DomainsNS.UpdateWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com", "specific-old-ip", "specific-new-ip")
 
 		assert.EqualError(t, err, "unable to parse server response: EOF")
 	})
@@ -114,7 +115,7 @@ func TestDomainNameserversUpdate(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Update("specific-sld", "specific-tld", "ns1.domain.com", "specific-old-ip", "specific-new-ip")
+		_, err := client.DomainsNS.UpdateWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com", "specific-old-ip", "specific-new-ip")
 
 		assert.EqualError(t, err, "unable to parse server response: expected element type <ApiResponse> but have <broken>")
 	})
@@ -143,7 +144,7 @@ func TestDomainNameserversUpdate(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Update("specific-sld", "specific-tld", "ns1.domain.com", "specific-old-ip", "specific-new-ip")
+		_, err := client.DomainsNS.UpdateWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com", "specific-old-ip", "specific-new-ip")
 
 		assert.EqualError(t, err, "Domain not found (2019166)")
 	})
@@ -172,7 +173,7 @@ func TestDomainNameserversUpdate(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Update("specific-sld", "specific-tld", "ns1.domain.com", "specific-old-ip", "specific-new-ip")
+		_, err := client.DomainsNS.UpdateWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com", "specific-old-ip", "specific-new-ip")
 
 		assert.EqualError(t, err, "Domain is not associated with your account (2016166)")
 	})
@@ -201,7 +202,7 @@ func TestDomainNameserversUpdate(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Update("specific-sld", "specific-tld", "ns1.domain.com", "specific-old-ip", "specific-new-ip")
+		_, err := client.DomainsNS.UpdateWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com", "specific-old-ip", "specific-new-ip")
 
 		assert.EqualError(t, err, "Error From Enom when Errorcount <> 0 (3031510)")
 	})
@@ -230,7 +231,7 @@ func TestDomainNameserversUpdate(t *testing.T) {
 		client := setupClient(nil)
 		client.BaseURL = mockServer.URL
 
-		_, err := client.DomainsNS.Update("specific-sld", "specific-tld", "ns1.domain.com", "specific-old-ip", "specific-new-ip")
+		_, err := client.DomainsNS.UpdateWithContext(context.Background(), "specific-sld", "specific-tld", "ns1.domain.com", "specific-old-ip", "specific-new-ip")
 
 		assert.EqualError(t, err, "Unknown error from Enom (3050900)")
 	})

--- a/namecheap/internal/syncretry/sync_retry.go
+++ b/namecheap/internal/syncretry/sync_retry.go
@@ -3,8 +3,8 @@
 package syncretry
 
 import (
+	"context"
 	"errors"
-	"sync"
 	"time"
 )
 
@@ -25,24 +25,47 @@ type Options struct {
 // SyncRetry executes a function with mutex-guarded retries on transient
 // failures signalled by ErrRetry.
 type SyncRetry struct {
-	m       *sync.Mutex
+	// sem is a capacity-1 semaphore used instead of a sync.Mutex so that a
+	// goroutine waiting to enter the retry section can be released by a
+	// cancelled context (a sync.Mutex.Lock cannot be interrupted).
+	sem     chan struct{}
 	options *Options
 }
 
 // NewSyncRetry returns a new SyncRetry configured with the given options.
 func NewSyncRetry(options *Options) *SyncRetry {
 	return &SyncRetry{
-		m:       &sync.Mutex{},
+		sem:     make(chan struct{}, 1),
 		options: options,
 	}
 }
 
-// Do calls f and, if f returns ErrRetry, acquires the mutex and retries f
-// after each delay configured in Options.Delays. It returns nil on the first
-// successful call, any non-retriable error immediately, or ErrRetryAttempts
-// when all retries are exhausted.
+// Do calls f and retries it after each configured delay when f returns
+// ErrRetry.
+//
+// Deprecated: Do drives the retry loop without a context, so neither the
+// inter-retry sleeps nor waiting to enter the retry section can be cancelled.
+// Use DoContext, which threads a context.Context through both. Do is retained
+// for backward compatibility and will be removed in v3.
 func (sq *SyncRetry) Do(f func() error) error {
-	err := f()
+	return sq.DoContext(context.Background(), func(context.Context) error { return f() })
+}
+
+// DoContext calls f and, if f returns ErrRetry, acquires the internal
+// semaphore and retries f after each delay configured in Options.Delays. It
+// returns nil on the first successful call, any non-retriable error
+// immediately, or ErrRetryAttempts when all retries are exhausted.
+//
+// DoContext is cancellable: if ctx is done it returns ctx.Err() instead of
+// (a) starting a new attempt, (b) completing a pending inter-retry sleep, or
+// (c) continuing to wait for the semaphore. The context is also passed to f so
+// the caller can bind it to the in-flight work (e.g. an HTTP request).
+func (sq *SyncRetry) DoContext(ctx context.Context, f func(context.Context) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	err := f(ctx)
 	if err == nil {
 		return nil
 	}
@@ -51,12 +74,21 @@ func (sq *SyncRetry) Do(f func() error) error {
 		return err
 	}
 
-	sq.m.Lock()
-	defer sq.m.Unlock()
+	// Acquire the retry section, but abort if the context is cancelled while
+	// we are queued behind another in-flight retry loop.
+	select {
+	case sq.sem <- struct{}{}:
+		defer func() { <-sq.sem }()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 
 	for _, delay := range sq.options.Delays {
-		time.Sleep(time.Duration(delay) * time.Second)
-		err = f()
+		if err := sleep(ctx, time.Duration(delay)*time.Second); err != nil {
+			return err
+		}
+
+		err = f(ctx)
 		if err == nil {
 			return nil
 		}
@@ -68,4 +100,18 @@ func (sq *SyncRetry) Do(f func() error) error {
 	}
 
 	return ErrRetryAttempts
+}
+
+// sleep waits for d or until ctx is done, returning ctx.Err() if the context
+// is cancelled first.
+func sleep(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }

--- a/namecheap/internal/syncretry/sync_retry_test.go
+++ b/namecheap/internal/syncretry/sync_retry_test.go
@@ -1,7 +1,9 @@
 package syncretry
 
 import (
+	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -245,4 +247,66 @@ func TestSyncRetry_Do(t *testing.T) {
 		assert.ErrorIs(t, err, nonRetryErr)
 		assert.Equal(t, 2, count)
 	})
+}
+
+func TestDoContextCancelsWhileWaitingForSemaphore(t *testing.T) {
+	t.Parallel()
+	sr := NewSyncRetry(&Options{Delays: []int{30}})
+
+	g1Holding := make(chan struct{})
+	var once sync.Once
+
+	// Goroutine 1 enters the retry section and holds the semaphore for the
+	// duration of a 30s inter-retry sleep.
+	go func() {
+		_ = sr.DoContext(context.Background(), func(context.Context) error {
+			once.Do(func() { close(g1Holding) })
+			return ErrRetry
+		})
+	}()
+
+	// Wait for goroutine 1's first attempt, then give it a moment to acquire
+	// the semaphore and start sleeping while holding it.
+	<-g1Holding
+	time.Sleep(30 * time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		cancel()
+	}()
+
+	result := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		// This call returns ErrRetry on its first attempt, then blocks waiting
+		// for the semaphore held by goroutine 1 until ctx is cancelled.
+		result <- sr.DoContext(ctx, func(context.Context) error {
+			return ErrRetry
+		})
+	}()
+
+	err := <-result
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, elapsed, 5*time.Second, "should return promptly instead of waiting out the 30s delay")
+}
+
+func TestDoContextCancelledUpFront(t *testing.T) {
+	t.Parallel()
+	sr := NewSyncRetry(&Options{Delays: []int{1, 1}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before invoking DoContext
+
+	var called atomic.Bool
+	err := sr.DoContext(ctx, func(context.Context) error {
+		called.Store(true)
+		return nil
+	})
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.False(t, called.Load(), "f must not be called when ctx is already cancelled")
 }

--- a/namecheap/namecheap.go
+++ b/namecheap/namecheap.go
@@ -3,6 +3,7 @@ package namecheap
 
 import (
 	"bytes"
+	"context"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -71,8 +72,10 @@ func NewClient(options *ClientOptions) *Client {
 	return client
 }
 
-// NewRequest creates a new request with the params
-func (c *Client) NewRequest(body map[string]string) (*http.Request, error) {
+// NewRequestWithContext creates a new request with the params, bound to ctx.
+// The returned *http.Request carries ctx, so cancelling it aborts the in-flight
+// call when the request is executed.
+func (c *Client) NewRequestWithContext(ctx context.Context, body map[string]string) (*http.Request, error) {
 	u, err := url.Parse(c.BaseURL)
 
 	if err != nil {
@@ -87,7 +90,7 @@ func (c *Client) NewRequest(body map[string]string) (*http.Request, error) {
 	rBody := encodeBody(body)
 
 	// Build the request
-	req, err := http.NewRequest("POST", u.String(), bytes.NewBufferString(rBody))
+	req, err := http.NewRequestWithContext(ctx, "POST", u.String(), bytes.NewBufferString(rBody))
 
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
@@ -99,10 +102,24 @@ func (c *Client) NewRequest(body map[string]string) (*http.Request, error) {
 	return req, nil
 }
 
-func (c *Client) DoXML(body map[string]string, obj any) (*http.Response, error) {
+// NewRequest creates a new request with the params.
+//
+// Deprecated: NewRequest builds a request with no context, so the call cannot
+// be cancelled or time-bounded. Use NewRequestWithContext. NewRequest is
+// retained for backward compatibility and will be removed in v3.
+func (c *Client) NewRequest(body map[string]string) (*http.Request, error) {
+	return c.NewRequestWithContext(context.Background(), body)
+}
+
+// DoXMLWithContext performs the API call described by body, decoding the XML
+// response into obj. The call is bound to ctx: cancelling ctx aborts the
+// in-flight HTTP request, any pending inter-retry sleep, and waiting to enter
+// the retry section. context.Canceled and context.DeadlineExceeded propagate
+// to the caller unwrapped (they are never rewritten into a retry-limit error).
+func (c *Client) DoXMLWithContext(ctx context.Context, body map[string]string, obj any) (*http.Response, error) {
 	var requestResponse *http.Response
-	err := c.sr.Do(func() error {
-		request, err := c.NewRequest(body)
+	err := c.sr.DoContext(ctx, func(ctx context.Context) error {
+		request, err := c.NewRequestWithContext(ctx, body)
 		if err != nil {
 			return err
 		}
@@ -113,6 +130,7 @@ func (c *Client) DoXML(body map[string]string, obj any) (*http.Response, error) 
 		}
 
 		if response.StatusCode == 405 {
+			response.Body.Close()
 			return syncretry.ErrRetry
 		}
 
@@ -127,6 +145,16 @@ func (c *Client) DoXML(body map[string]string, obj any) (*http.Response, error) 
 	}
 
 	return requestResponse, err
+}
+
+// DoXML performs the API call described by body, decoding the XML response
+// into obj.
+//
+// Deprecated: DoXML runs without a context, so the call cannot be cancelled or
+// time-bounded. Use DoXMLWithContext. DoXML is retained for backward
+// compatibility and will be removed in v3.
+func (c *Client) DoXML(body map[string]string, obj any) (*http.Response, error) {
+	return c.DoXMLWithContext(context.Background(), body, obj)
 }
 
 // decodeBody decodes the interface from received XML

--- a/namecheap/namecheap_test.go
+++ b/namecheap/namecheap_test.go
@@ -1,6 +1,7 @@
 package namecheap
 
 import (
+	"context"
 	"errors"
 	"io"
 	"log"
@@ -8,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/namecheap/go-namecheap-sdk/v2/namecheap/internal/syncretry"
 	"github.com/stretchr/testify/assert"
@@ -349,4 +351,92 @@ func TestDoXMLHTTPFailure(t *testing.T) {
 	var result any
 	_, err := client.DoXML(map[string]string{"Command": "test"}, &result)
 	assert.Error(t, err)
+}
+
+func TestDoXMLWithContextCancelsInFlightRequest(t *testing.T) {
+	t.Parallel()
+	// The server blocks well past the point at which we cancel, so a prompt
+	// return can only happen if cancellation aborts the in-flight request.
+	mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		time.Sleep(2 * time.Second)
+		_, _ = writer.Write([]byte(`<?xml version="1.0"?><ApiResponse Status="OK"/>`))
+	}))
+	defer mockServer.Close()
+
+	client := setupClient(nil)
+	client.BaseURL = mockServer.URL
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	var result any
+	_, err := client.DoXMLWithContext(ctx, map[string]string{"Command": "test"}, &result)
+	elapsed := time.Since(start)
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled), "expected context.Canceled, got %v", err)
+	assert.Less(t, elapsed, time.Second, "call should have returned promptly after cancellation")
+}
+
+func TestDoXMLWithContextCancelsRetrySleep(t *testing.T) {
+	t.Parallel()
+	// 405 forces the retry loop; a 30s inter-retry delay would dominate unless
+	// the context deadline cancels the sleep.
+	mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer mockServer.Close()
+
+	client := setupClient(nil)
+	client.sr = syncretry.NewSyncRetry(&syncretry.Options{Delays: []int{30}})
+	client.BaseURL = mockServer.URL
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	var result any
+	_, err := client.DoXMLWithContext(ctx, map[string]string{"Command": "test"}, &result)
+	elapsed := time.Since(start)
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded), "expected context.DeadlineExceeded, got %v", err)
+	// Context errors propagate unwrapped, never rewritten to the retry-limit error.
+	assert.NotContains(t, err.Error(), "API retry limit exceeded")
+	assert.Less(t, elapsed, 5*time.Second, "call should have returned promptly after the deadline")
+}
+
+func TestDeprecatedWrapperDelegates(t *testing.T) {
+	t.Parallel()
+	// Regression: the deprecated, context-less wrapper must still work by
+	// delegating to the ctx variant with context.Background().
+	fakeResponse := `<?xml version="1.0" encoding="utf-8"?>
+		<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+			<Errors />
+			<Warnings />
+			<RequestedCommand>namecheap.domains.getInfo</RequestedCommand>
+			<CommandResponse Type="namecheap.domains.getInfo">
+				<DomainGetInfoResult ID="123" DomainName="domain.com" IsPremium="false">
+					<DnsDetails ProviderType="FreeDNS" IsUsingOurDNS="true" HostCount="0" />
+				</DomainGetInfoResult>
+			</CommandResponse>
+		</ApiResponse>`
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = writer.Write([]byte(fakeResponse))
+	}))
+	defer mockServer.Close()
+
+	client := setupClient(nil)
+	client.BaseURL = mockServer.URL
+
+	result, err := client.Domains.GetInfo("domain.com")
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "domain.com", *result.DomainDNSGetListResult.DomainName)
 }


### PR DESCRIPTION
Closes #110. First item of the go-namecheap-sdk 2.0 roadmap (#122) — the modern client core everything else builds on.

## What
Adds `context.Context` support across the whole SDK, **additively**: new ctx-first `...WithContext` methods carry the real implementation; the existing context-less signatures remain as thin `// Deprecated:` wrappers that delegate with `context.Background()`. No breaking change within v2.

- `Client.NewRequestWithContext` / `Client.DoXMLWithContext` (via `http.NewRequestWithContext`).
- `syncretry.DoContext` — cancellable retry loop: aborts a pending inter-retry sleep **and** waiting to enter the retry section. The internal `sync.Mutex` is replaced with a capacity-1 semaphore so the wait is interruptible by `ctx.Done()` (a `Mutex.Lock` cannot be cancelled).
- All 14 service methods (`Domains`, `DomainsDNS`, `DomainsNS`) gain `...WithContext` forms; the DNS `GetList` threads ctx into its internal `Domains.GetInfoWithContext` call.
- `context.Canceled` / `context.DeadlineExceeded` propagate **unwrapped** — never rewritten into `"API retry limit exceeded"`.

## Design decision (flagged for review, per the issue)
Go has no method overloading and the old names must stay for backward compatibility, so the ctx-first variants use the `WithContext` suffix and the non-ctx methods are marked deprecated for removal in **v3**. This matches the issue's recommended "ctx-first, additive within v2" option (the deprecation/removal plan is what distinguishes it from the rejected "parallel `*Ctx` forever" approach). If review prefers a different naming, it's a mechanical rename.

## Acceptance criteria
- [x] Every service method has a ctx-first form; old signatures remain, delegate, carry `// Deprecated:`; `go vet` + golangci-lint (all linters) clean.
- [x] Cancelled context aborts (a) in-flight HTTP request, (b) pending retry sleep, (c) waiting on the internal lock — each covered by a mock-server / unit test.
- [x] `DeadlineExceeded`/`Canceled` propagate unwrapped through the retry layer (asserted).
- [x] Tests call the ctx variants; `make test-race` clean.
- [x] README switched to ctx-first; CHANGELOG documents the deprecation + planned v3 removal.
- [x] Doc comments on all new exported identifiers.
- [x] No behavior change for wrapper callers (existing wrapper tests unchanged + explicit delegation regression test).

## Verification (local, go 1.26.4 + golangci-lint 2.12.2)
`go vet` ✅ · `golangci-lint run` → 0 issues ✅ · `go mod tidy` diff empty (no new deps) ✅ · `make test` (unit + race) ✅
