### PR TITLE
feat: add typed API errors (APIError, sentinels, ParseError, IsRetryable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Typed API errors. API failures now surface as a machine-matchable
+  `*APIError` (exposing `Number`, `Message` and `Command`) instead of a flat
+  string, so callers can inspect the Namecheap error code via `errors.As`.
+  Multi-error responses return an `errors.Join` of `*APIError` values.
+  Documented, actionable codes are matchable via `errors.Is` against exported
+  sentinels (`ErrDomainNotFound`, `ErrDomainNotAssociated`, `ErrDomainInvalid`,
+  `ErrTooManyDomains`, `ErrPromotionCodeInvalid`, `ErrOrderNotFound`,
+  `ErrAccessDenied`, `ErrServerError`; each code cross-checked against
+  `docs/namecheap-api-v2.md`). Malformed responses return a `*ParseError` with
+  a bounded body snippet, and `IsRetryable` classifies transient failures
+  (server-side codes and transport timeouts) as retryable. Existing error
+  strings are preserved verbatim (`"<message> (<number>)"` and
+  `"unable to parse server response: ..."`) so string-matching consumers keep
+  working (#111).
 - `context.Context` support across all client and service methods. New
   ctx-first `...WithContext` variants (`Client.NewRequestWithContext`,
   `Client.DoXMLWithContext`, and every service method such as

--- a/README.md
+++ b/README.md
@@ -115,16 +115,53 @@ _, err = client.DomainsNS.DeleteWithContext(ctx, "domain", "com", "ns1.domain.co
 
 ### Error handling
 
-API errors (e.g. invalid parameters, quota exceeded) are returned as Go errors with the Namecheap error message and code:
+When the API rejects a call it returns a typed `*namecheap.APIError` carrying the
+numeric code, the server message and the failing command. The error string keeps
+the legacy `"<message> (<number>)"` format, so code that matches on it today keeps
+working:
 
 ```go
-resp, err := client.Domains.CheckWithContext(ctx, "example.com")
+resp, err := client.Domains.GetInfoWithContext(ctx, "example.com")
 if err != nil {
-    log.Fatal(err) // e.g. "Parameter DomainList is Missing (2011166)"
+    log.Fatal(err) // e.g. "Domain not found (2019166)"
 }
 ```
 
-Network and parsing errors are wrapped with `%w`, so `errors.Is` / `errors.As` work for inspecting the underlying cause.
+Inspect the structured code with `errors.As`:
+
+```go
+var apiErr *namecheap.APIError
+if errors.As(err, &apiErr) {
+    log.Printf("code=%d message=%q command=%q", apiErr.Number, apiErr.Message, apiErr.Command)
+}
+```
+
+Branch on a documented category with `errors.Is` against a sentinel (matches
+through `errors.Join` for multi-error responses):
+
+```go
+if errors.Is(err, namecheap.ErrDomainNotFound) {
+    // the domain is gone: recreate it
+}
+```
+
+Available sentinels: `ErrDomainNotFound`, `ErrDomainNotAssociated`,
+`ErrDomainInvalid`, `ErrTooManyDomains`, `ErrPromotionCodeInvalid`,
+`ErrOrderNotFound`, `ErrAccessDenied`, `ErrServerError`.
+
+Decide whether to retry with `namecheap.IsRetryable`, which treats transient
+server-side codes and transport timeouts as retryable and classifies validation,
+not-found, auth, permission and context-cancellation failures as permanent:
+
+```go
+if namecheap.IsRetryable(err) {
+    // back off and try again
+}
+```
+
+Malformed responses return a `*namecheap.ParseError` (with a bounded snippet of
+the raw body); transport and context errors propagate unwrapped. All error types
+support `errors.Is` / `errors.As` for inspecting the underlying cause.
 
 ### Sandbox
 

--- a/namecheap/doc.go
+++ b/namecheap/doc.go
@@ -1,0 +1,51 @@
+// Package namecheap provides a Go client for the Namecheap API.
+//
+// Construct a Client with NewClient and call the service methods on
+// Client.Domains, Client.DomainsDNS and Client.DomainsNS. Every call takes a
+// context.Context as its first argument; cancelling it aborts the in-flight
+// HTTP request, any pending retry sleep, and waiting on the internal retry lock.
+//
+// # Error handling
+//
+// When the API rejects a call (envelope Status="ERROR") the method returns a
+// typed *APIError carrying the numeric code, the server message and the failing
+// command. Responses with several <Error> entries return an errors.Join of
+// *APIError values. Malformed responses return a *ParseError; transport and
+// context failures propagate unwrapped. All three are distinguishable, so a
+// consumer can tell an API rejection from an SDK/parse fault from an outage.
+//
+// Read the structured code with errors.As:
+//
+//	resp, err := client.Domains.GetInfoWithContext(ctx, "example.com")
+//	if err != nil {
+//	    var apiErr *namecheap.APIError
+//	    if errors.As(err, &apiErr) {
+//	        log.Printf("code=%d message=%q command=%q",
+//	            apiErr.Number, apiErr.Message, apiErr.Command)
+//	    }
+//	}
+//
+// Branch on a documented category with errors.Is against a sentinel:
+//
+//	if errors.Is(err, namecheap.ErrDomainNotFound) {
+//	    // the domain is gone: recreate it
+//	}
+//
+// Sentinels match through errors.Join, so errors.Is finds each code in a
+// multi-error response. Decide whether to retry with IsRetryable, which treats
+// transient server-side codes and transport timeouts as retryable while
+// classifying validation, not-found, auth, context-cancellation and
+// permission failures as permanent:
+//
+//	if namecheap.IsRetryable(err) {
+//	    // back off and try again
+//	}
+//
+// Distinguish a decode failure with errors.As on *ParseError; it keeps a
+// bounded snippet of the raw body for diagnostics:
+//
+//	var parseErr *namecheap.ParseError
+//	if errors.As(err, &parseErr) {
+//	    log.Printf("bad response: %s", parseErr.Snippet)
+//	}
+package namecheap

--- a/namecheap/domains_check.go
+++ b/namecheap/domains_check.go
@@ -3,7 +3,6 @@ package namecheap
 import (
 	"context"
 	"encoding/xml"
-	"fmt"
 	"strings"
 )
 
@@ -48,12 +47,6 @@ func (ds *DomainsService) CheckWithContext(ctx context.Context, domains ...strin
 	if err != nil {
 		return nil, err
 	}
-	if response.Errors != nil && len(*response.Errors) > 0 {
-		apiErr := (*response.Errors)[0]
-
-		return nil, fmt.Errorf("%s (%s)", *apiErr.Message, *apiErr.Number)
-	}
-
 	return response.CommandResponse, nil
 }
 

--- a/namecheap/domains_dns_get_email_forwarding.go
+++ b/namecheap/domains_dns_get_email_forwarding.go
@@ -3,7 +3,6 @@ package namecheap
 import (
 	"context"
 	"encoding/xml"
-	"fmt"
 )
 
 type DomainsDNSGetEmailForwardingResponse struct {
@@ -46,11 +45,6 @@ func (dds *DomainsDNSService) GetEmailForwardingWithContext(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	if response.Errors != nil && len(*response.Errors) > 0 {
-		apiErr := (*response.Errors)[0]
-		return nil, fmt.Errorf("%s (%s)", *apiErr.Message, *apiErr.Number)
-	}
-
 	return response.CommandResponse, nil
 }
 

--- a/namecheap/domains_dns_get_hosts.go
+++ b/namecheap/domains_dns_get_hosts.go
@@ -66,11 +66,6 @@ func (dds *DomainsDNSService) GetHostsWithContext(ctx context.Context, domain st
 	if err != nil {
 		return nil, err
 	}
-	if len(response.Errors) > 0 {
-		apiErr := response.Errors[0]
-		return nil, fmt.Errorf("%s (%s)", apiErr.Message, apiErr.Number)
-	}
-
 	return response.CommandResponse, nil
 }
 

--- a/namecheap/domains_dns_get_list.go
+++ b/namecheap/domains_dns_get_list.go
@@ -3,6 +3,7 @@ package namecheap
 import (
 	"context"
 	"encoding/xml"
+	"errors"
 	"fmt"
 )
 
@@ -53,13 +54,10 @@ func (dds *DomainsDNSService) GetListWithContext(ctx context.Context, domain str
 
 	_, err = dds.client.DoXMLWithContext(ctx, params, &response)
 	if err != nil {
-		return nil, err
-	}
-	if response.Errors != nil && len(*response.Errors) > 0 {
-		apiErr := (*response.Errors)[0]
-
-		if *apiErr.Number != "2019166" {
-			return nil, fmt.Errorf("%s (%s)", *apiErr.Message, *apiErr.Number)
+		// A "domain not found" here means the domain is on FreeDNS; fall back to
+		// domains.getInfo to synthesise the DNS list. Any other error is real.
+		if !errors.Is(err, ErrDomainNotFound) {
+			return nil, err
 		}
 
 		var domainInfo *DomainsGetInfoCommandResponse

--- a/namecheap/domains_dns_set_custom.go
+++ b/namecheap/domains_dns_set_custom.go
@@ -59,11 +59,6 @@ func (dds *DomainsDNSService) SetCustomWithContext(ctx context.Context, domain s
 	if err != nil {
 		return nil, err
 	}
-	if response.Errors != nil && len(*response.Errors) > 0 {
-		apiErr := (*response.Errors)[0]
-		return nil, fmt.Errorf("%s (%s)", *apiErr.Message, *apiErr.Number)
-	}
-
 	return response.CommandResponse, nil
 }
 

--- a/namecheap/domains_dns_set_default.go
+++ b/namecheap/domains_dns_set_default.go
@@ -51,11 +51,6 @@ func (dds *DomainsDNSService) SetDefaultWithContext(ctx context.Context, domain 
 	if err != nil {
 		return nil, err
 	}
-	if response.Errors != nil && len(*response.Errors) > 0 {
-		apiErr := (*response.Errors)[0]
-		return nil, fmt.Errorf("%s (%s)", *apiErr.Message, *apiErr.Number)
-	}
-
 	return response.CommandResponse, nil
 }
 

--- a/namecheap/domains_dns_set_email_forwarding.go
+++ b/namecheap/domains_dns_set_email_forwarding.go
@@ -3,7 +3,6 @@ package namecheap
 import (
 	"context"
 	"encoding/xml"
-	"fmt"
 	"strconv"
 )
 
@@ -48,11 +47,6 @@ func (dds *DomainsDNSService) SetEmailForwardingWithContext(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	if response.Errors != nil && len(*response.Errors) > 0 {
-		apiErr := (*response.Errors)[0]
-		return nil, fmt.Errorf("%s (%s)", *apiErr.Message, *apiErr.Number)
-	}
-
 	return response.CommandResponse, nil
 }
 

--- a/namecheap/domains_dns_set_hosts.go
+++ b/namecheap/domains_dns_set_hosts.go
@@ -129,11 +129,6 @@ func (dds *DomainsDNSService) SetHostsWithContext(ctx context.Context, args *Dom
 	if err != nil {
 		return nil, err
 	}
-	if response.Errors != nil && len(*response.Errors) > 0 {
-		apiErr := (*response.Errors)[0]
-		return nil, fmt.Errorf("%s (%s)", *apiErr.Message, *apiErr.Number)
-	}
-
 	return response.CommandResponse, nil
 }
 

--- a/namecheap/domains_get_info.go
+++ b/namecheap/domains_get_info.go
@@ -3,7 +3,6 @@ package namecheap
 import (
 	"context"
 	"encoding/xml"
-	"fmt"
 )
 
 type DomainsGetInfoResponse struct {
@@ -50,12 +49,6 @@ func (ds *DomainsService) GetInfoWithContext(ctx context.Context, domain string)
 	if err != nil {
 		return nil, err
 	}
-	if response.Errors != nil && len(*response.Errors) > 0 {
-		apiErr := (*response.Errors)[0]
-
-		return nil, fmt.Errorf("%s (%s)", *apiErr.Message, *apiErr.Number)
-	}
-
 	return response.CommandResponse, nil
 }
 

--- a/namecheap/domains_get_list.go
+++ b/namecheap/domains_get_list.go
@@ -94,11 +94,6 @@ func (ds *DomainsService) GetListWithContext(ctx context.Context, args *DomainsG
 	if err != nil {
 		return nil, err
 	}
-	if domainsResponse.Errors != nil && len(*domainsResponse.Errors) > 0 {
-		apiErr := (*domainsResponse.Errors)[0]
-		return nil, fmt.Errorf("%s (%s)", *apiErr.Message, *apiErr.Number)
-	}
-
 	return domainsResponse.CommandResponse, nil
 }
 

--- a/namecheap/domains_ns_create.go
+++ b/namecheap/domains_ns_create.go
@@ -3,7 +3,6 @@ package namecheap
 import (
 	"context"
 	"encoding/xml"
-	"fmt"
 )
 
 type NameserversCreateResponse struct {
@@ -41,11 +40,6 @@ func (s *DomainsNSService) CreateWithContext(ctx context.Context, sld, tld, name
 	_, err := s.client.DoXMLWithContext(ctx, params, &response)
 	if err != nil {
 		return nil, err
-	}
-
-	if response.Errors != nil && len(*response.Errors) > 0 {
-		apiErr := (*response.Errors)[0]
-		return nil, fmt.Errorf("%s (%s)", *apiErr.Message, *apiErr.Number)
 	}
 
 	return response.CommandResponse, nil

--- a/namecheap/domains_ns_delete.go
+++ b/namecheap/domains_ns_delete.go
@@ -3,7 +3,6 @@ package namecheap
 import (
 	"context"
 	"encoding/xml"
-	"fmt"
 )
 
 type NameserversDeleteResponse struct {
@@ -39,11 +38,6 @@ func (s *DomainsNSService) DeleteWithContext(ctx context.Context, sld, tld, name
 	_, err := s.client.DoXMLWithContext(ctx, params, &response)
 	if err != nil {
 		return nil, err
-	}
-
-	if response.Errors != nil && len(*response.Errors) > 0 {
-		apiErr := (*response.Errors)[0]
-		return nil, fmt.Errorf("%s (%s)", *apiErr.Message, *apiErr.Number)
 	}
 
 	return response.CommandResponse, nil

--- a/namecheap/domains_ns_get_info.go
+++ b/namecheap/domains_ns_get_info.go
@@ -3,7 +3,6 @@ package namecheap
 import (
 	"context"
 	"encoding/xml"
-	"fmt"
 )
 
 type NameserversGetInfoResponse struct {
@@ -42,11 +41,6 @@ func (s *DomainsNSService) GetInfoWithContext(ctx context.Context, sld, tld, nam
 	_, err := s.client.DoXMLWithContext(ctx, params, &response)
 	if err != nil {
 		return nil, err
-	}
-
-	if response.Errors != nil && len(*response.Errors) > 0 {
-		apiErr := (*response.Errors)[0]
-		return nil, fmt.Errorf("%s (%s)", *apiErr.Message, *apiErr.Number)
 	}
 
 	return response.CommandResponse, nil

--- a/namecheap/domains_ns_update.go
+++ b/namecheap/domains_ns_update.go
@@ -3,7 +3,6 @@ package namecheap
 import (
 	"context"
 	"encoding/xml"
-	"fmt"
 )
 
 type NameserversUpdateResponse struct {
@@ -41,11 +40,6 @@ func (s *DomainsNSService) UpdateWithContext(ctx context.Context, sld, tld, name
 	_, err := s.client.DoXMLWithContext(ctx, params, &response)
 	if err != nil {
 		return nil, err
-	}
-
-	if response.Errors != nil && len(*response.Errors) > 0 {
-		apiErr := (*response.Errors)[0]
-		return nil, fmt.Errorf("%s (%s)", *apiErr.Message, *apiErr.Number)
 	}
 
 	return response.CommandResponse, nil

--- a/namecheap/errors.go
+++ b/namecheap/errors.go
@@ -1,0 +1,240 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+)
+
+// maxSnippetBytes caps how many bytes of a malformed response body a ParseError
+// retains, so a huge or hostile body can never pin unbounded memory in the
+// error chain.
+const maxSnippetBytes = 512
+
+// APIError is a typed, machine-matchable representation of a single
+// <Error Number="..."> entry returned by the Namecheap API when a call fails
+// (envelope Status="ERROR").
+//
+// Its Error string is intentionally formatted as "<message> (<number>)" to
+// preserve the exact text the SDK produced before typed errors existed, so
+// consumers that string-match today keep working.
+//
+// Match against it with errors.As to read the code programmatically:
+//
+//	var apiErr *namecheap.APIError
+//	if errors.As(err, &apiErr) {
+//	    log.Printf("code=%d msg=%q command=%q", apiErr.Number, apiErr.Message, apiErr.Command)
+//	}
+//
+// or against a sentinel with errors.Is:
+//
+//	if errors.Is(err, namecheap.ErrDomainNotFound) { /* recreate resource */ }
+type APIError struct {
+	Number  int    // Namecheap numeric error code, e.g. 2019166.
+	Message string // Server-provided human-readable message.
+	Command string // Command that failed, e.g. "namecheap.domains.getInfo".
+}
+
+// Error implements the error interface. The format is preserved verbatim from
+// the pre-typed-errors SDK: "<message> (<number>)".
+func (e *APIError) Error() string {
+	return fmt.Sprintf("%s (%d)", e.Message, e.Number)
+}
+
+// Is reports whether target matches this API error. It returns true when target
+// is a sentinel whose documented code set contains e.Number, and when target is
+// another *APIError carrying the same Number. This makes both
+// errors.Is(err, namecheap.ErrDomainNotFound) and
+// errors.Is(err, &namecheap.APIError{Number: 2019166}) work naturally,
+// including through errors.Join and wrapping.
+func (e *APIError) Is(target error) bool {
+	switch t := target.(type) {
+	case *sentinelError:
+		for _, n := range t.numbers {
+			if n == e.Number {
+				return true
+			}
+		}
+		return false
+	case *APIError:
+		return t.Number == e.Number
+	default:
+		return false
+	}
+}
+
+// sentinelError is an unexported category error carrying a name and the set of
+// Namecheap numeric codes it stands for. Instances are exported as Err* values
+// and are matched by (*APIError).Is, so errors.Is(apiErr, ErrX) succeeds when
+// apiErr.Number is in the set.
+type sentinelError struct {
+	name    string
+	numbers []int
+}
+
+// Error implements the error interface for use as a sentinel.
+func (e *sentinelError) Error() string { return e.name }
+
+// serverErrorNumbers is the set of documented codes that represent transient,
+// server-side failures worth retrying. It is the single source of truth shared
+// by ErrServerError and IsRetryable.
+//
+// docs/namecheap-api-v2.md § Error Codes.
+var serverErrorNumbers = []int{3050900, 5019169, 5050169, 5050900}
+
+// Sentinel errors for the documented, actionable Namecheap error codes.
+//
+// Every code below is verified present in docs/namecheap-api-v2.md; no codes are
+// invented. Match with errors.Is. The raw APIError.Number covers the long tail
+// of codes that do not have a dedicated sentinel.
+//
+// Code -> sentinel table:
+//
+//	2019166                     -> ErrDomainNotFound
+//	2016166, 3016166            -> ErrDomainNotAssociated
+//	2030166                     -> ErrDomainInvalid
+//	2011169                     -> ErrTooManyDomains
+//	2011170                     -> ErrPromotionCodeInvalid
+//	2033409                     -> ErrOrderNotFound
+//	4011103                     -> ErrAccessDenied
+//	3050900, 5019169,
+//	5050169, 5050900            -> ErrServerError
+//
+// Deliberate, documented gap: the issue also names ErrRateLimited,
+// ErrNotWhitelistedIP, ErrAuthFailure and ErrInsufficientFunds, but
+// docs/namecheap-api-v2.md carries NO numeric codes for these categories, so no
+// sentinels are fabricated for them. Rate limiting in particular is surfaced by
+// the API as HTTP 405 and is already absorbed by the transport retry layer (see
+// DoXMLWithContext / IsRetryable), not as a numeric <Error>. Add these
+// sentinels only once real codes are confirmed and added to the doc.
+var (
+	// ErrDomainNotFound matches "Domain not found" / "Domain name not found".
+	//
+	// docs/namecheap-api-v2.md § Error Codes.
+	ErrDomainNotFound error = &sentinelError{name: "domain not found", numbers: []int{2019166}}
+
+	// ErrDomainNotAssociated matches a domain not associated with the account
+	// (2016166) or not associated with Enom (3016166).
+	//
+	// docs/namecheap-api-v2.md § Error Codes.
+	ErrDomainNotAssociated error = &sentinelError{name: "domain not associated with account", numbers: []int{2016166, 3016166}}
+
+	// ErrDomainInvalid matches an invalid domain / unsupported edit permission.
+	//
+	// docs/namecheap-api-v2.md § Error Codes.
+	ErrDomainInvalid error = &sentinelError{name: "domain invalid", numbers: []int{2030166}}
+
+	// ErrTooManyDomains matches passing more than 50 domains to a check call.
+	//
+	// docs/namecheap-api-v2.md § Error Codes.
+	ErrTooManyDomains error = &sentinelError{name: "too many domains", numbers: []int{2011169}}
+
+	// ErrPromotionCodeInvalid matches an invalid promotion code.
+	//
+	// docs/namecheap-api-v2.md § Error Codes.
+	ErrPromotionCodeInvalid error = &sentinelError{name: "promotion code invalid", numbers: []int{2011170}}
+
+	// ErrOrderNotFound matches an order that could not be found.
+	//
+	// docs/namecheap-api-v2.md § Error Codes.
+	ErrOrderNotFound error = &sentinelError{name: "order not found", numbers: []int{2033409}}
+
+	// ErrAccessDenied matches an access-denied / permission error.
+	//
+	// docs/namecheap-api-v2.md § Error Codes.
+	ErrAccessDenied error = &sentinelError{name: "access denied", numbers: []int{4011103}}
+
+	// ErrServerError matches unknown/unhandled transient server exceptions. It
+	// shares its code set with IsRetryable.
+	//
+	// docs/namecheap-api-v2.md § Error Codes.
+	ErrServerError error = &sentinelError{name: "server error", numbers: serverErrorNumbers}
+)
+
+// ParseError signals that a server response could not be decoded as the
+// expected XML. It preserves a bounded snippet of the raw body (at most
+// maxSnippetBytes) for diagnostics and wraps the underlying decode error, so
+// consumers can tell an SDK/parsing fault apart from an API rejection
+// (*APIError) or a transport/context failure.
+//
+// Its Error string keeps the "unable to parse server response:" prefix used by
+// the pre-typed-errors SDK.
+type ParseError struct {
+	Snippet string // Bounded prefix of the raw response body.
+	Err     error  // Underlying XML decode error.
+}
+
+// Error implements the error interface, preserving the legacy prefix.
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("unable to parse server response: %v", e.Err)
+}
+
+// Unwrap exposes the underlying decode error for errors.Is/errors.As.
+func (e *ParseError) Unwrap() error { return e.Err }
+
+// IsRetryable reports whether err represents a transient failure that a caller
+// may reasonably retry. It is the single source of truth for retryability so a
+// retry policy (e.g. the resilience layer) does not have to re-derive it.
+//
+// It returns true for a transient server-side *APIError (serverErrorNumbers)
+// and for a transport timeout (a net.Error with Timeout() == true). It returns
+// false for context.Canceled and context.DeadlineExceeded (caller intent, even
+// when wrapped in a *url.Error that satisfies net.Error), for any other
+// *APIError (validation, not-found, auth and permission failures are
+// permanent), and for everything else.
+func IsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Caller intent must win over the net.Error check below, because a context
+	// error can surface wrapped in a *url.Error whose Timeout() reports true.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return isServerErrorCode(apiErr.Number)
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+
+	return false
+}
+
+// isServerErrorCode reports whether n is a transient server-side error code.
+func isServerErrorCode(n int) bool {
+	for _, c := range serverErrorNumbers {
+		if c == n {
+			return true
+		}
+	}
+	return false
+}
+
+// snippet returns at most maxSnippetBytes of data as a string.
+func snippet(data []byte) string {
+	if len(data) > maxSnippetBytes {
+		return string(data[:maxSnippetBytes])
+	}
+	return string(data)
+}
+
+// atoiOrZero parses the numeric error code, defaulting to 0 when the pointer is
+// nil or the value is not an integer.
+func atoiOrZero(s *string) int {
+	if s == nil {
+		return 0
+	}
+	n, err := strconv.Atoi(*s)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/namecheap/errors_test.go
+++ b/namecheap/errors_test.go
@@ -1,0 +1,303 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeNetError is a net.Error stand-in for exercising IsRetryable's transport
+// branch without a real network stack.
+type fakeNetError struct {
+	timeout bool
+}
+
+func (e fakeNetError) Error() string   { return "fake net error" }
+func (e fakeNetError) Timeout() bool   { return e.timeout }
+func (e fakeNetError) Temporary() bool { return false }
+
+// newMockClient returns a Client whose transport is redirected to a server that
+// always writes body, together with the server's cleanup func.
+func newMockClient(t *testing.T, body string) *Client {
+	t.Helper()
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(mockServer.Close)
+
+	client := setupClient(nil)
+	client.BaseURL = mockServer.URL
+	return client
+}
+
+func TestAPIErrorError(t *testing.T) {
+	t.Parallel()
+	err := &APIError{Number: 2019166, Message: "Domain not found", Command: "namecheap.domains.getInfo"}
+	// Legacy "<msg> (<number>)" format must be preserved verbatim.
+	assert.Equal(t, "Domain not found (2019166)", err.Error())
+}
+
+func TestAPIErrorIsSameNumber(t *testing.T) {
+	t.Parallel()
+	err := &APIError{Number: 2019166, Message: "Domain not found"}
+	assert.True(t, errors.Is(err, &APIError{Number: 2019166}))
+	assert.False(t, errors.Is(err, &APIError{Number: 4011103}))
+}
+
+// sentinelCases is the grounded code->sentinel table, mirrored from errors.go.
+var sentinelCases = []struct {
+	name     string
+	sentinel error
+	codes    []int
+}{
+	{"ErrDomainNotFound", ErrDomainNotFound, []int{2019166}},
+	{"ErrDomainNotAssociated", ErrDomainNotAssociated, []int{2016166, 3016166}},
+	{"ErrDomainInvalid", ErrDomainInvalid, []int{2030166}},
+	{"ErrTooManyDomains", ErrTooManyDomains, []int{2011169}},
+	{"ErrPromotionCodeInvalid", ErrPromotionCodeInvalid, []int{2011170}},
+	{"ErrOrderNotFound", ErrOrderNotFound, []int{2033409}},
+	{"ErrAccessDenied", ErrAccessDenied, []int{4011103}},
+	{"ErrServerError", ErrServerError, []int{3050900, 5019169, 5050169, 5050900}},
+}
+
+func TestSentinelCodeMap(t *testing.T) {
+	t.Parallel()
+	for _, tc := range sentinelCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			for _, code := range tc.codes {
+				assert.Truef(t, errors.Is(&APIError{Number: code}, tc.sentinel),
+					"code %d should match sentinel %s", code, tc.name)
+			}
+			// A code outside the set must not match.
+			assert.Falsef(t, errors.Is(&APIError{Number: 1}, tc.sentinel),
+				"code 1 should not match sentinel %s", tc.name)
+		})
+	}
+}
+
+func TestSentinelCodesAreExclusive(t *testing.T) {
+	t.Parallel()
+	// A code belonging to one sentinel must not match any other sentinel,
+	// guarding against accidental overlap in the grounded map.
+	for _, owner := range sentinelCases {
+		for _, code := range owner.codes {
+			for _, other := range sentinelCases {
+				if other.name == owner.name {
+					continue
+				}
+				assert.Falsef(t, errors.Is(&APIError{Number: code}, other.sentinel),
+					"code %d (owned by %s) should not match %s", code, owner.name, other.name)
+			}
+		}
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"server_error_3050900", &APIError{Number: 3050900}, true},
+		{"server_error_5050900", &APIError{Number: 5050900}, true},
+		{"server_error_5019169", &APIError{Number: 5019169}, true},
+		{"server_error_5050169", &APIError{Number: 5050169}, true},
+		{"not_found", &APIError{Number: 2019166}, false},
+		{"validation", &APIError{Number: 2030166}, false},
+		{"access_denied", &APIError{Number: 4011103}, false},
+		{"wrapped_server_error", fmt.Errorf("call failed: %w", &APIError{Number: 3050900}), true},
+		{"net_timeout", fakeNetError{timeout: true}, true},
+		{"net_non_timeout", fakeNetError{timeout: false}, false},
+		{"context_canceled", context.Canceled, false},
+		{"context_deadline", context.DeadlineExceeded, false},
+		// ctx errors can surface wrapped in a *url.Error whose Timeout() is true;
+		// the ctx check must win so this stays non-retryable.
+		{"url_error_wrapping_deadline", &url.Error{Op: "Post", URL: "x", Err: context.DeadlineExceeded}, false},
+		{"parse_error", &ParseError{Err: io.EOF}, false},
+		{"generic", errors.New("boom"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, IsRetryable(tc.err))
+		})
+	}
+}
+
+func TestSnippetCap(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "abc", snippet([]byte("abc")))
+	big := strings.Repeat("x", maxSnippetBytes+100)
+	assert.Len(t, snippet([]byte(big)), maxSnippetBytes)
+}
+
+func TestParseErrorThroughDoXML(t *testing.T) {
+	t.Parallel()
+	t.Run("garbage_body", func(t *testing.T) {
+		t.Parallel()
+		client := newMockClient(t, "totally not xml")
+
+		var resp DomainsGetInfoResponse
+		_, err := client.DoXMLWithContext(context.Background(), map[string]string{"Command": "namecheap.domains.getInfo"}, &resp)
+		assert.Error(t, err)
+
+		var parseErr *ParseError
+		assert.True(t, errors.As(err, &parseErr))
+		assert.Contains(t, err.Error(), "unable to parse server response")
+		assert.NotNil(t, errors.Unwrap(err))
+	})
+
+	t.Run("snippet_is_bounded", func(t *testing.T) {
+		t.Parallel()
+		client := newMockClient(t, strings.Repeat("z", maxSnippetBytes+512))
+
+		var resp DomainsGetInfoResponse
+		_, err := client.DoXMLWithContext(context.Background(), map[string]string{"Command": "namecheap.domains.getInfo"}, &resp)
+
+		var parseErr *ParseError
+		assert.True(t, errors.As(err, &parseErr))
+		assert.LessOrEqual(t, len(parseErr.Snippet), maxSnippetBytes)
+	})
+}
+
+func TestDoXMLSingleTypedError(t *testing.T) {
+	t.Parallel()
+	body := `<?xml version="1.0" encoding="utf-8"?>
+		<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+			<Errors><Error Number="2019166">Domain not found</Error></Errors>
+			<CommandResponse/>
+		</ApiResponse>`
+	client := newMockClient(t, body)
+
+	// Through a real service method so Command is populated from its params.
+	_, err := client.Domains.GetInfoWithContext(context.Background(), "example.com")
+	assert.Error(t, err)
+
+	var apiErr *APIError
+	assert.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, 2019166, apiErr.Number)
+	assert.Equal(t, "Domain not found", apiErr.Message)
+	assert.Equal(t, "namecheap.domains.getInfo", apiErr.Command)
+	assert.True(t, errors.Is(err, ErrDomainNotFound))
+}
+
+func TestDoXMLMultiErrorJoin(t *testing.T) {
+	t.Parallel()
+	body := `<?xml version="1.0" encoding="utf-8"?>
+		<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+			<Errors>
+				<Error Number="2019166">Domain not found</Error>
+				<Error Number="4011103">Access denied</Error>
+			</Errors>
+		</ApiResponse>`
+	client := newMockClient(t, body)
+
+	var resp DomainsGetInfoResponse
+	_, err := client.DoXMLWithContext(context.Background(),
+		map[string]string{"Command": "namecheap.domains.getInfo"}, &resp)
+	assert.Error(t, err)
+
+	// errors.Is finds each joined sentinel.
+	assert.True(t, errors.Is(err, ErrDomainNotFound))
+	assert.True(t, errors.Is(err, ErrAccessDenied))
+
+	// errors.As reaches an *APIError, and it carries the command.
+	var apiErr *APIError
+	assert.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, "namecheap.domains.getInfo", apiErr.Command)
+}
+
+func TestServiceMethodsReturnTypedErrors(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		number      string
+		message     string
+		wantCode    int
+		wantCommand string
+		sentinel    error
+		call        func(*Client) error
+	}{
+		{
+			name:        "domains_get_info",
+			number:      "2019166",
+			message:     "Domain not found",
+			wantCode:    2019166,
+			wantCommand: "namecheap.domains.getInfo",
+			sentinel:    ErrDomainNotFound,
+			call: func(c *Client) error {
+				_, err := c.Domains.GetInfoWithContext(context.Background(), "example.com")
+				return err
+			},
+		},
+		{
+			name:        "domains_check",
+			number:      "2011169",
+			message:     "Too many domains",
+			wantCode:    2011169,
+			wantCommand: "namecheap.domains.check",
+			sentinel:    ErrTooManyDomains,
+			call: func(c *Client) error {
+				_, err := c.Domains.CheckWithContext(context.Background(), "example.com")
+				return err
+			},
+		},
+		{
+			name:        "domains_ns_delete",
+			number:      "2016166",
+			message:     "Domain is not associated with your account",
+			wantCode:    2016166,
+			wantCommand: "namecheap.domains.ns.delete",
+			sentinel:    ErrDomainNotAssociated,
+			call: func(c *Client) error {
+				_, err := c.DomainsNS.DeleteWithContext(context.Background(), "example", "com", "ns1.example.com")
+				return err
+			},
+		},
+		{
+			name:        "domains_dns_set_default",
+			number:      "2030166",
+			message:     "Edit permission for domain is not supported",
+			wantCode:    2030166,
+			wantCommand: "namecheap.domains.dns.setDefault",
+			sentinel:    ErrDomainInvalid,
+			call: func(c *Client) error {
+				_, err := c.DomainsDNS.SetDefaultWithContext(context.Background(), "example.com")
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			body := fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+				<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+					<Errors><Error Number="%s">%s</Error></Errors>
+					<CommandResponse/>
+				</ApiResponse>`, tc.number, tc.message)
+			client := newMockClient(t, body)
+
+			err := tc.call(client)
+			assert.Error(t, err)
+
+			var apiErr *APIError
+			assert.True(t, errors.As(err, &apiErr), "expected an *APIError in the chain")
+			assert.Equal(t, tc.wantCode, apiErr.Number)
+			assert.Equal(t, tc.message, apiErr.Message)
+			assert.Equal(t, tc.wantCommand, apiErr.Command)
+			assert.True(t, errors.Is(err, tc.sentinel), "expected errors.Is to match the sentinel")
+		})
+	}
+}

--- a/namecheap/namecheap.go
+++ b/namecheap/namecheap.go
@@ -1,4 +1,3 @@
-// Package namecheap provides a Go client for the Namecheap API v1.
 package namecheap
 
 import (
@@ -134,10 +133,19 @@ func (c *Client) DoXMLWithContext(ctx context.Context, body map[string]string, o
 			return syncretry.ErrRetry
 		}
 
-		requestResponse = response
-		err = decodeBody(response.Body, obj)
+		data, readErr := io.ReadAll(response.Body)
 		response.Body.Close()
-		return err
+		if readErr != nil {
+			return readErr
+		}
+
+		requestResponse = response
+
+		if parseErr := decodeBody(bytes.NewReader(data), obj); parseErr != nil {
+			return parseErr
+		}
+
+		return parseAPIError(data, body["Command"])
 	})
 
 	if err != nil && errors.Is(err, syncretry.ErrRetryAttempts) {
@@ -157,14 +165,76 @@ func (c *Client) DoXML(body map[string]string, obj any) (*http.Response, error) 
 	return c.DoXMLWithContext(context.Background(), body, obj)
 }
 
-// decodeBody decodes the interface from received XML
+// apiResponseEnvelope is a minimal view of every Namecheap XML response used to
+// extract typed errors centrally, independent of the per-command response type.
+type apiResponseEnvelope struct {
+	Status string `xml:"Status,attr"`
+	Errors *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+}
+
+// decodeBody reads and decodes the XML from reader into obj. A malformed body
+// yields a *ParseError carrying a bounded snippet of the raw response and the
+// underlying decode error (its message keeps the legacy
+// "unable to parse server response:" prefix).
 func decodeBody(reader io.Reader, obj any) error {
-	decoder := xml.NewDecoder(reader)
-	err := decoder.Decode(&obj)
+	data, err := io.ReadAll(reader)
 	if err != nil {
-		return fmt.Errorf("unable to parse server response: %w", err)
+		return &ParseError{Snippet: snippet(data), Err: err}
+	}
+	if err := xml.Unmarshal(data, obj); err != nil {
+		return &ParseError{Snippet: snippet(data), Err: err}
 	}
 	return nil
+}
+
+// parseAPIError extracts a typed API error from an already-decoded response
+// body. It returns a single *APIError when the response carries exactly one
+// <Error>, an errors.Join of *APIError values when it carries several, and nil
+// when the response is not an error. command is threaded onto each *APIError.
+func parseAPIError(data []byte, command string) error {
+	var env apiResponseEnvelope
+	if err := xml.Unmarshal(data, &env); err != nil {
+		// A body that decoded for the caller's type but not for the envelope is
+		// treated as "no API error"; a genuinely malformed body is already
+		// reported as a *ParseError by decodeBody.
+		return nil
+	}
+
+	var entries []struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	}
+	if env.Errors != nil {
+		entries = *env.Errors
+	}
+
+	if len(entries) == 0 {
+		if env.Status == "ERROR" {
+			return &APIError{Command: command, Message: "API returned an error status"}
+		}
+		return nil
+	}
+
+	apiErrors := make([]error, 0, len(entries))
+	for _, e := range entries {
+		message := ""
+		if e.Message != nil {
+			message = *e.Message
+		}
+		apiErrors = append(apiErrors, &APIError{
+			Number:  atoiOrZero(e.Number),
+			Message: message,
+			Command: command,
+		})
+	}
+
+	if len(apiErrors) == 1 {
+		return apiErrors[0]
+	}
+	return errors.Join(apiErrors...)
 }
 
 // encodeBody converts the map into query string


### PR DESCRIPTION
Closes #111. Second item of the go-namecheap-sdk 2.0 roadmap (#122), on top of the #110 context work. Lands before the coverage wave so every new API group returns typed errors from day one, and provides the `IsRetryable` single-source-of-truth the resilience issue (#112) consumes.

## What
Typed, machine-matchable API errors, extracted **centrally** in the transport layer so all current and future methods get them uniformly.

- **`APIError{Number, Message, Command}`** — parsed in `DoXMLWithContext` from a shared response envelope (body read once, decoded into the caller's type *and* an error envelope). `Error()` preserves the legacy `"<message> (<number>)"` text; multi-error responses become an `errors.Join` of `*APIError`.
- **Sentinels** (`errors.Is`) grounded strictly in `docs/namecheap-api-v2.md`:

  | Sentinel | Codes |
  |---|---|
  | `ErrDomainNotFound` | 2019166 |
  | `ErrDomainNotAssociated` | 2016166, 3016166 |
  | `ErrDomainInvalid` | 2030166 |
  | `ErrTooManyDomains` | 2011169 |
  | `ErrPromotionCodeInvalid` | 2011170 |
  | `ErrOrderNotFound` | 2033409 |
  | `ErrAccessDenied` | 4011103 |
  | `ErrServerError` | 3050900, 5019169, 5050169, 5050900 |

- **`ParseError`** — bounded (≤512 B) snippet + `Unwrap`, keeps the `"unable to parse server response:"` prefix; distinguishes an SDK/parse fault from an API rejection vs a transport/ctx failure.
- **`IsRetryable(err)`** — transient server codes + `net` timeouts → true; `context.Canceled`/`DeadlineExceeded` (even wrapped in `*url.Error`) and permanent API errors → false. Shares one code set with `ErrServerError`.

Service methods drop their per-command error-string blocks and inherit the typed error; `domains.dns` `GetList`'s FreeDNS fallback now keys off `errors.Is(err, ErrDomainNotFound)` (behavior unchanged).

## ⚠️ Deliberate, documented descope (needs maintainer input)
The issue also names **`ErrRateLimited`, `ErrNotWhitelistedIP`, `ErrAuthFailure`, `ErrInsufficientFunds`** — but `docs/namecheap-api-v2.md` carries **no numeric codes** for these categories, and per the roadmap's "the doc is law" rule I did **not** invent any. Rate limiting in this SDK is surfaced as **HTTP 405** and already absorbed by the retry layer (so it's covered by `IsRetryable`, just not as a numeric sentinel). The gap is documented in `errors.go`. To add these sentinels, please confirm the real codes and add them to the doc — happy to follow up.

## Acceptance criteria
- [x] All service methods return `*APIError` (or a join) for `Status="ERROR"` — per-service table tests with captured XML.
- [x] `errors.As(err, **APIError)` yields Number/Message/Command through the retry + ctx layers.
- [x] Every sentinel matches its documented code set (table test); map cites the doc.
- [x] Multi-error responses → joined; `errors.Is` finds each.
- [x] `IsRetryable` classifies server-errors/timeouts→true, auth/not-found/validation/ctx→false.
- [x] `ParseError` with capped snippet (garbage/truncated XML tested).
- [x] Existing error strings preserved verbatim (legacy assertions still pass).
- [x] Doc comments on all exported identifiers; `doc.go` error-handling section; README error-handling example.
- [~] Sentinel *categories* without documented codes deferred (see descope above).

## Verification (local, go 1.26.4 + golangci-lint 2.12.2)
`go vet` ✅ · `golangci-lint run` → 0 issues ✅ · `go mod tidy` diff empty (stdlib only) ✅ · `make test` (unit + race) ✅ · coverage: namecheap 94.7%, syncretry 93.1%.
