### PR TITLE
feat: add domains lifecycle API (create/renew/reactivate/contacts/registrar-lock/getTldList)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Eight new `Domains` API methods, all context-first with the `WithContext`
+  suffix and no non-context wrappers (these are brand-new, charge-bearing or
+  read-only surfaces with no legacy to preserve): `CreateWithContext`,
+  `RenewWithContext`, `ReactivateWithContext`, `GetContactsWithContext`,
+  `SetContactsWithContext`, `GetRegistrarLockWithContext`,
+  `SetRegistrarLockWithContext` and `GetTldListWithContext`. Each returns a typed
+  `*...CommandResponse` and carries the Namecheap doc URL (#114).
+- Shared `ContactInfo` type used by both `create` and `setContacts` for the
+  Registrant/Tech/Admin/AuxBilling blocks, with up-front validation that reports
+  **all** missing required contact fields at once as a typed
+  `*InvalidArgumentsError` (rather than failing on the first) (#114).
+- `Amount`, a string-based money type. `ChargedAmount`, `PremiumPrice` and
+  `EapFee` are exposed as `Amount` and parsed from the exact server string —
+  money is never modeled as `float64`, avoiding decimal-rounding surprises (#114).
+- Premium-domain money-safety guard on `create`/`renew`/`reactivate`: when
+  `IsPremiumDomain` is true `PremiumPrice` is mandatory, and when it is false no
+  premium pricing may be set. A violation returns an `*InvalidArgumentsError`
+  before any charge-bearing request is sent, making an accidental premium
+  purchase impossible without explicit acknowledgment (#114).
+- Non-idempotent (charge-bearing) request classification. `create`, `renew` and
+  `reactivate` are no longer retried on ambiguous transport/server failures that
+  may already have executed (which could double-charge); only Namecheap's
+  pre-execution HTTP 405 rate-limit signal is retried for them. All other calls
+  remain idempotent and retry as before. Implemented by threading an idempotency
+  flag through the transport (`Client.doXML`) and `shouldRetry` (#114).
 - Typed API errors. API failures now surface as a machine-matchable
   `*APIError` (exposing `Number`, `Message` and `Command`) instead of a flat
   string, so callers can inspect the Namecheap error code via `errors.As`.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ ctx := context.Background()
 | `GetListWithContext(ctx, args)` | List domains for the account |
 | `GetInfoWithContext(ctx, domain)` | Get detailed info about a domain |
 | `CheckWithContext(ctx, domains...)` | Check availability of one or more domains |
+| `GetTldListWithContext(ctx)` | List all TLDs and their per-TLD API capabilities |
+| `CreateWithContext(ctx, args)` | Register a new domain (charge-bearing) |
+| `RenewWithContext(ctx, args)` | Renew an expiring domain (charge-bearing) |
+| `ReactivateWithContext(ctx, args)` | Reactivate an expired domain (charge-bearing) |
+| `GetContactsWithContext(ctx, domain)` | Get a domain's contact information |
+| `SetContactsWithContext(ctx, args)` | Set a domain's contact information |
+| `GetRegistrarLockWithContext(ctx, domain)` | Get the registrar-lock status |
+| `SetRegistrarLockWithContext(ctx, domain, action)` | Lock/unlock the domain at the registrar |
 
 ```go
 // Check domain availability
@@ -59,6 +67,77 @@ for _, result := range *resp.DomainCheckResults {
     fmt.Printf("%s available=%v\n", *result.Domain, *result.IsAvailable)
 }
 ```
+
+```go
+// Register a new domain. The four contact blocks reuse the shared
+// namecheap.ContactInfo type; all required fields are validated up front and
+// every missing field is reported at once as a *namecheap.InvalidArgumentsError.
+contact := namecheap.ContactInfo{
+    FirstName:    "John",
+    LastName:     "Smith",
+    Address1:     "8939 S.cross Blvd",
+    City:         "Phoenix",
+    StateProvince: "AZ",
+    PostalCode:   "85284",
+    Country:      "US",
+    Phone:        "+1.6613102107",
+    EmailAddress: "john@example.com",
+}
+created, err := client.Domains.CreateWithContext(ctx, &namecheap.DomainsCreateArgs{
+    DomainName: "example.com",
+    Years:      2,
+    Registrant: contact,
+    Tech:       contact,
+    Admin:      contact,
+    AuxBilling: contact,
+    // For a premium domain set IsPremiumDomain and PremiumPrice together; the
+    // premium guard rejects the call (before any charge) if they disagree.
+    // IsPremiumDomain: true,
+    // PremiumPrice:    namecheap.Amount("13000.0000"),
+})
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("registered=%v charged=%s\n",
+    *created.DomainCreateResult.Registered, created.DomainCreateResult.ChargedAmount)
+
+// Renew an expiring domain.
+renewed, err := client.Domains.RenewWithContext(ctx, &namecheap.DomainsRenewArgs{
+    DomainName: "example.com",
+    Years:      1,
+})
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("charged=%s\n", renewed.DomainRenewResult.ChargedAmount)
+```
+
+> **Money and charge-bearing calls.** `Create`, `Renew` and `Reactivate` can
+> charge the account. Their prices are exposed as `namecheap.Amount` — a string
+> type that preserves the exact server value (money is **never** a `float64`, to
+> avoid decimal rounding). These three calls are treated as **non-idempotent**:
+> on an ambiguous transport or server-side failure the SDK does **not** retry
+> (a resend could double-charge); only Namecheap's pre-execution HTTP 405
+> rate-limit signal is retried. Reconcile such failures via the account order
+> history. All other methods remain idempotent and retry as before.
+
+#### Domains API coverage matrix
+
+| `namecheap.domains.*` command | Status |
+|---|---|
+| `getList` | Implemented |
+| `getInfo` | Implemented |
+| `check` | Implemented |
+| `getTldList` | Implemented |
+| `create` | Implemented |
+| `renew` | Implemented |
+| `reactivate` | Implemented |
+| `getContacts` | Implemented |
+| `setContacts` | Implemented |
+| `getRegistrarLock` | Implemented |
+| `setRegistrarLock` | Implemented |
+| `getRegistrarLockStatus` (bulk) | Planned |
+| `transfer.*` | Planned |
 
 #### DomainsDNS (`client.DomainsDNS`)
 
@@ -162,6 +241,19 @@ if namecheap.IsRetryable(err) {
 Malformed responses return a `*namecheap.ParseError` (with a bounded snippet of
 the raw body); transport and context errors propagate unwrapped. All error types
 support `errors.Is` / `errors.As` for inspecting the underlying cause.
+
+Client-side validation failures (missing required arguments, missing required
+contact fields, or a tripped premium guard) are returned as a
+`*namecheap.InvalidArgumentsError` **before** any request is sent. It lists every
+offending field at once via its `Fields` slice, so a caller can fix them in a
+single pass:
+
+```go
+var argErr *namecheap.InvalidArgumentsError
+if errors.As(err, &argErr) {
+    log.Printf("fix these fields: %v", argErr.Fields)
+}
+```
 
 ### Rate limiting & retries
 

--- a/namecheap/amount.go
+++ b/namecheap/amount.go
@@ -1,0 +1,19 @@
+package namecheap
+
+// Amount is a monetary value kept as the exact decimal string the Namecheap API
+// returned (or that is sent to it), for example "10.87".
+//
+// Money is deliberately NOT modeled as float64. Binary floating point cannot
+// represent most decimal fractions exactly, so round-tripping a price through a
+// float can silently change it (10.87 becoming 10.869999999999999, and back to
+// 10.87 only by luck of rounding). Keeping the raw server string preserves both
+// the precise value and the server's own formatting, which matters for a
+// charge-bearing API. Convert it to a decimal type of your choice (for example
+// github.com/shopspring/decimal or math/big.Rat) at the point you actually need
+// arithmetic, so the rounding policy is yours and explicit.
+type Amount string
+
+// String returns the raw amount string, e.g. "10.87". It is provided so an
+// Amount can be used where a plain string is expected without an explicit
+// conversion.
+func (a Amount) String() string { return string(a) }

--- a/namecheap/amount_test.go
+++ b/namecheap/amount_test.go
@@ -1,0 +1,31 @@
+package namecheap
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAmountString(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "10.87", Amount("10.87").String())
+	assert.Equal(t, "", Amount("").String())
+}
+
+// TestAmountXMLExactPreservation asserts an Amount decodes from an attribute
+// verbatim, with no float rounding of a value that binary floats cannot hold.
+func TestAmountXMLExactPreservation(t *testing.T) {
+	t.Parallel()
+	type holder struct {
+		XMLName xml.Name `xml:"x"`
+		Charged *Amount  `xml:"ChargedAmount,attr"`
+	}
+	var h holder
+	err := xml.Unmarshal([]byte(`<x ChargedAmount="10.87"/>`), &h)
+	assert.NoError(t, err)
+	if assert.NotNil(t, h.Charged) {
+		assert.Equal(t, Amount("10.87"), *h.Charged)
+		assert.Equal(t, "10.87", h.Charged.String())
+	}
+}

--- a/namecheap/contact_info.go
+++ b/namecheap/contact_info.go
@@ -1,0 +1,136 @@
+package namecheap
+
+// ContactInfo holds the details of a single domain contact (Registrant, Tech,
+// Admin or AuxBilling). One definition serves three commands: it is the input
+// for CreateWithContext and SetContactsWithContext (flattened into the request
+// under a per-block prefix) and the parsed output of GetContactsWithContext.
+//
+// The nine leading fields are required by the Namecheap API for every contact
+// block; the trailing three are optional. Field names and required/optional
+// status follow docs/namecheap-api-v2.md (the create request table, lines
+// 143-154). The struct tags map to the response element names used by
+// getContacts.
+type ContactInfo struct {
+	// FirstName is the contact's first name. Required.
+	FirstName string `xml:"FirstName"`
+	// LastName is the contact's last name. Required.
+	LastName string `xml:"LastName"`
+	// Address1 is the primary street address. Required.
+	Address1 string `xml:"Address1"`
+	// City is the contact's city. Required.
+	City string `xml:"City"`
+	// StateProvince is the state or province. Required.
+	StateProvince string `xml:"StateProvince"`
+	// PostalCode is the postal/ZIP code. Required.
+	PostalCode string `xml:"PostalCode"`
+	// Country is the two-letter country code. Required.
+	Country string `xml:"Country"`
+	// Phone is the phone number in +NNN.NNNNNNNNNN format. Required.
+	Phone string `xml:"Phone"`
+	// EmailAddress is the contact e-mail address. Required.
+	EmailAddress string `xml:"EmailAddress"`
+
+	// OrganizationName is the contact's organization. Optional.
+	OrganizationName string `xml:"OrganizationName"`
+	// JobTitle is the contact's job title. Optional.
+	JobTitle string `xml:"JobTitle"`
+	// Address2 is the secondary street address. Optional.
+	Address2 string `xml:"Address2"`
+}
+
+// requiredContactField pairs a field's Namecheap suffix with its current value,
+// so validation can report every missing field without reflection.
+type requiredContactField struct {
+	suffix string
+	value  string
+}
+
+// required returns the contact's nine required fields paired with their values.
+func (c ContactInfo) required() []requiredContactField {
+	return []requiredContactField{
+		{"FirstName", c.FirstName},
+		{"LastName", c.LastName},
+		{"Address1", c.Address1},
+		{"City", c.City},
+		{"StateProvince", c.StateProvince},
+		{"PostalCode", c.PostalCode},
+		{"Country", c.Country},
+		{"Phone", c.Phone},
+		{"EmailAddress", c.EmailAddress},
+	}
+}
+
+// missingRequiredFields returns the prefixed names of every required field that
+// is empty (for example "RegistrantEmailAddress"), reporting all of them rather
+// than only the first.
+func (c ContactInfo) missingRequiredFields(prefix string) []string {
+	req := c.required()
+	missing := make([]string, 0, len(req))
+	for _, f := range req {
+		if f.value == "" {
+			missing = append(missing, prefix+f.suffix)
+		}
+	}
+	return missing
+}
+
+// apply flattens the contact into params under prefix, e.g. prefix "Registrant"
+// writes "RegistrantFirstName", "RegistrantLastName", and so on. Required fields
+// are always written (callers validate first); optional fields are written only
+// when non-empty so an unset optional never sends a blank value.
+func (c ContactInfo) apply(params map[string]string, prefix string) {
+	params[prefix+"FirstName"] = c.FirstName
+	params[prefix+"LastName"] = c.LastName
+	params[prefix+"Address1"] = c.Address1
+	params[prefix+"City"] = c.City
+	params[prefix+"StateProvince"] = c.StateProvince
+	params[prefix+"PostalCode"] = c.PostalCode
+	params[prefix+"Country"] = c.Country
+	params[prefix+"Phone"] = c.Phone
+	params[prefix+"EmailAddress"] = c.EmailAddress
+	setIfNotEmpty(params, prefix+"OrganizationName", c.OrganizationName)
+	setIfNotEmpty(params, prefix+"JobTitle", c.JobTitle)
+	setIfNotEmpty(params, prefix+"Address2", c.Address2)
+}
+
+// contactBlock names one of the four contact roles for validation and flattening.
+type contactBlock struct {
+	prefix  string
+	contact ContactInfo
+}
+
+// contactBlocks returns the four contact blocks in the canonical order.
+func contactBlocks(registrant, tech, admin, auxBilling ContactInfo) []contactBlock {
+	return []contactBlock{
+		{"Registrant", registrant},
+		{"Tech", tech},
+		{"Admin", admin},
+		{"AuxBilling", auxBilling},
+	}
+}
+
+// missingContactFields returns every missing required field across all four
+// contact blocks, prefixed by role (e.g. "TechCity", "AdminPhone"). It reports
+// all of them at once so a caller sees the complete list in a single error.
+func missingContactFields(registrant, tech, admin, auxBilling ContactInfo) []string {
+	blocks := contactBlocks(registrant, tech, admin, auxBilling)
+	missing := make([]string, 0, len(blocks)*len(ContactInfo{}.required()))
+	for _, b := range blocks {
+		missing = append(missing, b.contact.missingRequiredFields(b.prefix)...)
+	}
+	return missing
+}
+
+// applyContacts flattens all four contact blocks into params.
+func applyContacts(params map[string]string, registrant, tech, admin, auxBilling ContactInfo) {
+	for _, b := range contactBlocks(registrant, tech, admin, auxBilling) {
+		b.contact.apply(params, b.prefix)
+	}
+}
+
+// setIfNotEmpty writes key=value into params only when value is non-empty.
+func setIfNotEmpty(params map[string]string, key, value string) {
+	if value != "" {
+		params[key] = value
+	}
+}

--- a/namecheap/domains.go
+++ b/namecheap/domains.go
@@ -1,7 +1,11 @@
 package namecheap
 
-// DomainsService includes the following methods:
-// DomainsService.GetList - returns a list of domains for the particular user
+// DomainsService groups the namecheap.domains.* API commands: listing and
+// inspecting domains (GetListWithContext, GetInfoWithContext, CheckWithContext,
+// GetTldListWithContext), registration lifecycle (CreateWithContext,
+// RenewWithContext, ReactivateWithContext), contacts (GetContactsWithContext,
+// SetContactsWithContext) and the registrar lock (GetRegistrarLockWithContext,
+// SetRegistrarLockWithContext).
 //
 // Namecheap doc: https://www.namecheap.com/support/api/methods/domains/
 type DomainsService service

--- a/namecheap/domains_create.go
+++ b/namecheap/domains_create.go
@@ -1,0 +1,197 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+	"strings"
+)
+
+// DomainsCreateResponse is the raw envelope for namecheap.domains.create.
+type DomainsCreateResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *DomainsCreateCommandResponse `xml:"CommandResponse"`
+}
+
+// DomainsCreateCommandResponse wraps the create result.
+type DomainsCreateCommandResponse struct {
+	DomainCreateResult *DomainsCreateResult `xml:"DomainCreateResult"`
+}
+
+// DomainsCreateResult is the outcome of a registration. Fields follow the
+// create response table in docs/namecheap-api-v2.md (lines 167-174).
+type DomainsCreateResult struct {
+	// Domain is the domain name that was registered.
+	Domain *string `xml:"Domain,attr"`
+	// Registered indicates whether the domain was registered successfully.
+	Registered *bool `xml:"Registered,attr"`
+	// ChargedAmount is the total amount charged for the registration, kept as an
+	// exact decimal string (see Amount).
+	ChargedAmount *Amount `xml:"ChargedAmount,attr"`
+	// DomainID is the unique integer identifying the domain.
+	DomainID *int `xml:"DomainID,attr"`
+	// OrderID is the unique integer identifying the order.
+	OrderID *int `xml:"OrderID,attr"`
+	// TransactionID is the unique integer identifying the transaction.
+	TransactionID *int `xml:"TransactionID,attr"`
+}
+
+// DomainsCreateArgs are the arguments for CreateWithContext. Field names and
+// required/optional status follow the create request table in
+// docs/namecheap-api-v2.md (lines 138-163).
+type DomainsCreateArgs struct {
+	// DomainName is the domain to register. Required.
+	DomainName string
+	// Years is the number of years to register for. Required; the API default
+	// is 2 but this SDK requires an explicit value >= 1 for a charge-bearing call.
+	Years int
+	// PromotionCode is an optional promotional (coupon) code.
+	PromotionCode string
+
+	// Registrant, Tech, Admin and AuxBilling are the four required contact
+	// blocks. Every required ContactInfo field must be set on each.
+	Registrant ContactInfo
+	Tech       ContactInfo
+	Admin      ContactInfo
+	AuxBilling ContactInfo
+
+	// Nameservers is an optional list of custom nameservers; it is sent
+	// comma-joined. When empty the domain uses Namecheap's default DNS.
+	Nameservers []string
+	// AddFreeWhoisguard, when non-nil, adds (true) or omits (false) free domain
+	// privacy. Nil leaves the API default (Yes).
+	AddFreeWhoisguard *bool
+	// WGEnabled, when non-nil, enables (true) or disables (false) domain privacy.
+	// Nil leaves the API default (No).
+	WGEnabled *bool
+
+	// IsPremiumDomain must be true to register a premium domain. When true,
+	// PremiumPrice is mandatory (see the premium guard on CreateWithContext).
+	IsPremiumDomain bool
+	// PremiumPrice is the agreed registration price for a premium domain, as an
+	// exact decimal string (see Amount). Required when IsPremiumDomain is true;
+	// must be empty otherwise.
+	PremiumPrice Amount
+	// EapFee is the Early Access Program fee for a premium domain, as an exact
+	// decimal string (see Amount). Only meaningful when IsPremiumDomain is true.
+	EapFee Amount
+}
+
+// CreateWithContext registers a new domain name.
+//
+// It is a charge-bearing, non-idempotent call: on an ambiguous transport or
+// server-side failure the SDK does NOT retry (a resend could double-charge), so
+// the caller must reconcile such failures via the account order history.
+//
+// Premium guard (money safety). Before any network call, arguments are
+// validated and the premium fields are checked so an accidental premium purchase
+// is impossible without explicit acknowledgment:
+//   - if IsPremiumDomain is true, PremiumPrice must be a non-empty amount;
+//   - if IsPremiumDomain is false, neither PremiumPrice nor EapFee may be set.
+//
+// A violation returns an *InvalidArgumentsError before the request is sent, so
+// no charge can occur. Missing required contact fields are reported the same
+// way, all at once.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/domains/create/
+func (ds *DomainsService) CreateWithContext(ctx context.Context, args *DomainsCreateArgs) (*DomainsCreateCommandResponse, error) {
+	if args == nil {
+		return nil, &InvalidArgumentsError{Fields: []string{"args"}, Reason: "args must not be nil"}
+	}
+	if err := args.validate(); err != nil {
+		return nil, err
+	}
+
+	var response DomainsCreateResponse
+	// idempotent=false: never retry a charge-bearing call on an ambiguous error.
+	_, err := ds.client.doXML(ctx, args.params(), &response, false)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}
+
+// validate reports all missing required fields at once and then applies the
+// premium guard.
+func (a *DomainsCreateArgs) validate() error {
+	missing := make([]string, 0, 4)
+	if a.DomainName == "" {
+		missing = append(missing, "DomainName")
+	}
+	if a.Years < 1 {
+		missing = append(missing, "Years")
+	}
+	missing = append(missing, missingContactFields(a.Registrant, a.Tech, a.Admin, a.AuxBilling)...)
+	if len(missing) > 0 {
+		return &InvalidArgumentsError{Fields: missing}
+	}
+	return premiumGuard(a.IsPremiumDomain, a.PremiumPrice, a.EapFee)
+}
+
+// params flattens the validated args into the request map.
+func (a *DomainsCreateArgs) params() map[string]string {
+	params := map[string]string{
+		"Command":    "namecheap.domains.create",
+		"DomainName": a.DomainName,
+		"Years":      strconv.Itoa(a.Years),
+	}
+	setIfNotEmpty(params, "PromotionCode", a.PromotionCode)
+	applyContacts(params, a.Registrant, a.Tech, a.Admin, a.AuxBilling)
+	if len(a.Nameservers) > 0 {
+		params["Nameservers"] = strings.Join(a.Nameservers, ",")
+	}
+	if a.AddFreeWhoisguard != nil {
+		params["AddFreeWhoisguard"] = yesNo(*a.AddFreeWhoisguard)
+	}
+	if a.WGEnabled != nil {
+		params["WGEnabled"] = yesNo(*a.WGEnabled)
+	}
+	if a.IsPremiumDomain {
+		params["IsPremiumDomain"] = "true"
+		params["PremiumPrice"] = a.PremiumPrice.String()
+		setIfNotEmpty(params, "EapFee", a.EapFee.String())
+	}
+	return params
+}
+
+// premiumGuard enforces the money-safety contract shared by every
+// charge-bearing call that accepts premium pricing. See CreateWithContext for
+// the documented contract.
+func premiumGuard(isPremium bool, premiumPrice, eapFee Amount) error {
+	if isPremium {
+		if premiumPrice == "" {
+			return &InvalidArgumentsError{
+				Fields: []string{"PremiumPrice"},
+				Reason: "IsPremiumDomain is set but PremiumPrice is empty; a premium purchase requires an explicit price",
+			}
+		}
+		return nil
+	}
+
+	stray := make([]string, 0, 2)
+	if premiumPrice != "" {
+		stray = append(stray, "PremiumPrice")
+	}
+	if eapFee != "" {
+		stray = append(stray, "EapFee")
+	}
+	if len(stray) > 0 {
+		return &InvalidArgumentsError{
+			Fields: stray,
+			Reason: "premium pricing is set while IsPremiumDomain is false",
+		}
+	}
+	return nil
+}
+
+// yesNo maps a boolean onto Namecheap's "Yes"/"No" string convention.
+func yesNo(v bool) string {
+	if v {
+		return "Yes"
+	}
+	return "No"
+}

--- a/namecheap/domains_create_test.go
+++ b/namecheap/domains_create_test.go
@@ -1,0 +1,266 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// validContactInfo returns a fully-populated ContactInfo for use as any of the
+// four contact blocks in create/setContacts tests.
+func validContactInfo() ContactInfo {
+	return ContactInfo{
+		FirstName:        "John",
+		LastName:         "Smith",
+		Address1:         "8939 S.cross Blvd",
+		City:             "Phoenix",
+		StateProvince:    "AZ",
+		PostalCode:       "85284",
+		Country:          "US",
+		Phone:            "+1.6613102107",
+		EmailAddress:     "john@example.com",
+		OrganizationName: "NameCheap.com",
+		JobTitle:         "Dev",
+		Address2:         "Suite 600",
+	}
+}
+
+// validCreateArgs returns create args that pass validation, ready to be tweaked
+// per test.
+func validCreateArgs() *DomainsCreateArgs {
+	return &DomainsCreateArgs{
+		DomainName: "example.com",
+		Years:      2,
+		Registrant: validContactInfo(),
+		Tech:       validContactInfo(),
+		Admin:      validContactInfo(),
+		AuxBilling: validContactInfo(),
+	}
+}
+
+const domainsCreateOKResponse = `
+	<?xml version="1.0" encoding="utf-8"?>
+	<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+		<Errors />
+		<Warnings />
+		<RequestedCommand>namecheap.domains.create</RequestedCommand>
+		<CommandResponse Type="namecheap.domains.create">
+			<DomainCreateResult Domain="example.com" Registered="true" ChargedAmount="10.87" DomainID="1234567" OrderID="987654" TransactionID="112233" WhoisguardEnable="true" NonRealTimeDomain="false" />
+		</CommandResponse>
+		<Server>PHX01SBAPIEXT06</Server>
+		<GMTTimeDifference>--4:00</GMTTimeDifference>
+		<ExecutionTime>1.234</ExecutionTime>
+	</ApiResponse>
+`
+
+func TestDomainsService_Create(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse_and_command", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			query, _ := url.ParseQuery(string(body))
+			sentBody = query
+			_, _ = writer.Write([]byte(domainsCreateOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.Domains.CreateWithContext(context.Background(), validCreateArgs())
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.domains.create", sentBody.Get("Command"))
+		assert.Equal(t, "example.com", sentBody.Get("DomainName"))
+		assert.Equal(t, "2", sentBody.Get("Years"))
+		assert.Equal(t, "John", sentBody.Get("RegistrantFirstName"))
+		assert.Equal(t, "john@example.com", sentBody.Get("AuxBillingEmailAddress"))
+
+		result := resp.DomainCreateResult
+		assert.Equal(t, "example.com", *result.Domain)
+		assert.Equal(t, true, *result.Registered)
+		assert.Equal(t, 1234567, *result.DomainID)
+		assert.Equal(t, 987654, *result.OrderID)
+		assert.Equal(t, 112233, *result.TransactionID)
+	})
+
+	t.Run("money_preserved_exactly_as_string", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(domainsCreateOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.Domains.CreateWithContext(context.Background(), validCreateArgs())
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		// 10.87 cannot be represented exactly in binary floating point; assert the
+		// exact string is preserved by the Amount type (never parsed to float64).
+		assert.Equal(t, Amount("10.87"), *resp.DomainCreateResult.ChargedAmount)
+		assert.Equal(t, "10.87", resp.DomainCreateResult.ChargedAmount.String())
+	})
+
+	t.Run("nil_args", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.Domains.CreateWithContext(context.Background(), nil)
+		var argErr *InvalidArgumentsError
+		assert.True(t, errors.As(err, &argErr))
+	})
+
+	t.Run("missing_contact_fields_reported_all_at_once", func(t *testing.T) {
+		t.Parallel()
+		var called int32
+		mockServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&called, 1)
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		args := validCreateArgs()
+		args.Registrant.FirstName = ""
+		args.Tech.EmailAddress = ""
+		args.Admin.City = ""
+
+		_, err := client.Domains.CreateWithContext(context.Background(), args)
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "RegistrantFirstName")
+			assert.Contains(t, argErr.Fields, "TechEmailAddress")
+			assert.Contains(t, argErr.Fields, "AdminCity")
+			assert.Contains(t, err.Error(), "RegistrantFirstName")
+			assert.Contains(t, err.Error(), "TechEmailAddress")
+			assert.Contains(t, err.Error(), "AdminCity")
+		}
+		assert.Equal(t, int32(0), atomic.LoadInt32(&called), "no HTTP call may happen when validation fails")
+	})
+
+	t.Run("premium_guard_blocks_missing_price_no_http", func(t *testing.T) {
+		t.Parallel()
+		var called int32
+		mockServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&called, 1)
+			t.Errorf("server must not be called when the premium guard trips")
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		args := validCreateArgs()
+		args.IsPremiumDomain = true // PremiumPrice deliberately left empty
+
+		_, err := client.Domains.CreateWithContext(context.Background(), args)
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "PremiumPrice")
+		}
+		assert.Equal(t, int32(0), atomic.LoadInt32(&called), "no charge-bearing call may happen")
+	})
+
+	t.Run("premium_guard_blocks_inconsistent_pricing", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "http://127.0.0.1:0" // must never be reached
+
+		args := validCreateArgs()
+		args.IsPremiumDomain = false
+		args.PremiumPrice = Amount("99.99")
+
+		_, err := client.Domains.CreateWithContext(context.Background(), args)
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "PremiumPrice")
+		}
+	})
+
+	t.Run("premium_success_sends_price", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = writer.Write([]byte(domainsCreateOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		args := validCreateArgs()
+		args.IsPremiumDomain = true
+		args.PremiumPrice = Amount("13000.0000")
+		args.EapFee = Amount("2.5000")
+
+		_, err := client.Domains.CreateWithContext(context.Background(), args)
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+		assert.Equal(t, "true", sentBody.Get("IsPremiumDomain"))
+		assert.Equal(t, "13000.0000", sentBody.Get("PremiumPrice"))
+		assert.Equal(t, "2.5000", sentBody.Get("EapFee"))
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+				<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+					<Errors><Error Number="2011170">Promotion code is invalid</Error></Errors>
+					<CommandResponse/>
+				</ApiResponse>`))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.Domains.CreateWithContext(context.Background(), validCreateArgs())
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2011170, apiErr.Number)
+		}
+		assert.True(t, errors.Is(err, ErrPromotionCodeInvalid))
+	})
+
+	t.Run("non_idempotent_no_retry_on_server_error", func(t *testing.T) {
+		t.Parallel()
+		var calls int32
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&calls, 1)
+			_, _ = writer.Write([]byte(apiErrorXML(5050900, "Server exception")))
+		}))
+		defer mockServer.Close()
+
+		client := newResilienceClient(mockServer.URL, func(o *ClientOptions) {
+			o.RateLimit = &RateLimitOptions{Disabled: true}
+			o.Retry = &RetryOptions{MaxAttempts: 4, BaseDelay: time.Millisecond, MaxDelay: 2 * time.Millisecond}
+		})
+
+		_, err := client.Domains.CreateWithContext(context.Background(), validCreateArgs())
+		var apiErr *APIError
+		assert.True(t, errors.As(err, &apiErr))
+		assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "a charge-bearing call must not be retried on an ambiguous server error")
+		assert.NotContains(t, err.Error(), "after")
+	})
+}

--- a/namecheap/domains_get_contacts.go
+++ b/namecheap/domains_get_contacts.go
@@ -1,0 +1,63 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+)
+
+// DomainsGetContactsResponse is the raw envelope for namecheap.domains.getContacts.
+type DomainsGetContactsResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *DomainsGetContactsCommandResponse `xml:"CommandResponse"`
+}
+
+// DomainsGetContactsCommandResponse wraps the getContacts result.
+type DomainsGetContactsCommandResponse struct {
+	DomainContactsResult *DomainsGetContactsResult `xml:"DomainContactsResult"`
+}
+
+// DomainsGetContactsResult holds the domain identity and its four contact
+// blocks. The Domain/DomainNameID/ReadOnly fields follow the getContacts
+// response table in docs/namecheap-api-v2.md (lines 113-116); the contact blocks
+// reuse the shared ContactInfo type.
+type DomainsGetContactsResult struct {
+	// Domain is the registered domain name.
+	Domain *string `xml:"Domain,attr"`
+	// DomainNameID is the unique integer identifying the domain (the doc labels
+	// this "DomainnameID"; the wire attribute is lower-case).
+	DomainNameID *int `xml:"domainnameid,attr"`
+	// ReadOnly indicates whether the contact information is read-only.
+	ReadOnly *bool `xml:"Readonly,attr"`
+
+	// Registrant, Tech, Admin and AuxBilling are the domain's contact blocks.
+	Registrant *ContactInfo `xml:"Registrant"`
+	Tech       *ContactInfo `xml:"Tech"`
+	Admin      *ContactInfo `xml:"Admin"`
+	AuxBilling *ContactInfo `xml:"AuxBilling"`
+}
+
+// GetContactsWithContext returns the contact information for the requested
+// domain. It is a read-only, idempotent call.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/domains/get-contacts/
+func (ds *DomainsService) GetContactsWithContext(ctx context.Context, domain string) (*DomainsGetContactsCommandResponse, error) {
+	if domain == "" {
+		return nil, &InvalidArgumentsError{Fields: []string{"DomainName"}}
+	}
+
+	var response DomainsGetContactsResponse
+	params := map[string]string{
+		"Command":    "namecheap.domains.getContacts",
+		"DomainName": domain,
+	}
+
+	_, err := ds.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/domains_get_contacts_test.go
+++ b/namecheap/domains_get_contacts_test.go
@@ -1,0 +1,123 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const domainsGetContactsOKResponse = `
+	<?xml version="1.0" encoding="utf-8"?>
+	<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+		<Errors />
+		<Warnings />
+		<RequestedCommand>namecheap.domains.getContacts</RequestedCommand>
+		<CommandResponse Type="namecheap.domains.getContacts">
+			<DomainContactsResult Domain="example.com" domainnameid="30586" Readonly="false">
+				<Registrant>
+					<OrganizationName>NameCheap.com</OrganizationName>
+					<JobTitle>CEO</JobTitle>
+					<FirstName>John</FirstName>
+					<LastName>Smith</LastName>
+					<Address1>8939 S.cross Blvd</Address1>
+					<Address2>Suite 600</Address2>
+					<City>Phoenix</City>
+					<StateProvince>AZ</StateProvince>
+					<PostalCode>85284</PostalCode>
+					<Country>US</Country>
+					<Phone>+1.6613102107</Phone>
+					<EmailAddress>john@example.com</EmailAddress>
+				</Registrant>
+				<Tech>
+					<FirstName>Tech</FirstName>
+					<LastName>Person</LastName>
+					<EmailAddress>tech@example.com</EmailAddress>
+				</Tech>
+				<Admin>
+					<FirstName>Admin</FirstName>
+					<LastName>Person</LastName>
+				</Admin>
+				<AuxBilling>
+					<FirstName>Billing</FirstName>
+					<LastName>Person</LastName>
+				</AuxBilling>
+			</DomainContactsResult>
+		</CommandResponse>
+		<Server>PHX01SBAPIEXT06</Server>
+		<GMTTimeDifference>--4:00</GMTTimeDifference>
+		<ExecutionTime>0.5</ExecutionTime>
+	</ApiResponse>
+`
+
+func TestDomainsService_GetContacts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse_and_command", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = writer.Write([]byte(domainsGetContactsOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.Domains.GetContactsWithContext(context.Background(), "example.com")
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.domains.getContacts", sentBody.Get("Command"))
+		assert.Equal(t, "example.com", sentBody.Get("DomainName"))
+
+		result := resp.DomainContactsResult
+		assert.Equal(t, "example.com", *result.Domain)
+		assert.Equal(t, 30586, *result.DomainNameID)
+		assert.Equal(t, false, *result.ReadOnly)
+		assert.Equal(t, "John", result.Registrant.FirstName)
+		assert.Equal(t, "john@example.com", result.Registrant.EmailAddress)
+		assert.Equal(t, "NameCheap.com", result.Registrant.OrganizationName)
+		assert.Equal(t, "tech@example.com", result.Tech.EmailAddress)
+		assert.Equal(t, "Admin", result.Admin.FirstName)
+		assert.Equal(t, "Billing", result.AuxBilling.FirstName)
+	})
+
+	t.Run("empty_domain", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.Domains.GetContactsWithContext(context.Background(), "")
+		var argErr *InvalidArgumentsError
+		assert.True(t, errors.As(err, &argErr))
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+				<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+					<Errors><Error Number="2019166">Domain not found</Error></Errors>
+					<CommandResponse/>
+				</ApiResponse>`))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.Domains.GetContactsWithContext(context.Background(), "notfound.com")
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2019166, apiErr.Number)
+		}
+		assert.True(t, errors.Is(err, ErrDomainNotFound))
+	})
+}

--- a/namecheap/domains_get_registrar_lock.go
+++ b/namecheap/domains_get_registrar_lock.go
@@ -1,0 +1,53 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+)
+
+// DomainsGetRegistrarLockResponse is the raw envelope for
+// namecheap.domains.getRegistrarLock.
+type DomainsGetRegistrarLockResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *DomainsGetRegistrarLockCommandResponse `xml:"CommandResponse"`
+}
+
+// DomainsGetRegistrarLockCommandResponse wraps the getRegistrarLock result.
+type DomainsGetRegistrarLockCommandResponse struct {
+	DomainGetRegistrarLockResult *DomainsGetRegistrarLockResult `xml:"DomainGetRegistrarLockResult"`
+}
+
+// DomainsGetRegistrarLockResult is the outcome of a getRegistrarLock call.
+// Fields follow the response table in docs/namecheap-api-v2.md (lines 337-340).
+type DomainsGetRegistrarLockResult struct {
+	// Domain is the domain that was queried.
+	Domain *string `xml:"Domain,attr"`
+	// RegistrarLockStatus is true when the registrar lock is set.
+	RegistrarLockStatus *bool `xml:"RegistrarLockStatus,attr"`
+}
+
+// GetRegistrarLockWithContext returns the registrar-lock status of a domain. It
+// is a read-only, idempotent call.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/domains/get-registrar-lock/
+func (ds *DomainsService) GetRegistrarLockWithContext(ctx context.Context, domain string) (*DomainsGetRegistrarLockCommandResponse, error) {
+	if domain == "" {
+		return nil, &InvalidArgumentsError{Fields: []string{"DomainName"}}
+	}
+
+	var response DomainsGetRegistrarLockResponse
+	params := map[string]string{
+		"Command":    "namecheap.domains.getRegistrarLock",
+		"DomainName": domain,
+	}
+
+	_, err := ds.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/domains_get_registrar_lock_test.go
+++ b/namecheap/domains_get_registrar_lock_test.go
@@ -1,0 +1,85 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const domainsGetRegistrarLockOKResponse = `
+	<?xml version="1.0" encoding="utf-8"?>
+	<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+		<Errors />
+		<Warnings />
+		<RequestedCommand>namecheap.domains.getRegistrarLock</RequestedCommand>
+		<CommandResponse Type="namecheap.domains.getRegistrarLock">
+			<DomainGetRegistrarLockResult Domain="example.com" RegistrarLockStatus="true" />
+		</CommandResponse>
+		<Server>PHX01SBAPIEXT06</Server>
+		<GMTTimeDifference>--4:00</GMTTimeDifference>
+		<ExecutionTime>0.5</ExecutionTime>
+	</ApiResponse>
+`
+
+func TestDomainsService_GetRegistrarLock(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse_and_command", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = writer.Write([]byte(domainsGetRegistrarLockOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.Domains.GetRegistrarLockWithContext(context.Background(), "example.com")
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.domains.getRegistrarLock", sentBody.Get("Command"))
+		assert.Equal(t, "example.com", sentBody.Get("DomainName"))
+		assert.Equal(t, "example.com", *resp.DomainGetRegistrarLockResult.Domain)
+		assert.Equal(t, true, *resp.DomainGetRegistrarLockResult.RegistrarLockStatus)
+	})
+
+	t.Run("empty_domain", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.Domains.GetRegistrarLockWithContext(context.Background(), "")
+		var argErr *InvalidArgumentsError
+		assert.True(t, errors.As(err, &argErr))
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+				<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+					<Errors><Error Number="2019166">Domain not found</Error></Errors>
+					<CommandResponse/>
+				</ApiResponse>`))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.Domains.GetRegistrarLockWithContext(context.Background(), "notfound.com")
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2019166, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/domains_get_tld_list.go
+++ b/namecheap/domains_get_tld_list.go
@@ -1,0 +1,74 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+)
+
+// DomainsGetTldListResponse is the raw envelope for namecheap.domains.getTldList.
+type DomainsGetTldListResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *DomainsGetTldListCommandResponse `xml:"CommandResponse"`
+}
+
+// DomainsGetTldListCommandResponse wraps the list of TLD entries.
+type DomainsGetTldListCommandResponse struct {
+	Tlds *[]TldListEntry `xml:"Tlds>Tld"`
+}
+
+// TldListEntry describes a single top-level domain and its API capabilities.
+// Fields follow the getTldList response table in docs/namecheap-api-v2.md
+// (lines 190-201). Go field names normalize the "Api" initialism to "API"; the
+// struct tags carry the exact wire attribute names.
+type TldListEntry struct {
+	// Name is the top-level domain, e.g. "com".
+	Name *string `xml:"Name,attr"`
+	// NonRealTimeDomain reports whether registration is non-instant.
+	NonRealTimeDomain *bool `xml:"NonRealTimeDomain,attr"`
+	// MinRegisterYears is the minimum registration term in years.
+	MinRegisterYears *int `xml:"MinRegisterYears,attr"`
+	// MaxRegisterYears is the maximum registration term in years.
+	MaxRegisterYears *int `xml:"MaxRegisterYears,attr"`
+	// MinRenewYears is the minimum renewal term in years.
+	MinRenewYears *int `xml:"MinRenewYears,attr"`
+	// MaxRenewYears is the maximum renewal term in years.
+	MaxRenewYears *int `xml:"MaxRenewYears,attr"`
+	// MinTransferYears is the minimum transfer term in years.
+	MinTransferYears *int `xml:"MinTransferYears,attr"`
+	// MaxTransferYears is the maximum transfer term in years.
+	MaxTransferYears *int `xml:"MaxTransferYears,attr"`
+	// IsAPIRegisterable reports whether the TLD can be registered via the API.
+	IsAPIRegisterable *bool `xml:"IsApiRegisterable,attr"`
+	// IsAPIRenewable reports whether the TLD can be renewed via the API.
+	IsAPIRenewable *bool `xml:"IsApiRenewable,attr"`
+	// IsAPITransferable reports whether the TLD can be transferred via the API.
+	IsAPITransferable *bool `xml:"IsApiTransferable,attr"`
+	// IsEppRequired reports whether an EPP code is required for the TLD.
+	IsEppRequired *bool `xml:"IsEppRequired,attr"`
+}
+
+// GetTldListWithContext returns the full list of TLDs and their per-TLD API
+// capabilities.
+//
+// This is a heavyweight call: it returns Namecheap's entire TLD catalogue (many
+// hundreds of entries) and the data changes rarely, so it is a good candidate to
+// fetch once and cache rather than call on a hot path. It is a read-only,
+// idempotent call and takes no parameters.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/domains/get-tld-list/
+func (ds *DomainsService) GetTldListWithContext(ctx context.Context) (*DomainsGetTldListCommandResponse, error) {
+	var response DomainsGetTldListResponse
+	params := map[string]string{
+		"Command": "namecheap.domains.getTldList",
+	}
+
+	_, err := ds.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/domains_get_tld_list_test.go
+++ b/namecheap/domains_get_tld_list_test.go
@@ -1,0 +1,95 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const domainsGetTldListOKResponse = `
+	<?xml version="1.0" encoding="utf-8"?>
+	<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+		<Errors />
+		<Warnings />
+		<RequestedCommand>namecheap.domains.getTldList</RequestedCommand>
+		<CommandResponse Type="namecheap.domains.getTldList">
+			<Tlds>
+				<Tld Name="com" NonRealTimeDomain="false" MinRegisterYears="1" MaxRegisterYears="10" MinRenewYears="1" MaxRenewYears="10" MinTransferYears="1" MaxTransferYears="1" IsApiRegisterable="true" IsApiRenewable="true" IsApiTransferable="false" IsEppRequired="true">.com domain</Tld>
+				<Tld Name="net" NonRealTimeDomain="false" MinRegisterYears="1" MaxRegisterYears="10" MinRenewYears="1" MaxRenewYears="10" MinTransferYears="1" MaxTransferYears="1" IsApiRegisterable="true" IsApiRenewable="true" IsApiTransferable="true" IsEppRequired="false">.net domain</Tld>
+			</Tlds>
+		</CommandResponse>
+		<Server>PHX01SBAPIEXT06</Server>
+		<GMTTimeDifference>--4:00</GMTTimeDifference>
+		<ExecutionTime>0.9</ExecutionTime>
+	</ApiResponse>
+`
+
+func TestDomainsService_GetTldList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse_and_command", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = writer.Write([]byte(domainsGetTldListOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.Domains.GetTldListWithContext(context.Background())
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.domains.getTldList", sentBody.Get("Command"))
+
+		tlds := *resp.Tlds
+		assert.Len(t, tlds, 2)
+
+		com := tlds[0]
+		assert.Equal(t, "com", *com.Name)
+		assert.Equal(t, false, *com.NonRealTimeDomain)
+		assert.Equal(t, 1, *com.MinRegisterYears)
+		assert.Equal(t, 10, *com.MaxRegisterYears)
+		assert.Equal(t, true, *com.IsAPIRegisterable)
+		assert.Equal(t, true, *com.IsAPIRenewable)
+		assert.Equal(t, false, *com.IsAPITransferable)
+		assert.Equal(t, true, *com.IsEppRequired)
+
+		net := tlds[1]
+		assert.Equal(t, "net", *net.Name)
+		assert.Equal(t, true, *net.IsAPITransferable)
+		assert.Equal(t, false, *net.IsEppRequired)
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+				<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+					<Errors><Error Number="5050900">Unknown exceptions</Error></Errors>
+					<CommandResponse/>
+				</ApiResponse>`))
+		}))
+		defer mockServer.Close()
+
+		client := setupNoRetryClient()
+		client.BaseURL = mockServer.URL
+
+		_, err := client.Domains.GetTldListWithContext(context.Background())
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 5050900, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/domains_reactivate.go
+++ b/namecheap/domains_reactivate.go
@@ -1,0 +1,112 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// DomainsReactivateResponse is the raw envelope for namecheap.domains.reactivate.
+type DomainsReactivateResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *DomainsReactivateCommandResponse `xml:"CommandResponse"`
+}
+
+// DomainsReactivateCommandResponse wraps the reactivate result.
+type DomainsReactivateCommandResponse struct {
+	DomainReactivateResult *DomainsReactivateResult `xml:"DomainReactivateResult"`
+}
+
+// DomainsReactivateResult is the outcome of a reactivation. Fields follow the
+// reactivate response table in docs/namecheap-api-v2.md (lines 284-290).
+type DomainsReactivateResult struct {
+	// Domain is the domain that was reactivated (the doc labels this "DomainName").
+	Domain *string `xml:"Domain,attr"`
+	// IsSuccess indicates whether the domain was reactivated successfully.
+	IsSuccess *bool `xml:"IsSuccess,attr"`
+	// ChargedAmount is the total amount charged for the reactivation, kept as an
+	// exact decimal string (see Amount).
+	ChargedAmount *Amount `xml:"ChargedAmount,attr"`
+	// OrderID is the unique integer identifying the order.
+	OrderID *int `xml:"OrderID,attr"`
+	// TransactionID is the unique integer identifying the transaction.
+	TransactionID *int `xml:"TransactionID,attr"`
+}
+
+// DomainsReactivateArgs are the arguments for ReactivateWithContext. Field names
+// and required/optional status follow the reactivate request table in
+// docs/namecheap-api-v2.md (lines 275-280).
+type DomainsReactivateArgs struct {
+	// DomainName is the expired domain to reactivate. Required.
+	DomainName string
+	// PromotionCode is an optional promotional code.
+	PromotionCode string
+	// YearsToAdd is the optional number of years to add after expiry. When 0 the
+	// parameter is omitted and the API default applies.
+	YearsToAdd int
+	// IsPremiumDomain must be true to reactivate a premium domain; when true,
+	// PremiumPrice is mandatory (see the premium guard on ReactivateWithContext).
+	IsPremiumDomain bool
+	// PremiumPrice is the agreed reactivation price for a premium domain, as an
+	// exact decimal string (see Amount). Required when IsPremiumDomain is true;
+	// must be empty otherwise.
+	PremiumPrice Amount
+}
+
+// ReactivateWithContext reactivates an expired domain.
+//
+// It is a charge-bearing, non-idempotent call: on an ambiguous transport or
+// server-side failure the SDK does NOT retry (a resend could double-charge), so
+// the caller must reconcile such failures via the account order history.
+//
+// The same premium guard as CreateWithContext applies: when IsPremiumDomain is
+// true PremiumPrice must be set, and when it is false PremiumPrice must be
+// empty. A violation returns an *InvalidArgumentsError before the request is
+// sent, so no charge can occur.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/domains/reactivate/
+func (ds *DomainsService) ReactivateWithContext(ctx context.Context, args *DomainsReactivateArgs) (*DomainsReactivateCommandResponse, error) {
+	if args == nil {
+		return nil, &InvalidArgumentsError{Fields: []string{"args"}, Reason: "args must not be nil"}
+	}
+	if err := args.validate(); err != nil {
+		return nil, err
+	}
+
+	var response DomainsReactivateResponse
+	// idempotent=false: never retry a charge-bearing call on an ambiguous error.
+	_, err := ds.client.doXML(ctx, args.params(), &response, false)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}
+
+// validate reports a missing domain and applies the premium guard.
+func (a *DomainsReactivateArgs) validate() error {
+	if a.DomainName == "" {
+		return &InvalidArgumentsError{Fields: []string{"DomainName"}}
+	}
+	return premiumGuard(a.IsPremiumDomain, a.PremiumPrice, "")
+}
+
+// params flattens the validated args into the request map.
+func (a *DomainsReactivateArgs) params() map[string]string {
+	params := map[string]string{
+		"Command":    "namecheap.domains.reactivate",
+		"DomainName": a.DomainName,
+	}
+	setIfNotEmpty(params, "PromotionCode", a.PromotionCode)
+	if a.YearsToAdd > 0 {
+		params["YearsToAdd"] = strconv.Itoa(a.YearsToAdd)
+	}
+	if a.IsPremiumDomain {
+		params["IsPremiumDomain"] = "true"
+		params["PremiumPrice"] = a.PremiumPrice.String()
+	}
+	return params
+}

--- a/namecheap/domains_reactivate_test.go
+++ b/namecheap/domains_reactivate_test.go
@@ -1,0 +1,117 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const domainsReactivateOKResponse = `
+	<?xml version="1.0" encoding="utf-8"?>
+	<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+		<Errors />
+		<Warnings />
+		<RequestedCommand>namecheap.domains.reactivate</RequestedCommand>
+		<CommandResponse Type="namecheap.domains.reactivate">
+			<DomainReactivateResult Domain="example.com" IsSuccess="true" ChargedAmount="650.78" OrderID="23628" TransactionID="24581" />
+		</CommandResponse>
+		<Server>PHX01SBAPIEXT06</Server>
+		<GMTTimeDifference>--4:00</GMTTimeDifference>
+		<ExecutionTime>1.234</ExecutionTime>
+	</ApiResponse>
+`
+
+func TestDomainsService_Reactivate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse_and_command", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = writer.Write([]byte(domainsReactivateOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.Domains.ReactivateWithContext(context.Background(), &DomainsReactivateArgs{
+			DomainName: "example.com",
+			YearsToAdd: 1,
+		})
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.domains.reactivate", sentBody.Get("Command"))
+		assert.Equal(t, "example.com", sentBody.Get("DomainName"))
+		assert.Equal(t, "1", sentBody.Get("YearsToAdd"))
+
+		result := resp.DomainReactivateResult
+		assert.Equal(t, "example.com", *result.Domain)
+		assert.Equal(t, true, *result.IsSuccess)
+		assert.Equal(t, Amount("650.78"), *result.ChargedAmount)
+		assert.Equal(t, 23628, *result.OrderID)
+		assert.Equal(t, 24581, *result.TransactionID)
+	})
+
+	t.Run("nil_args", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.Domains.ReactivateWithContext(context.Background(), nil)
+		var argErr *InvalidArgumentsError
+		assert.True(t, errors.As(err, &argErr))
+	})
+
+	t.Run("missing_domain", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.Domains.ReactivateWithContext(context.Background(), &DomainsReactivateArgs{})
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "DomainName")
+		}
+	})
+
+	t.Run("premium_guard_blocks_missing_price", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.Domains.ReactivateWithContext(context.Background(), &DomainsReactivateArgs{
+			DomainName:      "example.com",
+			IsPremiumDomain: true,
+		})
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "PremiumPrice")
+		}
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+				<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+					<Errors><Error Number="2019166">Domain not found</Error></Errors>
+					<CommandResponse/>
+				</ApiResponse>`))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.Domains.ReactivateWithContext(context.Background(), &DomainsReactivateArgs{DomainName: "notfound.com"})
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2019166, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/domains_renew.go
+++ b/namecheap/domains_renew.go
@@ -1,0 +1,118 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// DomainsRenewResponse is the raw envelope for namecheap.domains.renew.
+type DomainsRenewResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *DomainsRenewCommandResponse `xml:"CommandResponse"`
+}
+
+// DomainsRenewCommandResponse wraps the renew result.
+type DomainsRenewCommandResponse struct {
+	DomainRenewResult *DomainsRenewResult `xml:"DomainRenewResult"`
+}
+
+// DomainsRenewResult is the outcome of a renewal. Fields follow the renew
+// response table in docs/namecheap-api-v2.md (lines 311-319).
+type DomainsRenewResult struct {
+	// DomainName is the domain that was renewed.
+	DomainName *string `xml:"DomainName,attr"`
+	// DomainID is the unique integer identifying the domain.
+	DomainID *int `xml:"DomainID,attr"`
+	// Renew indicates whether the domain was renewed successfully.
+	Renew *bool `xml:"Renew,attr"`
+	// ChargedAmount is the total amount charged for the renewal, kept as an exact
+	// decimal string (see Amount).
+	ChargedAmount *Amount `xml:"ChargedAmount,attr"`
+	// OrderID is the unique integer identifying the order.
+	OrderID *int `xml:"OrderID,attr"`
+	// TransactionID is the unique integer identifying the transaction.
+	TransactionID *int `xml:"TransactionID,attr"`
+}
+
+// DomainsRenewArgs are the arguments for RenewWithContext. Field names and
+// required/optional status follow the renew request table in
+// docs/namecheap-api-v2.md (lines 302-308).
+type DomainsRenewArgs struct {
+	// DomainName is the domain to renew. Required.
+	DomainName string
+	// Years is the number of years to renew for. Required (>= 1).
+	Years int
+	// PromotionCode is an optional promotional code.
+	PromotionCode string
+	// IsPremiumDomain must be true to renew a premium domain; when true,
+	// PremiumPrice is mandatory (see the premium guard on RenewWithContext).
+	IsPremiumDomain bool
+	// PremiumPrice is the agreed renewal price for a premium domain, as an exact
+	// decimal string (see Amount). Required when IsPremiumDomain is true; must be
+	// empty otherwise.
+	PremiumPrice Amount
+}
+
+// RenewWithContext renews an expiring domain.
+//
+// It is a charge-bearing, non-idempotent call: on an ambiguous transport or
+// server-side failure the SDK does NOT retry (a resend could double-charge), so
+// the caller must reconcile such failures via the account order history.
+//
+// The same premium guard as CreateWithContext applies: when IsPremiumDomain is
+// true PremiumPrice must be set, and when it is false PremiumPrice must be
+// empty. A violation returns an *InvalidArgumentsError before the request is
+// sent, so no charge can occur.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/domains/renew/
+func (ds *DomainsService) RenewWithContext(ctx context.Context, args *DomainsRenewArgs) (*DomainsRenewCommandResponse, error) {
+	if args == nil {
+		return nil, &InvalidArgumentsError{Fields: []string{"args"}, Reason: "args must not be nil"}
+	}
+	if err := args.validate(); err != nil {
+		return nil, err
+	}
+
+	var response DomainsRenewResponse
+	// idempotent=false: never retry a charge-bearing call on an ambiguous error.
+	_, err := ds.client.doXML(ctx, args.params(), &response, false)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}
+
+// validate reports missing required fields and applies the premium guard.
+func (a *DomainsRenewArgs) validate() error {
+	missing := make([]string, 0, 2)
+	if a.DomainName == "" {
+		missing = append(missing, "DomainName")
+	}
+	if a.Years < 1 {
+		missing = append(missing, "Years")
+	}
+	if len(missing) > 0 {
+		return &InvalidArgumentsError{Fields: missing}
+	}
+	return premiumGuard(a.IsPremiumDomain, a.PremiumPrice, "")
+}
+
+// params flattens the validated args into the request map.
+func (a *DomainsRenewArgs) params() map[string]string {
+	params := map[string]string{
+		"Command":    "namecheap.domains.renew",
+		"DomainName": a.DomainName,
+		"Years":      strconv.Itoa(a.Years),
+	}
+	setIfNotEmpty(params, "PromotionCode", a.PromotionCode)
+	if a.IsPremiumDomain {
+		params["IsPremiumDomain"] = "true"
+		params["PremiumPrice"] = a.PremiumPrice.String()
+	}
+	return params
+}

--- a/namecheap/domains_renew_test.go
+++ b/namecheap/domains_renew_test.go
@@ -1,0 +1,148 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const domainsRenewOKResponse = `
+	<?xml version="1.0" encoding="utf-8"?>
+	<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+		<Errors />
+		<Warnings />
+		<RequestedCommand>namecheap.domains.renew</RequestedCommand>
+		<CommandResponse Type="namecheap.domains.renew">
+			<DomainRenewResult DomainName="example.com" DomainID="1234567" Renew="true" OrderID="987654" TransactionID="112233" ChargedAmount="9.56">
+				<DomainDetails>
+					<ExpiredDate>10/13/2027</ExpiredDate>
+					<NumYears>0</NumYears>
+				</DomainDetails>
+			</DomainRenewResult>
+		</CommandResponse>
+		<Server>PHX01SBAPIEXT06</Server>
+		<GMTTimeDifference>--4:00</GMTTimeDifference>
+		<ExecutionTime>1.234</ExecutionTime>
+	</ApiResponse>
+`
+
+func TestDomainsService_Renew(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse_and_command", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = writer.Write([]byte(domainsRenewOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.Domains.RenewWithContext(context.Background(), &DomainsRenewArgs{
+			DomainName:    "example.com",
+			Years:         1,
+			PromotionCode: "PROMO",
+		})
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.domains.renew", sentBody.Get("Command"))
+		assert.Equal(t, "example.com", sentBody.Get("DomainName"))
+		assert.Equal(t, "1", sentBody.Get("Years"))
+		assert.Equal(t, "PROMO", sentBody.Get("PromotionCode"))
+
+		result := resp.DomainRenewResult
+		assert.Equal(t, "example.com", *result.DomainName)
+		assert.Equal(t, 1234567, *result.DomainID)
+		assert.Equal(t, true, *result.Renew)
+		assert.Equal(t, 987654, *result.OrderID)
+		assert.Equal(t, 112233, *result.TransactionID)
+		assert.Equal(t, Amount("9.56"), *result.ChargedAmount)
+	})
+
+	t.Run("nil_args", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.Domains.RenewWithContext(context.Background(), nil)
+		var argErr *InvalidArgumentsError
+		assert.True(t, errors.As(err, &argErr))
+	})
+
+	t.Run("missing_required_fields", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.Domains.RenewWithContext(context.Background(), &DomainsRenewArgs{})
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "DomainName")
+			assert.Contains(t, argErr.Fields, "Years")
+		}
+	})
+
+	t.Run("premium_guard_blocks_missing_price", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.Domains.RenewWithContext(context.Background(), &DomainsRenewArgs{
+			DomainName:      "example.com",
+			Years:           1,
+			IsPremiumDomain: true,
+		})
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "PremiumPrice")
+		}
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+				<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+					<Errors><Error Number="2019166">Domain not found</Error></Errors>
+					<CommandResponse/>
+				</ApiResponse>`))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.Domains.RenewWithContext(context.Background(), &DomainsRenewArgs{DomainName: "notfound.com", Years: 1})
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2019166, apiErr.Number)
+		}
+	})
+
+	t.Run("non_idempotent_no_retry_on_server_error", func(t *testing.T) {
+		t.Parallel()
+		var calls int32
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&calls, 1)
+			_, _ = writer.Write([]byte(apiErrorXML(5050900, "Server exception")))
+		}))
+		defer mockServer.Close()
+
+		client := newResilienceClient(mockServer.URL, func(o *ClientOptions) {
+			o.RateLimit = &RateLimitOptions{Disabled: true}
+			o.Retry = &RetryOptions{MaxAttempts: 4, BaseDelay: time.Millisecond, MaxDelay: 2 * time.Millisecond}
+		})
+
+		_, err := client.Domains.RenewWithContext(context.Background(), &DomainsRenewArgs{DomainName: "example.com", Years: 1})
+		assert.Error(t, err)
+		assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "a charge-bearing renew must not be retried on an ambiguous server error")
+	})
+}

--- a/namecheap/domains_set_contacts.go
+++ b/namecheap/domains_set_contacts.go
@@ -1,0 +1,79 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+)
+
+// DomainsSetContactsResponse is the raw envelope for namecheap.domains.setContacts.
+type DomainsSetContactsResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *DomainsSetContactsCommandResponse `xml:"CommandResponse"`
+}
+
+// DomainsSetContactsCommandResponse wraps the setContacts result.
+type DomainsSetContactsCommandResponse struct {
+	DomainSetContactResult *DomainsSetContactsResult `xml:"DomainSetContactResult"`
+}
+
+// DomainsSetContactsResult is the outcome of a setContacts call.
+type DomainsSetContactsResult struct {
+	// Domain is the domain whose contacts were set.
+	Domain *string `xml:"Domain,attr"`
+	// IsSuccess indicates whether the contacts were updated successfully.
+	IsSuccess *bool `xml:"IsSuccess,attr"`
+}
+
+// DomainsSetContactsArgs are the arguments for SetContactsWithContext. The four
+// contact blocks reuse the shared ContactInfo type and every required field on
+// each is validated up front. Field requirements follow the setContacts request
+// table in docs/namecheap-api-v2.md (lines 213-227).
+type DomainsSetContactsArgs struct {
+	// DomainName is the domain to set contacts for. Required.
+	DomainName string
+	// Registrant, Tech, Admin and AuxBilling are the four required contact
+	// blocks. Every required ContactInfo field must be set on each.
+	Registrant ContactInfo
+	Tech       ContactInfo
+	Admin      ContactInfo
+	AuxBilling ContactInfo
+}
+
+// SetContactsWithContext sets the contact information for a domain. It is not
+// charge-bearing, so it is treated as idempotent for retry purposes.
+//
+// All missing required contact fields (across every block) are reported at once
+// as an *InvalidArgumentsError before any request is sent.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/domains/set-contacts/
+func (ds *DomainsService) SetContactsWithContext(ctx context.Context, args *DomainsSetContactsArgs) (*DomainsSetContactsCommandResponse, error) {
+	if args == nil {
+		return nil, &InvalidArgumentsError{Fields: []string{"args"}, Reason: "args must not be nil"}
+	}
+
+	missing := make([]string, 0, 1)
+	if args.DomainName == "" {
+		missing = append(missing, "DomainName")
+	}
+	missing = append(missing, missingContactFields(args.Registrant, args.Tech, args.Admin, args.AuxBilling)...)
+	if len(missing) > 0 {
+		return nil, &InvalidArgumentsError{Fields: missing}
+	}
+
+	params := map[string]string{
+		"Command":    "namecheap.domains.setContacts",
+		"DomainName": args.DomainName,
+	}
+	applyContacts(params, args.Registrant, args.Tech, args.Admin, args.AuxBilling)
+
+	var response DomainsSetContactsResponse
+	_, err := ds.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/domains_set_contacts_test.go
+++ b/namecheap/domains_set_contacts_test.go
@@ -1,0 +1,125 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const domainsSetContactsOKResponse = `
+	<?xml version="1.0" encoding="utf-8"?>
+	<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+		<Errors />
+		<Warnings />
+		<RequestedCommand>namecheap.domains.setContacts</RequestedCommand>
+		<CommandResponse Type="namecheap.domains.setContacts">
+			<DomainSetContactResult Domain="example.com" IsSuccess="true" />
+		</CommandResponse>
+		<Server>PHX01SBAPIEXT06</Server>
+		<GMTTimeDifference>--4:00</GMTTimeDifference>
+		<ExecutionTime>0.5</ExecutionTime>
+	</ApiResponse>
+`
+
+func validSetContactsArgs() *DomainsSetContactsArgs {
+	return &DomainsSetContactsArgs{
+		DomainName: "example.com",
+		Registrant: validContactInfo(),
+		Tech:       validContactInfo(),
+		Admin:      validContactInfo(),
+		AuxBilling: validContactInfo(),
+	}
+}
+
+func TestDomainsService_SetContacts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse_and_command", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = writer.Write([]byte(domainsSetContactsOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.Domains.SetContactsWithContext(context.Background(), validSetContactsArgs())
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.domains.setContacts", sentBody.Get("Command"))
+		assert.Equal(t, "example.com", sentBody.Get("DomainName"))
+		assert.Equal(t, "John", sentBody.Get("RegistrantFirstName"))
+		assert.Equal(t, "Suite 600", sentBody.Get("TechAddress2"))
+		assert.Equal(t, "example.com", *resp.DomainSetContactResult.Domain)
+		assert.Equal(t, true, *resp.DomainSetContactResult.IsSuccess)
+	})
+
+	t.Run("nil_args", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.Domains.SetContactsWithContext(context.Background(), nil)
+		var argErr *InvalidArgumentsError
+		assert.True(t, errors.As(err, &argErr))
+	})
+
+	t.Run("missing_contact_fields_reported_all_at_once", func(t *testing.T) {
+		t.Parallel()
+		var called int32
+		mockServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&called, 1)
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		args := validSetContactsArgs()
+		args.Registrant.FirstName = ""
+		args.Registrant.LastName = ""
+		args.AuxBilling.Country = ""
+
+		_, err := client.Domains.SetContactsWithContext(context.Background(), args)
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "RegistrantFirstName")
+			assert.Contains(t, argErr.Fields, "RegistrantLastName")
+			assert.Contains(t, argErr.Fields, "AuxBillingCountry")
+			assert.GreaterOrEqual(t, len(argErr.Fields), 3, "every missing field must be listed, not just the first")
+		}
+		assert.Equal(t, int32(0), atomic.LoadInt32(&called), "no HTTP call may happen when validation fails")
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+				<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+					<Errors><Error Number="2016166">Domain is not associated with your account</Error></Errors>
+					<CommandResponse/>
+				</ApiResponse>`))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.Domains.SetContactsWithContext(context.Background(), validSetContactsArgs())
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2016166, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/domains_set_registrar_lock.go
+++ b/namecheap/domains_set_registrar_lock.go
@@ -1,0 +1,84 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+)
+
+// LockAction is the explicit registrar-lock action passed to
+// SetRegistrarLockWithContext. Using a dedicated type (rather than a bare bool)
+// keeps call sites self-documenting and maps directly onto the API's LOCK/UNLOCK
+// values.
+type LockAction string
+
+const (
+	// RegistrarLock locks the domain at the registrar (API value "LOCK").
+	RegistrarLock LockAction = "LOCK"
+	// RegistrarUnlock unlocks the domain at the registrar (API value "UNLOCK").
+	RegistrarUnlock LockAction = "UNLOCK"
+)
+
+// valid reports whether the action is one of the two supported values.
+func (a LockAction) valid() bool {
+	return a == RegistrarLock || a == RegistrarUnlock
+}
+
+// DomainsSetRegistrarLockResponse is the raw envelope for
+// namecheap.domains.setRegistrarLock.
+type DomainsSetRegistrarLockResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *DomainsSetRegistrarLockCommandResponse `xml:"CommandResponse"`
+}
+
+// DomainsSetRegistrarLockCommandResponse wraps the setRegistrarLock result.
+type DomainsSetRegistrarLockCommandResponse struct {
+	DomainSetRegistrarLockResult *DomainsSetRegistrarLockResult `xml:"DomainSetRegistrarLockResult"`
+}
+
+// DomainsSetRegistrarLockResult is the outcome of a setRegistrarLock call.
+// Fields follow the response table in docs/namecheap-api-v2.md (lines 359-362).
+type DomainsSetRegistrarLockResult struct {
+	// Domain is the domain whose lock status was set.
+	Domain *string `xml:"Domain,attr"`
+	// IsSuccess indicates whether the registrar lock was set successfully.
+	IsSuccess *bool `xml:"IsSuccess,attr"`
+}
+
+// SetRegistrarLockWithContext sets the registrar-lock status of a domain. Pass
+// RegistrarLock or RegistrarUnlock for action. It is not charge-bearing, so it
+// is treated as idempotent for retry purposes.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/domains/set-registrar-lock/
+func (ds *DomainsService) SetRegistrarLockWithContext(ctx context.Context, domain string, action LockAction) (*DomainsSetRegistrarLockCommandResponse, error) {
+	missing := make([]string, 0, 2)
+	if domain == "" {
+		missing = append(missing, "DomainName")
+	}
+	if !action.valid() {
+		missing = append(missing, "LockAction")
+	}
+	if len(missing) > 0 {
+		reason := ""
+		if !action.valid() {
+			reason = "LockAction must be RegistrarLock or RegistrarUnlock"
+		}
+		return nil, &InvalidArgumentsError{Fields: missing, Reason: reason}
+	}
+
+	var response DomainsSetRegistrarLockResponse
+	params := map[string]string{
+		"Command":    "namecheap.domains.setRegistrarLock",
+		"DomainName": domain,
+		"LockAction": string(action),
+	}
+
+	_, err := ds.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/domains_set_registrar_lock_test.go
+++ b/namecheap/domains_set_registrar_lock_test.go
@@ -1,0 +1,126 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const domainsSetRegistrarLockOKResponse = `
+	<?xml version="1.0" encoding="utf-8"?>
+	<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+		<Errors />
+		<Warnings />
+		<RequestedCommand>namecheap.domains.setRegistrarLock</RequestedCommand>
+		<CommandResponse Type="namecheap.domains.setRegistrarLock">
+			<DomainSetRegistrarLockResult Domain="example.com" IsSuccess="true" />
+		</CommandResponse>
+		<Server>PHX01SBAPIEXT06</Server>
+		<GMTTimeDifference>--4:00</GMTTimeDifference>
+		<ExecutionTime>0.5</ExecutionTime>
+	</ApiResponse>
+`
+
+func TestDomainsService_SetRegistrarLock(t *testing.T) {
+	t.Parallel()
+
+	t.Run("lock_sends_LOCK", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = writer.Write([]byte(domainsSetRegistrarLockOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.Domains.SetRegistrarLockWithContext(context.Background(), "example.com", RegistrarLock)
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+		assert.Equal(t, "namecheap.domains.setRegistrarLock", sentBody.Get("Command"))
+		assert.Equal(t, "example.com", sentBody.Get("DomainName"))
+		assert.Equal(t, "LOCK", sentBody.Get("LockAction"))
+		assert.Equal(t, true, *resp.DomainSetRegistrarLockResult.IsSuccess)
+	})
+
+	t.Run("unlock_sends_UNLOCK", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = writer.Write([]byte(domainsSetRegistrarLockOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.Domains.SetRegistrarLockWithContext(context.Background(), "example.com", RegistrarUnlock)
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+		assert.Equal(t, "UNLOCK", sentBody.Get("LockAction"))
+	})
+
+	t.Run("invalid_action_no_http", func(t *testing.T) {
+		t.Parallel()
+		var called int32
+		mockServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&called, 1)
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.Domains.SetRegistrarLockWithContext(context.Background(), "example.com", LockAction("SIDEWAYS"))
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "LockAction")
+		}
+		assert.Equal(t, int32(0), atomic.LoadInt32(&called))
+	})
+
+	t.Run("empty_domain", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.Domains.SetRegistrarLockWithContext(context.Background(), "", RegistrarLock)
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "DomainName")
+		}
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+				<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+					<Errors><Error Number="2019166">Domain not found</Error></Errors>
+					<CommandResponse/>
+				</ApiResponse>`))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.Domains.SetRegistrarLockWithContext(context.Background(), "notfound.com", RegistrarLock)
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2019166, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/errors.go
+++ b/namecheap/errors.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 )
 
 // maxSnippetBytes caps how many bytes of a malformed response body a ParseError
@@ -152,6 +153,40 @@ var (
 	// docs/namecheap-api-v2.md § Error Codes.
 	ErrServerError error = &sentinelError{name: "server error", numbers: serverErrorNumbers}
 )
+
+// InvalidArgumentsError is a client-side validation error returned before any
+// HTTP request is made, when method arguments are missing or inconsistent. It
+// reports every offending field at once (not just the first) so a caller can fix
+// them in a single pass.
+//
+// It is used for missing required contact fields (see ContactInfo) and for the
+// premium-domain money-safety guard on charge-bearing calls. Match it with
+// errors.As:
+//
+//	var argErr *namecheap.InvalidArgumentsError
+//	if errors.As(err, &argErr) {
+//	    log.Printf("invalid fields: %v", argErr.Fields)
+//	}
+type InvalidArgumentsError struct {
+	// Fields lists the names of the invalid or missing arguments, using the
+	// Namecheap parameter names (e.g. "RegistrantFirstName", "PremiumPrice").
+	Fields []string
+	// Reason, when set, explains why the fields are invalid. When empty the
+	// fields are treated as plain "missing required" fields.
+	Reason string
+}
+
+// Error implements the error interface, listing every offending field.
+func (e *InvalidArgumentsError) Error() string {
+	switch {
+	case e.Reason != "" && len(e.Fields) > 0:
+		return fmt.Sprintf("invalid arguments: %s (%s)", e.Reason, strings.Join(e.Fields, ", "))
+	case e.Reason != "":
+		return "invalid arguments: " + e.Reason
+	default:
+		return "missing required fields: " + strings.Join(e.Fields, ", ")
+	}
+}
 
 // ParseError signals that a server response could not be decoded as the
 // expected XML. It preserves a bounded snippet of the raw body (at most

--- a/namecheap/idempotency_test.go
+++ b/namecheap/idempotency_test.go
@@ -1,0 +1,164 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// timeoutError is a net.Error whose Timeout reports true, so IsRetryable treats
+// it as a retryable transport failure.
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "simulated i/o timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }
+
+// countingErrRT is an http.RoundTripper that counts calls and always fails with
+// a fixed error, exercising the transport-error retry path without a network.
+type countingErrRT struct {
+	err error
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (rt *countingErrRT) RoundTrip(*http.Request) (*http.Response, error) {
+	rt.mu.Lock()
+	rt.calls++
+	rt.mu.Unlock()
+	return nil, rt.err
+}
+
+func (rt *countingErrRT) count() int {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return rt.calls
+}
+
+func retryingClient(baseURL string, transport http.RoundTripper) *Client {
+	return newResilienceClient(baseURL, func(o *ClientOptions) {
+		o.Transport = transport
+		o.RateLimit = &RateLimitOptions{Disabled: true}
+		o.Retry = &RetryOptions{MaxAttempts: 4, BaseDelay: time.Millisecond, MaxDelay: 2 * time.Millisecond}
+	})
+}
+
+// TestShouldRetryClassification unit-tests the idempotency-aware retry gate.
+func TestShouldRetryClassification(t *testing.T) {
+	t.Parallel()
+
+	serverErr := &APIError{Number: 5050900, Message: "Server exception"}
+
+	// 405 (pre-execution rate-limit) is always retryable.
+	assert.True(t, shouldRetry(errRetryStatus, true))
+	assert.True(t, shouldRetry(errRetryStatus, false))
+
+	// A retryable server-side error: retried only for idempotent calls.
+	assert.True(t, shouldRetry(serverErr, true))
+	assert.False(t, shouldRetry(serverErr, false))
+
+	// A transport timeout: retried only for idempotent calls.
+	assert.True(t, shouldRetry(timeoutError{}, true))
+	assert.False(t, shouldRetry(timeoutError{}, false))
+
+	// A permanent error is never retried.
+	assert.False(t, shouldRetry(&APIError{Number: 2019166}, true))
+	assert.False(t, shouldRetry(&APIError{Number: 2019166}, false))
+}
+
+// TestDoXMLServerErrorRetryByClass proves the same retryable server-error XML is
+// retried MaxAttempts times for an idempotent call but exactly once for a
+// non-idempotent (charge-bearing) call.
+func TestDoXMLServerErrorRetryByClass(t *testing.T) {
+	t.Parallel()
+
+	newServer := func(calls *int32) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(calls, 1)
+			_, _ = w.Write([]byte(apiErrorXML(5050900, "Server exception")))
+		}))
+	}
+
+	t.Run("idempotent_retries", func(t *testing.T) {
+		t.Parallel()
+		var calls int32
+		server := newServer(&calls)
+		defer server.Close()
+
+		client := retryingClient(server.URL, nil)
+		var obj testResponse
+		_, err := client.doXML(context.Background(), map[string]string{"Command": "x"}, &obj, true)
+		assert.Error(t, err)
+		assert.Equal(t, int32(4), atomic.LoadInt32(&calls))
+		assert.Contains(t, err.Error(), "after")
+	})
+
+	t.Run("non_idempotent_single_attempt", func(t *testing.T) {
+		t.Parallel()
+		var calls int32
+		server := newServer(&calls)
+		defer server.Close()
+
+		client := retryingClient(server.URL, nil)
+		var obj testResponse
+		_, err := client.doXML(context.Background(), map[string]string{"Command": "x"}, &obj, false)
+		var apiErr *APIError
+		assert.True(t, errors.As(err, &apiErr))
+		assert.Equal(t, 5050900, apiErr.Number)
+		assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+		assert.NotContains(t, err.Error(), "after")
+	})
+}
+
+// TestDoXMLTimeoutRetryByClass proves a transport timeout is retried for an
+// idempotent call but not for a non-idempotent one.
+func TestDoXMLTimeoutRetryByClass(t *testing.T) {
+	t.Parallel()
+
+	t.Run("idempotent_retries", func(t *testing.T) {
+		t.Parallel()
+		rt := &countingErrRT{err: timeoutError{}}
+		client := retryingClient("", rt)
+		var obj testResponse
+		_, err := client.doXML(context.Background(), map[string]string{"Command": "x"}, &obj, true)
+		assert.Error(t, err)
+		assert.Equal(t, 4, rt.count())
+	})
+
+	t.Run("non_idempotent_single_attempt", func(t *testing.T) {
+		t.Parallel()
+		rt := &countingErrRT{err: timeoutError{}}
+		client := retryingClient("", rt)
+		var obj testResponse
+		_, err := client.doXML(context.Background(), map[string]string{"Command": "x"}, &obj, false)
+		assert.Error(t, err)
+		assert.Equal(t, 1, rt.count(), "an ambiguous timeout must not be retried on a charge-bearing call")
+	})
+}
+
+// TestDoXMLNonIdempotentRetriesOn405 proves the pre-execution HTTP 405
+// rate-limit signal is still retried even for a non-idempotent call, because a
+// 405 provably means the request was rejected before it executed.
+func TestDoXMLNonIdempotentRetriesOn405(t *testing.T) {
+	t.Parallel()
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer server.Close()
+
+	client := retryingClient(server.URL, nil)
+	var obj testResponse
+	_, err := client.doXML(context.Background(), map[string]string{"Command": "x"}, &obj, false)
+	assert.Error(t, err)
+	assert.Greater(t, atomic.LoadInt32(&calls), int32(1), "405 is safe to resend and must be retried")
+}

--- a/namecheap/namecheap.go
+++ b/namecheap/namecheap.go
@@ -160,8 +160,22 @@ func (c *Client) NewRequest(body map[string]string) (*http.Request, error) {
 // the last real error as "after N attempts: <err>", so errors.Is and errors.As
 // still reach the underlying *APIError.
 func (c *Client) DoXMLWithContext(ctx context.Context, body map[string]string, obj any) (*http.Response, error) {
+	return c.doXML(ctx, body, obj, true)
+}
+
+// doXML is the shared engine behind DoXMLWithContext. It performs the API call
+// described by body, decoding the XML response into obj, and threads idempotent
+// into the retry driver.
+//
+// idempotent must be true for safely-repeatable calls (every read and every
+// non-charge-bearing write) and false for charge-bearing, non-idempotent calls
+// (domain create/renew/reactivate). A false value narrows the retry policy so an
+// ambiguous transport/server failure — which may already have executed and
+// charged the account — is never resent; only Namecheap's pre-execution HTTP 405
+// rate-limit signal is retried. See shouldRetry.
+func (c *Client) doXML(ctx context.Context, body map[string]string, obj any, idempotent bool) (*http.Response, error) {
 	var requestResponse *http.Response
-	err := c.do(ctx, func(ctx context.Context) error {
+	err := c.do(ctx, idempotent, func(ctx context.Context) error {
 		request, err := c.NewRequestWithContext(ctx, body)
 		if err != nil {
 			return err

--- a/namecheap/transport.go
+++ b/namecheap/transport.go
@@ -129,16 +129,21 @@ func resolveUserAgent(ua string) string {
 }
 
 // do runs attempt through the resilience pipeline: rate limiter -> concurrency
-// gate -> attempt -> retry policy. It retries an attempt only while its error
-// is retryable (IsRetryable or the internal 405 sentinel), attempts remain, and
-// the elapsed budget is not exhausted, sleeping an exponential, jittered,
+// gate -> attempt -> retry policy. It retries an attempt only while its error is
+// retryable for the given idempotency class (see shouldRetry), attempts remain,
+// and the elapsed budget is not exhausted, sleeping an exponential, jittered,
 // ctx-aware backoff between tries.
+//
+// idempotent distinguishes a safely-repeatable call from a charge-bearing one
+// (domain create/renew/reactivate): a non-idempotent call is retried only on the
+// pre-execution HTTP 405 rate-limit signal, never on ambiguous transport/server
+// failures that may already have executed server-side.
 //
 // A cancelled context aborts a limiter wait, a concurrency wait, or a backoff
 // sleep promptly and returns the context error unwrapped. A terminal retry
 // failure wraps the last real error as "after N attempts: <err>" so errors.Is
 // and errors.As still reach the underlying *APIError.
-func (c *Client) do(ctx context.Context, attempt func(context.Context) error) error {
+func (c *Client) do(ctx context.Context, idempotent bool, attempt func(context.Context) error) error {
 	start := time.Now()
 	var lastErr error
 	attempts := 0
@@ -158,7 +163,7 @@ func (c *Client) do(ctx context.Context, attempt func(context.Context) error) er
 		}
 		lastErr = err
 
-		if !shouldRetry(err) {
+		if !shouldRetry(err, idempotent) {
 			return err
 		}
 		if attempts >= c.retry.MaxAttempts {
@@ -208,10 +213,27 @@ func (c *Client) nextDelay(attempt int, elapsed time.Duration) (time.Duration, b
 	return d, true
 }
 
-// shouldRetry reports whether err is worth another attempt: either a typed
-// retryable error (IsRetryable) or the internal HTTP 405 rate-limit sentinel.
-func shouldRetry(err error) bool {
-	return IsRetryable(err) || errors.Is(err, errRetryStatus)
+// shouldRetry reports whether err is worth another attempt, given whether the
+// call is idempotent.
+//
+// The internal HTTP 405 rate-limit sentinel (errRetryStatus) is always
+// retryable: Namecheap returns 405 before it processes the request, so the call
+// provably did not execute and resending it cannot double-apply an effect.
+//
+// For an idempotent call, any typed-retryable error (IsRetryable — transient
+// server-side codes and transport timeouts) is also retried. For a
+// non-idempotent, charge-bearing call it is NOT: a timeout or a server-side
+// exception is ambiguous (the request may already have executed), so a blind
+// resend could double-charge the account. Such calls fail fast on the first
+// real error and let the caller reconcile.
+func shouldRetry(err error, idempotent bool) bool {
+	if errors.Is(err, errRetryStatus) {
+		return true
+	}
+	if !idempotent {
+		return false
+	}
+	return IsRetryable(err)
 }
 
 // backoff computes the delay before the given attempt (1-based): an exponential


### PR DESCRIPTION
Closes #114. First item of Phase 2 (API coverage) on the go-namecheap-sdk 2.0 roadmap (#122). Highest-value coverage item — unlocks the registration lifecycle for the Terraform provider and every automation consumer. Introduces the README coverage matrix and the shared `ContactInfo` type that #117 (users/address) builds on.

## What
Extends `DomainsService` from the read-only sliver (`Check`/`GetInfo`/`GetList`) to the full lifecycle — 8 ctx-first methods, structs cross-checked field-by-field against `docs/namecheap-api-v2.md`:

`CreateWithContext` · `RenewWithContext` · `ReactivateWithContext` · `GetContactsWithContext` · `SetContactsWithContext` · `GetRegistrarLockWithContext` · `SetRegistrarLockWithContext` · `GetTldListWithContext`

## 💰 Money-safety (these commands spend real money)
- **No `float64` for currency** — new `Amount` (string) type preserves the exact server value; tested that `10.87` round-trips exactly.
- **Non-idempotent retry classification (double-charge prevention)** — `create`/`renew`/`reactivate` go through a new unexported `doXML(ctx, body, obj, idempotent=false)`. The #112 retry driver now retries a non-idempotent call **only** on the pre-execution HTTP 405 signal (the request provably didn't execute), **never** on ambiguous transport/server failures that may already have applied server-side. `DoXMLWithContext` stays idempotent — public behavior unchanged. Tested: non-idempotent → exactly 1 attempt on a 5xx/timeout; idempotent → retries.
- **Premium guard** — Create/Renew/Reactivate reject a premium purchase with no explicit `PremiumPrice` (and reject stray premium pricing when not premium) **before** any charge-bearing HTTP call (tested: guard trips → zero HTTP requests).

## Design decisions (flagged for review)
- New methods are **ctx-first with the `WithContext` suffix and no deprecated non-ctx wrappers** — uniform with the post-#110 surface, and avoids a footgun context-less money call. (The v3 cleanup can drop the suffix across the board.)
- **`ContactInfo`** shared by Create + SetContacts (one definition, two commands); client-side validation reports **all** missing required fields at once via `InvalidArgumentsError`.
- **`LockAction`** enum for SetRegistrarLock instead of a bare bool.
- XML tags follow the real wire where doc prose differs (noted inline); field names/types/required-ness follow the doc.

## Acceptance criteria
- [x] All 8 methods with args/response structs matching the doc param tables (line ranges cited in commit).
- [x] `ContactInfo` shared; validation lists every missing field (tested).
- [x] Premium guard returns a typed error before any charge (mock-tested, no HTTP).
- [x] Per-method table tests: success parse, `*APIError` mapping, required-param validation; money parses safely (no float64).
- [x] ctx-first; retry/rate-limit pipeline applies; create/renew/reactivate non-idempotent (classified + tested).
- [x] README coverage matrix + Create/Renew usage; CHANGELOG; doc comments on every exported identifier.

## Verification (local, go 1.26.4 + golangci-lint 2.12.2)
`go vet` ✅ · `golangci-lint run` → 0 issues ✅ · `go mod verify` (no new deps, go.mod/go.sum unchanged) ✅ · `make test` unit + **race** ✅ (338 subtests, 93.4% coverage).
