### PR TITLE
feat: add record-level DNS operations (AddRecords/DeleteRecords/UpsertRecords/Plan)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Record-level DNS helpers on `DomainsDNSService`, all context-first with the
+  `WithContext` suffix and no non-context wrappers:
+  `AddRecordsWithContext` (append, preserving all existing records),
+  `DeleteRecordsWithContext` (remove selector-matched records, preserve the rest)
+  and `UpsertRecordsWithContext` (replace exactly the selector-matched records).
+  Each is a read-modify-write over `GetHosts`/`SetHosts` that preserves every
+  settable field and the zone `EmailType`, then re-reads and verifies the result,
+  returning `ErrConcurrentModification` on a detected lost-update race. They fix
+  the `setHosts` "replaces everything" footgun (#49) and de-duplicate logic every
+  consumer re-derives (#119).
+- `RecordSelector` for exact-match record selection (HostName/RecordType/Address/
+  MXPref; empty selector rejected as a typed `*InvalidArgumentsError`; `MatchAll`
+  required for an intentional full wipe), and `WithRetryOnConflict(n)` to
+  auto-retry the read-modify-write-verify cycle on conflict (#119).
+- `PlanWithContext` plus the `RecordOp` constructors `AddOp`/`DeleteOp`/`UpsertOp`
+  and the `RecordDiff` type: compute the add/remove/keep diff for a set of
+  operations **without writing** (zero `setHosts` calls), for previewing changes
+  (#119).
+- `RecordFromDetailed` (maps a `GetHosts` `DomainsDNSHostRecordDetailed` to a
+  `SetHosts` `DomainsDNSHostRecord`, converting/clamping `MXPref` and consciously
+  dropping server-managed read-only fields), plus exported `NormalizeRecord` and
+  `RecordsEqual` normalization/comparison helpers (TTL default 1799, hostname
+  case, `@`/trailing-dot handling, record-type case). A `reflect`-based
+  exhaustiveness test fails loudly if a new struct field is left unmapped (#119).
+- `ErrConcurrentModification`, a typed, `errors.Is`-matchable sentinel returned
+  when a record-level mutation detects that the zone changed between its read and
+  its verifying re-read (#119).
 - Eight new `Domains` API methods, all context-first with the `WithContext`
   suffix and no non-context wrappers (these are brand-new, charge-bearing or
   read-only surfaces with no legacy to preserve): `CreateWithContext`,

--- a/README.md
+++ b/README.md
@@ -147,7 +147,11 @@ fmt.Printf("charged=%s\n", renewed.DomainRenewResult.ChargedAmount)
 | `SetDefaultWithContext(ctx, domain)` | Switch domain to Namecheap default DNS |
 | `SetCustomWithContext(ctx, domain, nameservers)` | Switch domain to custom nameservers |
 | `GetHostsWithContext(ctx, domain)` | Get DNS host records |
-| `SetHostsWithContext(ctx, args)` | Set DNS host records |
+| `SetHostsWithContext(ctx, args)` | Set (replace) the entire DNS host record set |
+| `AddRecordsWithContext(ctx, domain, records, opts...)` | Add records, preserving all existing ones |
+| `DeleteRecordsWithContext(ctx, domain, selector, opts...)` | Delete records matching a selector, preserving the rest |
+| `UpsertRecordsWithContext(ctx, domain, selector, records, opts...)` | Replace the selector-matched records with new ones |
+| `PlanWithContext(ctx, domain, ops...)` | Compute an add/remove/keep diff without writing |
 | `GetEmailForwardingWithContext(ctx, domain)` | Get email forwarding rules |
 | `SetEmailForwardingWithContext(ctx, domain, forwards)` | Set email forwarding rules |
 
@@ -174,6 +178,80 @@ _, err = client.DomainsDNS.SetEmailForwardingWithContext(ctx, "domain.com", []na
     {Mailbox: "info", ForwardTo: "user@example.com"},
 })
 ```
+
+#### Managing individual DNS records
+
+`SetHosts` (`namecheap.domains.dns.setHosts`) is the only write endpoint the API
+offers, and it **replaces the entire record set**. To change one record you must
+read every record, edit the slice, and write them all back — forget one and it is
+silently deleted (this is the [#49](https://github.com/namecheap/go-namecheap-sdk/issues/49)
+footgun). The record-level helpers own that read-modify-write once, correctly.
+
+Delete one record — the #49 question, answered in five lines:
+
+```go
+_, err := client.DomainsDNS.DeleteRecordsWithContext(ctx, "example.com",
+    namecheap.RecordSelector{
+        HostName:   namecheap.String("blog"),
+        RecordType: namecheap.String("A"),
+    })
+// every other record (and the zone EmailType) is preserved automatically.
+```
+
+```go
+// Add records, keeping everything else:
+_, err := client.DomainsDNS.AddRecordsWithContext(ctx, "example.com",
+    []namecheap.DomainsDNSHostRecord{
+        {HostName: namecheap.String("www"), RecordType: namecheap.String("A"), Address: namecheap.String("1.2.3.4")},
+    })
+
+// Replace exactly the selector-matched records (upsert):
+_, err = client.DomainsDNS.UpsertRecordsWithContext(ctx, "example.com",
+    namecheap.RecordSelector{RecordType: namecheap.String("TXT")},
+    []namecheap.DomainsDNSHostRecord{
+        {HostName: namecheap.String("@"), RecordType: namecheap.String("TXT"), Address: namecheap.String("v=spf1 -all")},
+    })
+
+// Preview a change without writing (zero setHosts calls):
+diff, err := client.DomainsDNS.PlanWithContext(ctx, "example.com",
+    namecheap.DeleteOp(namecheap.RecordSelector{HostName: namecheap.String("old")}))
+fmt.Println(diff) // RecordDiff: +0 -1 =7
+```
+
+A `RecordSelector` matches a record when **every** non-nil field equals the
+record's (HostName/RecordType compared case-insensitively, a trailing dot on the
+address ignored, MXPref exact). An empty selector is **rejected** with a typed
+`*InvalidArgumentsError` to refuse an accidental mass-delete; set
+`RecordSelector{MatchAll: true}` for an intentional full wipe.
+
+> **⚠️ The API is not transactional.** `setHosts` replaces the whole zone, so a
+> concurrent writer between your read and your write causes a lost update. Every
+> mutating helper re-reads the zone after writing and, if the result does not
+> match what it intended, returns `namecheap.ErrConcurrentModification`
+> (`errors.Is`-matchable) instead of silently accepting the race:
+>
+> ```go
+> _, err := client.DomainsDNS.AddRecordsWithContext(ctx, "example.com", records)
+> if errors.Is(err, namecheap.ErrConcurrentModification) {
+>     // someone else changed the zone; re-read and retry
+> }
+> ```
+>
+> Pass `namecheap.WithRetryOnConflict(n)` to have the helper retry the whole
+> read-modify-write-verify cycle up to `n` times automatically:
+>
+> ```go
+> _, err := client.DomainsDNS.AddRecordsWithContext(ctx, "example.com", records,
+>     namecheap.WithRetryOnConflict(3))
+> ```
+>
+> This is detection-plus-retry, not true transactionality (the API cannot offer
+> that) — but it turns a silent data-loss footgun into an explicit, handleable
+> error.
+
+`NormalizeRecord` and `RecordsEqual` are exported so consumers can reuse the same
+comparison logic (TTL defaults to 1799, hostname lower-cased, `@` apex handling,
+trailing-dot handling, record type upper-cased).
 
 #### DomainsNS (`client.DomainsNS`)
 

--- a/namecheap/domains_dns_records.go
+++ b/namecheap/domains_dns_records.go
@@ -1,0 +1,578 @@
+package namecheap
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// defaultTTL is the TTL Namecheap applies to a host record that is created
+// without an explicit TTL (its "automatic" value, 1799 seconds). NormalizeRecord
+// treats a nil or zero TTL as this value so a record left on automatic compares
+// equal to the value the getHosts API echoes back for it.
+//
+// Note: the DomainsDNSHostRecord.TTL field comment historically cites 1800; 1799
+// is what the API actually returns for an automatic record and is the value
+// issue #119 specifies for normalization, so it is used here.
+const defaultTTL = 1799
+
+// RecordSelector selects host records for DeleteRecordsWithContext and
+// UpsertRecordsWithContext (and for building DeleteOp/UpsertOp).
+//
+// A record matches when every non-nil field equals the corresponding field of
+// the record after normalization: HostName and RecordType are compared
+// case-insensitively, a single trailing dot on Address is ignored, and MXPref is
+// compared exactly (a nil MXPref on the record never matches a non-nil selector
+// MXPref). See NormalizeRecord for the exact rules.
+//
+// A selector with no fields set and MatchAll false is invalid and is rejected
+// before any HTTP call, to refuse an accidental mass-delete. Set MatchAll to true
+// to intentionally select every record; it is the only way to select all.
+type RecordSelector struct {
+	// HostName, when non-nil, matches records whose (normalized) host equals it.
+	HostName *string
+	// RecordType, when non-nil, matches records whose (normalized) type equals it.
+	RecordType *string
+	// Address, when non-nil, matches records whose (normalized) address equals it.
+	Address *string
+	// MXPref, when non-nil, matches records whose MXPref equals it.
+	MXPref *uint8
+	// MatchAll, when true, matches every record regardless of the other fields.
+	MatchAll bool
+}
+
+// isEmpty reports whether the selector matches on nothing, which is treated as
+// an invalid mass-delete rather than an intentional wipe (use MatchAll for that).
+func (s RecordSelector) isEmpty() bool {
+	return !s.MatchAll && s.HostName == nil && s.RecordType == nil && s.Address == nil && s.MXPref == nil
+}
+
+// matches reports whether r satisfies the selector. Every non-nil selector field
+// must equal the corresponding normalized field of r.
+func (s RecordSelector) matches(r DomainsDNSHostRecord) bool {
+	if s.MatchAll {
+		return true
+	}
+	n := NormalizeRecord(r)
+	if s.HostName != nil && normHostName(*s.HostName) != *n.HostName {
+		return false
+	}
+	if s.RecordType != nil && normRecordType(*s.RecordType) != *n.RecordType {
+		return false
+	}
+	if s.Address != nil && normAddress(*s.Address) != *n.Address {
+		return false
+	}
+	if s.MXPref != nil && (n.MXPref == nil || *n.MXPref != *s.MXPref) {
+		return false
+	}
+	return true
+}
+
+// RecordDiff is the result of planning a set of record operations against the
+// current zone: Add lists the records that would be created, Remove the records
+// that would be deleted, and Keep the existing records left untouched. The
+// slices are sorted deterministically by normalized identity.
+type RecordDiff struct {
+	Add    []DomainsDNSHostRecord
+	Remove []DomainsDNSHostRecord
+	Keep   []DomainsDNSHostRecord
+}
+
+// String renders the diff as a stable, human-readable summary.
+func (d RecordDiff) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "RecordDiff: +%d -%d =%d", len(d.Add), len(d.Remove), len(d.Keep))
+	for _, r := range d.Add {
+		fmt.Fprintf(&b, "\n  + %s", recordString(r))
+	}
+	for _, r := range d.Remove {
+		fmt.Fprintf(&b, "\n  - %s", recordString(r))
+	}
+	for _, r := range d.Keep {
+		fmt.Fprintf(&b, "\n    %s", recordString(r))
+	}
+	return b.String()
+}
+
+// RecordChangeResult reports the outcome of a record-level mutation.
+type RecordChangeResult struct {
+	// Added, Removed and Kept are the counts of records created, deleted and left
+	// untouched relative to the zone as it was read.
+	Added   int
+	Removed int
+	Kept    int
+	// Records is the full record set written to the zone (its new state).
+	Records []DomainsDNSHostRecord
+	// Response is the raw setHosts command response for the successful write.
+	Response *DomainsDNSSetHostsCommandResponse
+}
+
+// RecordOption configures a record-level mutation.
+type RecordOption func(*recordOptions)
+
+type recordOptions struct {
+	maxAttempts int
+}
+
+// WithRetryOnConflict enables automatic retry of the whole
+// read-modify-write-verify cycle when a concurrent modification is detected, for
+// up to maxAttempts total attempts (values below 1 are treated as 1). With no
+// option the mutation makes a single attempt and returns ErrConcurrentModification
+// on conflict.
+func WithRetryOnConflict(maxAttempts int) RecordOption {
+	return func(o *recordOptions) {
+		if maxAttempts < 1 {
+			maxAttempts = 1
+		}
+		o.maxAttempts = maxAttempts
+	}
+}
+
+func buildRecordOptions(opts []RecordOption) recordOptions {
+	o := recordOptions{maxAttempts: 1}
+	for _, fn := range opts {
+		fn(&o)
+	}
+	return o
+}
+
+type recordOpKind int
+
+const (
+	recordOpAdd recordOpKind = iota
+	recordOpDelete
+	recordOpUpsert
+)
+
+// RecordOp is a single record operation (add, delete or upsert). Build one with
+// AddOp, DeleteOp or UpsertOp and pass it to PlanWithContext; the mutating
+// helpers build the same values internally so Plan and the writers share one
+// diff engine. The zero value is not valid.
+type RecordOp struct {
+	kind     recordOpKind
+	selector RecordSelector
+	records  []DomainsDNSHostRecord
+}
+
+// AddOp returns an operation that appends records, preserving all existing ones.
+func AddOp(records ...DomainsDNSHostRecord) RecordOp {
+	return RecordOp{kind: recordOpAdd, records: records}
+}
+
+// DeleteOp returns an operation that removes every record matching selector.
+func DeleteOp(selector RecordSelector) RecordOp {
+	return RecordOp{kind: recordOpDelete, selector: selector}
+}
+
+// UpsertOp returns an operation that replaces exactly the records matching
+// selector with records (matching records are removed, then records appended).
+func UpsertOp(selector RecordSelector, records []DomainsDNSHostRecord) RecordOp {
+	return RecordOp{kind: recordOpUpsert, selector: selector, records: records}
+}
+
+// RecordFromDetailed converts a DomainsDNSHostRecordDetailed returned by
+// GetHosts into a DomainsDNSHostRecord accepted by SetHosts, so a zone can be
+// read, modified and written back without losing settable fields.
+//
+// Field mapping:
+//
+//	Detailed.Name    -> HostName
+//	Detailed.Type    -> RecordType
+//	Detailed.Address -> Address
+//	Detailed.TTL     -> TTL
+//	Detailed.MXPref  -> MXPref (int -> uint8; clamped to 0..255; nil stays nil)
+//
+// The following read-only, server-managed fields are intentionally dropped
+// because setHosts has no input for them and the server regenerates them on
+// every write: HostId, AssociatedAppTitle, FriendlyName, IsActive and
+// IsDDNSEnabled. Carrying them would be meaningless (setHosts ignores them). The
+// knownFields exhaustiveness test asserts every field of the detailed struct is
+// either mapped here or consciously dropped, so a new API field fails the test
+// instead of being silently lost.
+func RecordFromDetailed(d DomainsDNSHostRecordDetailed) DomainsDNSHostRecord {
+	return DomainsDNSHostRecord{
+		HostName:   d.Name,
+		RecordType: d.Type,
+		Address:    d.Address,
+		TTL:        d.TTL,
+		MXPref:     mxPrefFromInt(d.MXPref),
+	}
+}
+
+// mxPrefFromInt converts a getHosts MXPref (*int) to a setHosts MXPref (*uint8),
+// clamping to the valid 0..255 range. A nil input stays nil.
+func mxPrefFromInt(p *int) *uint8 {
+	if p == nil {
+		return nil
+	}
+	v := *p
+	switch {
+	case v < 0:
+		v = 0
+	case v > 255:
+		v = 255
+	}
+	out := uint8(v)
+	return &out
+}
+
+// normHostName canonicalizes a hostname: trimmed, lower-cased, and an empty host
+// mapped to "@" (the apex), matching how the API denotes the zone root.
+func normHostName(s string) string {
+	h := strings.ToLower(strings.TrimSpace(s))
+	if h == "" {
+		return "@"
+	}
+	return h
+}
+
+// normRecordType canonicalizes a record type: trimmed and upper-cased.
+func normRecordType(s string) string {
+	return strings.ToUpper(strings.TrimSpace(s))
+}
+
+// normAddress canonicalizes an address by removing a single trailing dot. The
+// dot is DNS-insignificant for the hostname targets the API echoes back
+// (CNAME/MX/ALIAS/NS) and the server may add or drop it, so trimming it keeps a
+// read-modify-write round-trip stable. Case is preserved because TXT values are
+// case-sensitive.
+func normAddress(s string) string {
+	return strings.TrimSuffix(s, ".")
+}
+
+// NormalizeRecord returns a copy of r in canonical form so two records that mean
+// the same thing compare equal (see RecordsEqual). It does not mutate r or the
+// values its pointers reference. The normalizations are:
+//
+//   - HostName: trimmed, lower-cased; an empty or nil host becomes "@" (apex).
+//   - RecordType: trimmed, upper-cased.
+//   - Address: a single trailing dot is removed (case preserved for TXT).
+//   - TTL: a nil or zero TTL becomes the Namecheap automatic default (1799).
+//   - MXPref: copied unchanged (nil stays nil).
+func NormalizeRecord(r DomainsDNSHostRecord) DomainsDNSHostRecord {
+	host := "@"
+	if r.HostName != nil {
+		host = normHostName(*r.HostName)
+	}
+
+	recordType := ""
+	if r.RecordType != nil {
+		recordType = normRecordType(*r.RecordType)
+	}
+
+	address := ""
+	if r.Address != nil {
+		address = normAddress(*r.Address)
+	}
+
+	ttl := defaultTTL
+	if r.TTL != nil && *r.TTL != 0 {
+		ttl = *r.TTL
+	}
+
+	out := DomainsDNSHostRecord{
+		HostName:   &host,
+		RecordType: &recordType,
+		Address:    &address,
+		TTL:        &ttl,
+	}
+	if r.MXPref != nil {
+		mx := *r.MXPref
+		out.MXPref = &mx
+	}
+	return out
+}
+
+// RecordsEqual reports whether a and b denote the same host record, comparing
+// them in normalized form (see NormalizeRecord). It is symmetric and consistent
+// with NormalizeRecord, and is the equality used by the diff engine and by the
+// post-write verification.
+func RecordsEqual(a, b DomainsDNSHostRecord) bool {
+	return recordKey(a) == recordKey(b)
+}
+
+// recordKey builds a collision-resistant canonical key for a normalized record,
+// used for equality and multiset comparisons. It includes every settable field
+// (host, type, address, MXPref, TTL) so a change to any of them is detected.
+func recordKey(r DomainsDNSHostRecord) string {
+	n := NormalizeRecord(r)
+	mx := ""
+	if n.MXPref != nil {
+		mx = strconv.Itoa(int(*n.MXPref))
+	}
+	return strings.Join([]string{*n.HostName, *n.RecordType, *n.Address, mx, strconv.Itoa(*n.TTL)}, "\x00")
+}
+
+// recordString formats a record for diagnostics, nil-safely.
+func recordString(r DomainsDNSHostRecord) string {
+	return fmt.Sprintf("%s %s %s (mxpref=%v ttl=%v)", derefStr(r.HostName), derefStr(r.RecordType), derefStr(r.Address), deref(r.MXPref), deref(r.TTL))
+}
+
+// derefStr returns the string a non-nil pointer references, or "" for nil.
+func derefStr(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+// validateOps rejects delete/upsert operations carrying an empty selector before
+// any HTTP request, guarding against an accidental mass-delete.
+func validateOps(ops []RecordOp) error {
+	for _, op := range ops {
+		if op.kind == recordOpDelete || op.kind == recordOpUpsert {
+			if op.selector.isEmpty() {
+				return &InvalidArgumentsError{
+					Fields: []string{"RecordSelector"},
+					Reason: "empty selector would match every record; set at least one field, or MatchAll to intentionally select all",
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// applyOps returns the record set produced by applying ops in order to current.
+// It preserves ordering (surviving records keep their relative order, appended
+// records follow) so the written zone is deterministic.
+func applyOps(current []DomainsDNSHostRecord, ops []RecordOp) []DomainsDNSHostRecord {
+	working := slices.Clone(current)
+	for _, op := range ops {
+		switch op.kind {
+		case recordOpAdd:
+			working = append(working, op.records...)
+		case recordOpDelete:
+			working = filterOut(working, op.selector)
+		case recordOpUpsert:
+			working = append(filterOut(working, op.selector), op.records...)
+		}
+	}
+	return working
+}
+
+// filterOut returns the records that do not match selector, in original order.
+func filterOut(records []DomainsDNSHostRecord, selector RecordSelector) []DomainsDNSHostRecord {
+	kept := make([]DomainsDNSHostRecord, 0, len(records))
+	for _, r := range records {
+		if !selector.matches(r) {
+			kept = append(kept, r)
+		}
+	}
+	return kept
+}
+
+// computeDiff applies ops to current and returns both the resulting diff and the
+// final record set to be written.
+func computeDiff(current []DomainsDNSHostRecord, ops []RecordOp) (RecordDiff, []DomainsDNSHostRecord) {
+	final := applyOps(current, ops)
+	return diffSets(current, final), final
+}
+
+// diffSets compares current and final as multisets keyed by normalized identity:
+// records in both are Keep, records only in current are Remove, and records only
+// in final are Add. The result slices are sorted for determinism.
+func diffSets(current, final []DomainsDNSHostRecord) RecordDiff {
+	curByKey := groupByKey(current)
+	finalByKey := groupByKey(final)
+
+	diff := RecordDiff{
+		Add:    make([]DomainsDNSHostRecord, 0, len(final)),
+		Remove: make([]DomainsDNSHostRecord, 0, len(current)),
+		Keep:   make([]DomainsDNSHostRecord, 0, len(current)),
+	}
+
+	for key, curs := range curByKey {
+		keep := min(len(curs), len(finalByKey[key]))
+		diff.Keep = append(diff.Keep, curs[:keep]...)
+		diff.Remove = append(diff.Remove, curs[keep:]...)
+	}
+	for key, finals := range finalByKey {
+		curN := len(curByKey[key])
+		if len(finals) > curN {
+			diff.Add = append(diff.Add, finals[curN:]...)
+		}
+	}
+
+	sortRecords(diff.Add)
+	sortRecords(diff.Remove)
+	sortRecords(diff.Keep)
+	return diff
+}
+
+// groupByKey buckets records by their normalized identity key.
+func groupByKey(records []DomainsDNSHostRecord) map[string][]DomainsDNSHostRecord {
+	m := make(map[string][]DomainsDNSHostRecord, len(records))
+	for _, r := range records {
+		key := recordKey(r)
+		m[key] = append(m[key], r)
+	}
+	return m
+}
+
+// sortRecords orders records deterministically by their normalized identity key.
+func sortRecords(records []DomainsDNSHostRecord) {
+	slices.SortFunc(records, func(a, b DomainsDNSHostRecord) int {
+		return strings.Compare(recordKey(a), recordKey(b))
+	})
+}
+
+// recordSetsEqual reports whether a and b contain the same records as multisets
+// (order-independent), using normalized identity.
+func recordSetsEqual(a, b []DomainsDNSHostRecord) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := make(map[string]int, len(a))
+	for _, r := range a {
+		counts[recordKey(r)]++
+	}
+	for _, r := range b {
+		counts[recordKey(r)]--
+	}
+	for _, c := range counts {
+		if c != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// recordsFromResult extracts the settable record set and the zone EmailType from
+// a getHosts response. A nil or empty EmailType defaults to EmailTypeNone so a
+// partial update never silently clears email routing.
+func recordsFromResult(resp *DomainsDNSGetHostsCommandResponse) ([]DomainsDNSHostRecord, string) {
+	emailType := EmailTypeNone
+	if resp == nil || resp.DomainDNSGetHostsResult == nil {
+		return nil, emailType
+	}
+	result := resp.DomainDNSGetHostsResult
+	if result.EmailType != nil && *result.EmailType != "" {
+		emailType = *result.EmailType
+	}
+	if result.Hosts == nil {
+		return nil, emailType
+	}
+	hosts := *result.Hosts
+	records := make([]DomainsDNSHostRecord, 0, len(hosts))
+	for _, h := range hosts {
+		records = append(records, RecordFromDetailed(h))
+	}
+	return records, emailType
+}
+
+// buildSetHostsArgs assembles the setHosts arguments for a full-zone write,
+// always carrying the (preserved) EmailType so email routing is not disturbed.
+func buildSetHostsArgs(domain string, records []DomainsDNSHostRecord, emailType string) *DomainsDNSSetHostsArgs {
+	return &DomainsDNSSetHostsArgs{
+		Domain:    &domain,
+		Records:   &records,
+		EmailType: &emailType,
+	}
+}
+
+// AddRecordsWithContext appends records to domain's zone, preserving every
+// existing record (and the zone EmailType), then verifies the result by
+// re-reading the zone. It returns ErrConcurrentModification if the zone changed
+// under it, unless WithRetryOnConflict is supplied. See the package README on
+// the non-transactional setHosts API.
+func (dds *DomainsDNSService) AddRecordsWithContext(ctx context.Context, domain string, records []DomainsDNSHostRecord, opts ...RecordOption) (*RecordChangeResult, error) {
+	return dds.applyRecordOps(ctx, domain, []RecordOp{AddOp(records...)}, opts)
+}
+
+// DeleteRecordsWithContext removes every record matching selector from domain's
+// zone, preserving the rest (and the zone EmailType), then verifies the result.
+// An empty selector is rejected before any request; use
+// RecordSelector{MatchAll: true} to intentionally delete all records. It returns
+// ErrConcurrentModification on a detected race unless WithRetryOnConflict is
+// supplied.
+func (dds *DomainsDNSService) DeleteRecordsWithContext(ctx context.Context, domain string, selector RecordSelector, opts ...RecordOption) (*RecordChangeResult, error) {
+	return dds.applyRecordOps(ctx, domain, []RecordOp{DeleteOp(selector)}, opts)
+}
+
+// UpsertRecordsWithContext replaces exactly the records matching selector with
+// records, preserving all other records (and the zone EmailType), then verifies
+// the result. An empty selector is rejected before any request. It returns
+// ErrConcurrentModification on a detected race unless WithRetryOnConflict is
+// supplied.
+func (dds *DomainsDNSService) UpsertRecordsWithContext(ctx context.Context, domain string, selector RecordSelector, records []DomainsDNSHostRecord, opts ...RecordOption) (*RecordChangeResult, error) {
+	return dds.applyRecordOps(ctx, domain, []RecordOp{UpsertOp(selector, records)}, opts)
+}
+
+// PlanWithContext computes the add/remove/keep diff that ops would produce
+// against domain's current zone, without writing anything: it performs a single
+// getHosts and zero setHosts calls. Use it to preview a change before applying it
+// with AddRecords/DeleteRecords/UpsertRecords.
+func (dds *DomainsDNSService) PlanWithContext(ctx context.Context, domain string, ops ...RecordOp) (RecordDiff, error) {
+	if err := validateOps(ops); err != nil {
+		return RecordDiff{}, err
+	}
+	getResp, err := dds.GetHostsWithContext(ctx, domain)
+	if err != nil {
+		return RecordDiff{}, err
+	}
+	current, _ := recordsFromResult(getResp)
+	diff, _ := computeDiff(current, ops)
+	return diff, nil
+}
+
+// applyRecordOps runs the read-modify-write-verify cycle for a single logical
+// change (built from ops) against domain, honoring the retry-on-conflict option.
+// Selectors are validated once, before any HTTP call.
+func (dds *DomainsDNSService) applyRecordOps(ctx context.Context, domain string, ops []RecordOp, opts []RecordOption) (*RecordChangeResult, error) {
+	if err := validateOps(ops); err != nil {
+		return nil, err
+	}
+	cfg := buildRecordOptions(opts)
+
+	var lastErr error
+	for attempt := 0; attempt < cfg.maxAttempts; attempt++ {
+		result, conflict, err := dds.attemptRecordOps(ctx, domain, ops)
+		if err != nil {
+			return nil, err
+		}
+		if !conflict {
+			return result, nil
+		}
+		lastErr = ErrConcurrentModification
+	}
+	return nil, lastErr
+}
+
+// attemptRecordOps performs one read-modify-write-verify cycle. It reports a
+// conflict (second return value) when the verifying re-read does not match the
+// record set it intended to write; a conflict is not an error so the caller can
+// decide whether to retry.
+func (dds *DomainsDNSService) attemptRecordOps(ctx context.Context, domain string, ops []RecordOp) (*RecordChangeResult, bool, error) {
+	getResp, err := dds.GetHostsWithContext(ctx, domain)
+	if err != nil {
+		return nil, false, err
+	}
+	current, emailType := recordsFromResult(getResp)
+
+	diff, final := computeDiff(current, ops)
+
+	setResp, err := dds.SetHostsWithContext(ctx, buildSetHostsArgs(domain, final, emailType))
+	if err != nil {
+		return nil, false, err
+	}
+
+	verifyResp, err := dds.GetHostsWithContext(ctx, domain)
+	if err != nil {
+		return nil, false, err
+	}
+	got, _ := recordsFromResult(verifyResp)
+	if !recordSetsEqual(got, final) {
+		return nil, true, nil
+	}
+
+	return &RecordChangeResult{
+		Added:    len(diff.Add),
+		Removed:  len(diff.Remove),
+		Kept:     len(diff.Keep),
+		Records:  final,
+		Response: setResp,
+	}, false, nil
+}

--- a/namecheap/domains_dns_records_test.go
+++ b/namecheap/domains_dns_records_test.go
@@ -1,0 +1,666 @@
+package namecheap
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// dnsMock is a stateful in-memory Namecheap DNS server for httptest. It behaves
+// like the real, non-transactional API: getHosts renders the current zone and
+// setHosts fully replaces it. This lets the read-modify-write helpers be
+// exercised end to end, with an afterSet hook to simulate a concurrent writer.
+type dnsMock struct {
+	mu        sync.Mutex
+	emailType string
+	zone      []DomainsDNSHostRecordDetailed
+	getCount  int
+	setCount  int
+	setParams []url.Values
+	nextID    int
+	// afterSet, when set, runs after each setHosts has replaced the zone, with the
+	// 1-based setHosts call index. It may mutate m.zone to simulate a concurrent
+	// modification by another writer.
+	afterSet func(m *dnsMock, setIndex int)
+}
+
+func newDNSMock(emailType string, zone []DomainsDNSHostRecordDetailed) *dnsMock {
+	return &dnsMock{emailType: emailType, zone: zone, nextID: 900000}
+}
+
+func (m *dnsMock) handle(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	query, _ := url.ParseQuery(string(body))
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	switch query.Get("Command") {
+	case "namecheap.domains.dns.getHosts":
+		m.getCount++
+		_, _ = w.Write([]byte(m.renderGetHosts()))
+	case "namecheap.domains.dns.setHosts":
+		m.setCount++
+		m.setParams = append(m.setParams, query)
+		m.zone = m.parseSetHosts(query)
+		if et := query.Get("EmailType"); et != "" {
+			m.emailType = et
+		}
+		if m.afterSet != nil {
+			m.afterSet(m, m.setCount)
+		}
+		_, _ = w.Write([]byte(setHostsOKResponse))
+	default:
+		_, _ = w.Write([]byte(setHostsOKResponse))
+	}
+}
+
+func (m *dnsMock) renderGetHosts() string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="utf-8"?>`)
+	b.WriteString(`<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">`)
+	b.WriteString(`<Errors /><Warnings />`)
+	b.WriteString(`<CommandResponse Type="namecheap.domains.dns.getHosts">`)
+	b.WriteString(`<DomainDNSGetHostsResult Domain="domain.net" EmailType="` + xmlAttr(m.emailType) + `" IsUsingOurDNS="true">`)
+	for _, h := range m.zone {
+		b.WriteString(renderHost(h))
+	}
+	b.WriteString(`</DomainDNSGetHostsResult></CommandResponse></ApiResponse>`)
+	return b.String()
+}
+
+func (m *dnsMock) parseSetHosts(q url.Values) []DomainsDNSHostRecordDetailed {
+	var zone []DomainsDNSHostRecordDetailed
+	for i := 1; ; i++ {
+		idx := strconv.Itoa(i)
+		recordType := q.Get("RecordType" + idx)
+		if recordType == "" {
+			break
+		}
+		m.nextID++
+		rec := DomainsDNSHostRecordDetailed{
+			HostId:  Int(m.nextID),
+			Name:    String(q.Get("HostName" + idx)),
+			Type:    String(recordType),
+			Address: String(q.Get("Address" + idx)),
+		}
+		if v := q.Get("TTL" + idx); v != "" {
+			if n, err := strconv.Atoi(v); err == nil {
+				rec.TTL = Int(n)
+			}
+		}
+		if v := q.Get("MXPref" + idx); v != "" {
+			if n, err := strconv.Atoi(v); err == nil {
+				rec.MXPref = Int(n)
+			}
+		}
+		zone = append(zone, rec)
+	}
+	return zone
+}
+
+const setHostsOKResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors /><Warnings />
+	<CommandResponse Type="namecheap.domains.dns.setHosts">
+		<DomainDNSSetHostsResult Domain="domain.net" IsSuccess="true"><Warnings /></DomainDNSSetHostsResult>
+	</CommandResponse>
+</ApiResponse>`
+
+func renderHost(h DomainsDNSHostRecordDetailed) string {
+	attrs := []string{
+		`HostId="` + strconv.Itoa(derefIntZero(h.HostId)) + `"`,
+		`Name="` + xmlAttr(derefStr(h.Name)) + `"`,
+		`Type="` + xmlAttr(derefStr(h.Type)) + `"`,
+		`Address="` + xmlAttr(derefStr(h.Address)) + `"`,
+	}
+	if h.MXPref != nil {
+		attrs = append(attrs, `MXPref="`+strconv.Itoa(*h.MXPref)+`"`)
+	}
+	if h.TTL != nil {
+		attrs = append(attrs, `TTL="`+strconv.Itoa(*h.TTL)+`"`)
+	}
+	attrs = append(attrs, `AssociatedAppTitle=""`, `FriendlyName=""`, `IsActive="true"`, `IsDDNSEnabled="false"`)
+	return "<host " + strings.Join(attrs, " ") + " />"
+}
+
+func xmlAttr(s string) string {
+	var buf bytes.Buffer
+	_ = xml.EscapeText(&buf, []byte(s))
+	return buf.String()
+}
+
+func derefIntZero(p *int) int {
+	if p == nil {
+		return 0
+	}
+	return *p
+}
+
+func mockedClient(m *dnsMock) (*Client, *httptest.Server) {
+	server := httptest.NewServer(http.HandlerFunc(m.handle))
+	client := setupClient(nil)
+	client.BaseURL = server.URL
+	return client, server
+}
+
+// detailed builds a getHosts-style detailed record. A nil mxpref leaves MXPref
+// unset (as the API does for non-MX records).
+func detailed(name, recordType, address string, mxpref *int, ttl int) DomainsDNSHostRecordDetailed {
+	d := DomainsDNSHostRecordDetailed{
+		HostId:             Int(100),
+		Name:               String(name),
+		Type:               String(recordType),
+		Address:            String(address),
+		TTL:                Int(ttl),
+		AssociatedAppTitle: String(""),
+		FriendlyName:       String(""),
+		IsActive:           Bool(true),
+		IsDDNSEnabled:      Bool(false),
+	}
+	if mxpref != nil {
+		d.MXPref = mxpref
+	}
+	return d
+}
+
+// fixtureAllTypes returns a zone containing every documented record type except
+// MXE. MX and MXE cannot coexist under a single EmailType (setHosts validation),
+// so this fixture uses EmailType=MX and includes the MX record; MXE is covered
+// separately by the Plan fixture (no write) and by TestRecordFromDetailed.
+func fixtureAllTypes() []DomainsDNSHostRecordDetailed {
+	return []DomainsDNSHostRecordDetailed{
+		detailed("@", RecordTypeA, "10.0.0.1", nil, 1800),
+		detailed("ipv6", RecordTypeAAAA, "2001:db8::1", nil, 1800),
+		detailed("alias", RecordTypeAlias, "target.example.com", nil, 1800),
+		detailed("@", RecordTypeCAA, `0 issue "letsencrypt.org"`, nil, 1800),
+		detailed("blog", RecordTypeCNAME, "hosting.example.com", nil, 1800),
+		detailed("mail", RecordTypeMX, "mailhost.example.com", Int(10), 1800),
+		detailed("@", RecordTypeNS, "dns1.example.com", nil, 1800),
+		detailed("@", RecordTypeTXT, "v=spf1 include:_spf.example.com ~all", nil, 1800),
+		detailed("go", RecordTypeURL, "https://example.com/go", nil, 1800),
+		detailed("old", RecordTypeURL301, "https://example.com/new", nil, 1800),
+		detailed("frame", RecordTypeFrame, "https://example.com/framed", nil, 1800),
+	}
+}
+
+// fixtureEveryType extends fixtureAllTypes with an MXE record (12 types). It is
+// used only by Plan, which never writes and so never triggers setHosts's MX/MXE
+// mutual-exclusion validation.
+func fixtureEveryType() []DomainsDNSHostRecordDetailed {
+	return append(fixtureAllTypes(), detailed("mxe", RecordTypeMXE, "10.0.0.5", nil, 1800))
+}
+
+// requestRecordIndex returns the 1-based index of the record in a setHosts
+// request matching host/type/address, or 0 if absent.
+func requestRecordIndex(params url.Values, host, recordType, address string) int {
+	for i := 1; ; i++ {
+		idx := strconv.Itoa(i)
+		rt := params.Get("RecordType" + idx)
+		if rt == "" {
+			return 0
+		}
+		if params.Get("HostName"+idx) == host && rt == recordType && params.Get("Address"+idx) == address {
+			return i
+		}
+	}
+}
+
+func requestHasHost(params url.Values, host, recordType string) bool {
+	for i := 1; ; i++ {
+		idx := strconv.Itoa(i)
+		rt := params.Get("RecordType" + idx)
+		if rt == "" {
+			return false
+		}
+		if params.Get("HostName"+idx) == host && rt == recordType {
+			return true
+		}
+	}
+}
+
+func assertRequestHasRecord(t *testing.T, params url.Values, host, recordType, address, ttl, mxpref string) {
+	t.Helper()
+	i := requestRecordIndex(params, host, recordType, address)
+	if i == 0 {
+		t.Errorf("record %s/%s/%s not found in setHosts request", host, recordType, address)
+		return
+	}
+	idx := strconv.Itoa(i)
+	if ttl != "" {
+		assert.Equal(t, ttl, params.Get("TTL"+idx), "TTL for %s/%s", host, recordType)
+	}
+	if mxpref != "" {
+		assert.Equal(t, mxpref, params.Get("MXPref"+idx), "MXPref for %s/%s", host, recordType)
+	}
+}
+
+func zoneHas(m *dnsMock, host, recordType, address string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, h := range m.zone {
+		if derefStr(h.Name) == host && derefStr(h.Type) == recordType && derefStr(h.Address) == address {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRecordFromDetailed(t *testing.T) {
+	t.Parallel()
+
+	t.Run("maps settable fields and drops read-only ones", func(t *testing.T) {
+		t.Parallel()
+		d := DomainsDNSHostRecordDetailed{
+			HostId:             Int(123),
+			Name:               String("mail"),
+			Type:               String(RecordTypeMX),
+			Address:            String("mailhost.example.com"),
+			MXPref:             Int(10),
+			TTL:                Int(1800),
+			AssociatedAppTitle: String("app"),
+			FriendlyName:       String("friendly"),
+			IsActive:           Bool(true),
+			IsDDNSEnabled:      Bool(true),
+		}
+		r := RecordFromDetailed(d)
+		assert.Equal(t, "mail", *r.HostName)
+		assert.Equal(t, RecordTypeMX, *r.RecordType)
+		assert.Equal(t, "mailhost.example.com", *r.Address)
+		assert.Equal(t, 1800, *r.TTL)
+		assert.Equal(t, uint8(10), *r.MXPref)
+	})
+
+	t.Run("nil mxpref stays nil", func(t *testing.T) {
+		t.Parallel()
+		r := RecordFromDetailed(DomainsDNSHostRecordDetailed{Name: String("@"), Type: String(RecordTypeA), Address: String("1.2.3.4")})
+		assert.Nil(t, r.MXPref)
+	})
+
+	t.Run("mxpref clamped to upper bound", func(t *testing.T) {
+		t.Parallel()
+		r := RecordFromDetailed(DomainsDNSHostRecordDetailed{MXPref: Int(9000)})
+		assert.Equal(t, uint8(255), *r.MXPref)
+	})
+
+	t.Run("mxpref clamped to lower bound", func(t *testing.T) {
+		t.Parallel()
+		r := RecordFromDetailed(DomainsDNSHostRecordDetailed{MXPref: Int(-5)})
+		assert.Equal(t, uint8(0), *r.MXPref)
+	})
+
+	t.Run("every documented record type maps its type through", func(t *testing.T) {
+		t.Parallel()
+		for _, rt := range AllowedRecordTypeValues {
+			r := RecordFromDetailed(DomainsDNSHostRecordDetailed{Name: String("@"), Type: String(rt), Address: String("x")})
+			assert.Equal(t, rt, *r.RecordType)
+		}
+	})
+}
+
+// TestKnownFieldsGuard fails loudly if a field is added to the getHosts response
+// structs without being consciously mapped or dropped in the record mapping.
+func TestKnownFieldsGuard(t *testing.T) {
+	t.Parallel()
+
+	detailedHandled := map[string]struct{}{
+		"HostId": {}, "Name": {}, "Type": {}, "Address": {}, "MXPref": {},
+		"TTL": {}, "AssociatedAppTitle": {}, "FriendlyName": {}, "IsActive": {},
+		"IsDDNSEnabled": {},
+	}
+	assertAllExportedFieldsHandled(t, reflect.TypeOf(DomainsDNSHostRecordDetailed{}), detailedHandled)
+
+	resultHandled := map[string]struct{}{
+		"Domain": {}, "EmailType": {}, "IsUsingOurDNS": {}, "Hosts": {},
+	}
+	assertAllExportedFieldsHandled(t, reflect.TypeOf(DomainDNSGetHostsResult{}), resultHandled)
+}
+
+func assertAllExportedFieldsHandled(t *testing.T, typ reflect.Type, handled map[string]struct{}) {
+	t.Helper()
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		if _, ok := handled[f.Name]; !ok {
+			t.Errorf("%s.%s is not accounted for in the record mapping; update RecordFromDetailed / recordsFromResult and this guard so the field is either mapped or consciously dropped", typ.Name(), f.Name)
+		}
+	}
+}
+
+func TestAddRecordsFidelity(t *testing.T) {
+	t.Parallel()
+	m := newDNSMock(EmailTypeMX, fixtureAllTypes())
+	client, server := mockedClient(m)
+	defer server.Close()
+
+	res, err := client.DomainsDNS.AddRecordsWithContext(context.Background(), "domain.net",
+		[]DomainsDNSHostRecord{
+			{HostName: String("new"), RecordType: String(RecordTypeA), Address: String("10.0.0.9"), TTL: Int(1800)},
+		})
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.Equal(t, 1, res.Added)
+	assert.Equal(t, 0, res.Removed)
+	assert.Equal(t, 11, res.Kept)
+	assert.Len(t, res.Records, 12)
+
+	// Exactly one setHosts, and EmailType is preserved in it.
+	assert.Len(t, m.setParams, 1)
+	assert.Equal(t, EmailTypeMX, m.setParams[0].Get("EmailType"))
+
+	// Unrelated records survive with all settable fields intact.
+	assertRequestHasRecord(t, m.setParams[0], "blog", RecordTypeCNAME, "hosting.example.com", "1800", "")
+	assertRequestHasRecord(t, m.setParams[0], "mail", RecordTypeMX, "mailhost.example.com", "1800", "10")
+	assertRequestHasRecord(t, m.setParams[0], "@", RecordTypeTXT, "v=spf1 include:_spf.example.com ~all", "1800", "")
+	assertRequestHasRecord(t, m.setParams[0], "@", RecordTypeCAA, `0 issue "letsencrypt.org"`, "1800", "")
+	// The intended change happened.
+	assertRequestHasRecord(t, m.setParams[0], "new", RecordTypeA, "10.0.0.9", "1800", "")
+	assert.True(t, zoneHas(m, "new", RecordTypeA, "10.0.0.9"))
+}
+
+func TestDeleteRecordsFidelity(t *testing.T) {
+	t.Parallel()
+	m := newDNSMock(EmailTypeMX, fixtureAllTypes())
+	client, server := mockedClient(m)
+	defer server.Close()
+
+	res, err := client.DomainsDNS.DeleteRecordsWithContext(context.Background(), "domain.net",
+		RecordSelector{HostName: String("blog"), RecordType: String(RecordTypeCNAME)})
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.Equal(t, 0, res.Added)
+	assert.Equal(t, 1, res.Removed)
+	assert.Equal(t, 10, res.Kept)
+	assert.Len(t, res.Records, 10)
+
+	assert.Equal(t, EmailTypeMX, m.setParams[0].Get("EmailType"))
+	// Target gone, unrelated records survive with fields intact.
+	assert.False(t, requestHasHost(m.setParams[0], "blog", RecordTypeCNAME))
+	assertRequestHasRecord(t, m.setParams[0], "mail", RecordTypeMX, "mailhost.example.com", "1800", "10")
+	assertRequestHasRecord(t, m.setParams[0], "@", RecordTypeTXT, "v=spf1 include:_spf.example.com ~all", "1800", "")
+	assert.False(t, zoneHas(m, "blog", RecordTypeCNAME, "hosting.example.com"))
+}
+
+func TestUpsertRecordsFidelity(t *testing.T) {
+	t.Parallel()
+	m := newDNSMock(EmailTypeMX, fixtureAllTypes())
+	client, server := mockedClient(m)
+	defer server.Close()
+
+	res, err := client.DomainsDNS.UpsertRecordsWithContext(context.Background(), "domain.net",
+		RecordSelector{RecordType: String(RecordTypeTXT)},
+		[]DomainsDNSHostRecord{
+			{HostName: String("@"), RecordType: String(RecordTypeTXT), Address: String("v=spf1 -all"), TTL: Int(1800)},
+			{HostName: String("_dmarc"), RecordType: String(RecordTypeTXT), Address: String("v=DMARC1; p=reject"), TTL: Int(1800)},
+		})
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.Equal(t, 2, res.Added)
+	assert.Equal(t, 1, res.Removed)
+	assert.Equal(t, 10, res.Kept)
+	assert.Len(t, res.Records, 12)
+
+	assert.Equal(t, EmailTypeMX, m.setParams[0].Get("EmailType"))
+	// Old TXT replaced by the two new TXT records.
+	assert.Equal(t, 0, requestRecordIndex(m.setParams[0], "@", RecordTypeTXT, "v=spf1 include:_spf.example.com ~all"))
+	assertRequestHasRecord(t, m.setParams[0], "@", RecordTypeTXT, "v=spf1 -all", "1800", "")
+	assertRequestHasRecord(t, m.setParams[0], "_dmarc", RecordTypeTXT, "v=DMARC1; p=reject", "1800", "")
+	// Untouched MX survives with fields intact.
+	assertRequestHasRecord(t, m.setParams[0], "mail", RecordTypeMX, "mailhost.example.com", "1800", "10")
+}
+
+func TestConcurrentModificationDetected(t *testing.T) {
+	t.Parallel()
+	m := newDNSMock(EmailTypeNone, []DomainsDNSHostRecordDetailed{
+		detailed("@", RecordTypeA, "10.0.0.1", nil, 1800),
+		detailed("www", RecordTypeA, "10.0.0.2", nil, 1800),
+	})
+	// Another writer adds a record after every setHosts, so verify never matches.
+	m.afterSet = func(m *dnsMock, _ int) {
+		m.zone = append(m.zone, detailed("gremlin", RecordTypeA, "10.0.0.99", nil, 1800))
+	}
+	client, server := mockedClient(m)
+	defer server.Close()
+
+	_, err := client.DomainsDNS.DeleteRecordsWithContext(context.Background(), "domain.net",
+		RecordSelector{HostName: String("www"), RecordType: String(RecordTypeA)})
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrConcurrentModification)
+	assert.Equal(t, 1, m.setCount) // no retry by default
+}
+
+func TestRetryOnConflictSucceedsSecondAttempt(t *testing.T) {
+	t.Parallel()
+	m := newDNSMock(EmailTypeNone, []DomainsDNSHostRecordDetailed{
+		detailed("@", RecordTypeA, "10.0.0.1", nil, 1800),
+		detailed("www", RecordTypeA, "10.0.0.2", nil, 1800),
+	})
+	// Inject a conflicting write only after the first setHosts; the second
+	// attempt's verify then matches.
+	m.afterSet = func(m *dnsMock, setIndex int) {
+		if setIndex == 1 {
+			m.zone = append(m.zone, detailed("gremlin", RecordTypeA, "10.0.0.99", nil, 1800))
+		}
+	}
+	client, server := mockedClient(m)
+	defer server.Close()
+
+	res, err := client.DomainsDNS.DeleteRecordsWithContext(context.Background(), "domain.net",
+		RecordSelector{HostName: String("www"), RecordType: String(RecordTypeA)},
+		WithRetryOnConflict(2))
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.Equal(t, 2, m.setCount) // succeeded on the second attempt
+}
+
+func TestDeleteRecordsEmptySelectorRejected(t *testing.T) {
+	t.Parallel()
+	m := newDNSMock(EmailTypeNone, []DomainsDNSHostRecordDetailed{
+		detailed("@", RecordTypeA, "10.0.0.1", nil, 1800),
+	})
+	client, server := mockedClient(m)
+	defer server.Close()
+
+	_, err := client.DomainsDNS.DeleteRecordsWithContext(context.Background(), "domain.net", RecordSelector{})
+	assert.Error(t, err)
+	var argErr *InvalidArgumentsError
+	assert.ErrorAs(t, err, &argErr)
+	// No HTTP call was made.
+	assert.Equal(t, 0, m.getCount)
+	assert.Equal(t, 0, m.setCount)
+}
+
+func TestDeleteRecordsMatchAllWipe(t *testing.T) {
+	t.Parallel()
+	m := newDNSMock(EmailTypeNone, []DomainsDNSHostRecordDetailed{
+		detailed("@", RecordTypeA, "10.0.0.1", nil, 1800),
+		detailed("www", RecordTypeA, "10.0.0.2", nil, 1800),
+	})
+	client, server := mockedClient(m)
+	defer server.Close()
+
+	res, err := client.DomainsDNS.DeleteRecordsWithContext(context.Background(), "domain.net", RecordSelector{MatchAll: true})
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.Equal(t, 2, res.Removed)
+	assert.Empty(t, res.Records)
+
+	m.mu.Lock()
+	remaining := len(m.zone)
+	m.mu.Unlock()
+	assert.Equal(t, 0, remaining)
+}
+
+func TestSelectorMatching(t *testing.T) {
+	t.Parallel()
+	rec := DomainsDNSHostRecord{
+		HostName: String("www"), RecordType: String(RecordTypeA),
+		Address: String("10.0.0.1"), TTL: Int(1800),
+	}
+	mxRec := DomainsDNSHostRecord{
+		HostName: String("mail"), RecordType: String(RecordTypeMX),
+		Address: String("mailhost.example.com"), MXPref: UInt8(10), TTL: Int(1800),
+	}
+	cases := []struct {
+		name     string
+		selector RecordSelector
+		record   DomainsDNSHostRecord
+		want     bool
+	}{
+		{"hostname match", RecordSelector{HostName: String("www")}, rec, true},
+		{"hostname case-insensitive", RecordSelector{HostName: String("WWW")}, rec, true},
+		{"hostname mismatch", RecordSelector{HostName: String("blog")}, rec, false},
+		{"type match case-insensitive", RecordSelector{RecordType: String("a")}, rec, true},
+		{"type mismatch", RecordSelector{RecordType: String(RecordTypeCNAME)}, rec, false},
+		{"address match", RecordSelector{Address: String("10.0.0.1")}, rec, true},
+		{"address trailing dot ignored", RecordSelector{Address: String("mailhost.example.com.")}, mxRec, true},
+		{"combined match", RecordSelector{HostName: String("www"), RecordType: String(RecordTypeA), Address: String("10.0.0.1")}, rec, true},
+		{"combined one field mismatch", RecordSelector{HostName: String("www"), RecordType: String(RecordTypeA), Address: String("10.0.0.2")}, rec, false},
+		{"mxpref match", RecordSelector{MXPref: UInt8(10)}, mxRec, true},
+		{"mxpref mismatch", RecordSelector{MXPref: UInt8(20)}, mxRec, false},
+		{"mxpref against nil record", RecordSelector{MXPref: UInt8(10)}, rec, false},
+		{"matchall", RecordSelector{MatchAll: true}, rec, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.selector.matches(tc.record))
+		})
+	}
+}
+
+func TestPlan(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		ops        []RecordOp
+		wantAdd    int
+		wantRemove int
+		wantKeep   int
+	}{
+		{
+			name:    "add",
+			ops:     []RecordOp{AddOp(DomainsDNSHostRecord{HostName: String("new"), RecordType: String(RecordTypeA), Address: String("10.0.0.9"), TTL: Int(1800)})},
+			wantAdd: 1, wantRemove: 0, wantKeep: 12,
+		},
+		{
+			name:    "delete",
+			ops:     []RecordOp{DeleteOp(RecordSelector{RecordType: String(RecordTypeTXT)})},
+			wantAdd: 0, wantRemove: 1, wantKeep: 11,
+		},
+		{
+			name: "upsert",
+			ops: []RecordOp{UpsertOp(
+				RecordSelector{HostName: String("blog"), RecordType: String(RecordTypeCNAME)},
+				[]DomainsDNSHostRecord{{HostName: String("blog"), RecordType: String(RecordTypeCNAME), Address: String("newhost.example.com"), TTL: Int(1800)}},
+			)},
+			wantAdd: 1, wantRemove: 1, wantKeep: 11,
+		},
+		{
+			name:    "no-op",
+			ops:     []RecordOp{DeleteOp(RecordSelector{HostName: String("doesnotexist")})},
+			wantAdd: 0, wantRemove: 0, wantKeep: 12,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m := newDNSMock(EmailTypeMX, fixtureEveryType())
+			client, server := mockedClient(m)
+			defer server.Close()
+
+			diff, err := client.DomainsDNS.PlanWithContext(context.Background(), "domain.net", tc.ops...)
+			assert.NoError(t, err)
+			assert.Len(t, diff.Add, tc.wantAdd)
+			assert.Len(t, diff.Remove, tc.wantRemove)
+			assert.Len(t, diff.Keep, tc.wantKeep)
+			// Plan performs a single read and zero writes.
+			assert.Equal(t, 1, m.getCount)
+			assert.Equal(t, 0, m.setCount)
+			assert.Contains(t, diff.String(), "RecordDiff:")
+		})
+	}
+}
+
+func TestPlanEmptySelectorRejected(t *testing.T) {
+	t.Parallel()
+	m := newDNSMock(EmailTypeMX, fixtureAllTypes())
+	client, server := mockedClient(m)
+	defer server.Close()
+
+	_, err := client.DomainsDNS.PlanWithContext(context.Background(), "domain.net", DeleteOp(RecordSelector{}))
+	assert.Error(t, err)
+	var argErr *InvalidArgumentsError
+	assert.ErrorAs(t, err, &argErr)
+	assert.Equal(t, 0, m.getCount)
+	assert.Equal(t, 0, m.setCount)
+}
+
+func TestNormalizeRecord(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		in      DomainsDNSHostRecord
+		host    string
+		rtype   string
+		address string
+		ttl     int
+	}{
+		{"nil ttl defaults to 1799", DomainsDNSHostRecord{HostName: String("@"), RecordType: String(RecordTypeA), Address: String("1.2.3.4")}, "@", "A", "1.2.3.4", 1799},
+		{"zero ttl defaults to 1799", DomainsDNSHostRecord{HostName: String("@"), RecordType: String(RecordTypeA), Address: String("1.2.3.4"), TTL: Int(0)}, "@", "A", "1.2.3.4", 1799},
+		{"explicit ttl kept", DomainsDNSHostRecord{HostName: String("@"), RecordType: String(RecordTypeA), Address: String("1.2.3.4"), TTL: Int(3600)}, "@", "A", "1.2.3.4", 3600},
+		{"host lower-cased and type upper-cased", DomainsDNSHostRecord{HostName: String("WWW"), RecordType: String("a"), Address: String("1.2.3.4")}, "www", "A", "1.2.3.4", 1799},
+		{"empty host becomes apex", DomainsDNSHostRecord{HostName: String(""), RecordType: String(RecordTypeA), Address: String("1.2.3.4")}, "@", "A", "1.2.3.4", 1799},
+		{"trailing dot trimmed from address", DomainsDNSHostRecord{HostName: String("blog"), RecordType: String(RecordTypeCNAME), Address: String("target.example.com.")}, "blog", "CNAME", "target.example.com", 1799},
+		{"txt address case preserved", DomainsDNSHostRecord{HostName: String("@"), RecordType: String(RecordTypeTXT), Address: String("V=spf1")}, "@", "TXT", "V=spf1", 1799},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := NormalizeRecord(tc.in)
+			assert.Equal(t, tc.host, *out.HostName)
+			assert.Equal(t, tc.rtype, *out.RecordType)
+			assert.Equal(t, tc.address, *out.Address)
+			assert.Equal(t, tc.ttl, *out.TTL)
+		})
+	}
+}
+
+func TestNormalizeRecordDoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+	host := "WWW"
+	addr := "target.com."
+	in := DomainsDNSHostRecord{HostName: &host, RecordType: String("a"), Address: &addr}
+	_ = NormalizeRecord(in)
+	assert.Equal(t, "WWW", host)
+	assert.Equal(t, "target.com.", addr)
+}
+
+func TestRecordsEqual(t *testing.T) {
+	t.Parallel()
+	a := DomainsDNSHostRecord{HostName: String("WWW"), RecordType: String("a"), Address: String("target.com."), TTL: Int(0)}
+	b := DomainsDNSHostRecord{HostName: String("www"), RecordType: String(RecordTypeA), Address: String("target.com"), TTL: Int(1799)}
+	assert.True(t, RecordsEqual(a, b))
+	assert.True(t, RecordsEqual(b, a)) // symmetric
+
+	c := DomainsDNSHostRecord{HostName: String("www"), RecordType: String(RecordTypeA), Address: String("other.com")}
+	assert.False(t, RecordsEqual(a, c))
+	assert.False(t, RecordsEqual(c, a))
+
+	// TTL is part of identity.
+	d := DomainsDNSHostRecord{HostName: String("www"), RecordType: String(RecordTypeA), Address: String("target.com"), TTL: Int(60)}
+	assert.False(t, RecordsEqual(b, d))
+}

--- a/namecheap/errors.go
+++ b/namecheap/errors.go
@@ -154,6 +154,21 @@ var (
 	ErrServerError error = &sentinelError{name: "server error", numbers: serverErrorNumbers}
 )
 
+// ErrConcurrentModification is returned by the record-level DNS helpers
+// (AddRecordsWithContext, DeleteRecordsWithContext, UpsertRecordsWithContext)
+// when the post-write verification read shows a record set that differs from
+// the one the helper intended to write. Because namecheap.domains.dns.setHosts
+// replaces the entire zone and is not transactional, this signals a lost-update
+// race: another writer changed the zone between the helper's read and its write.
+//
+// It is a client-side sentinel (not an *APIError). Match it with errors.Is:
+//
+//	if errors.Is(err, namecheap.ErrConcurrentModification) { /* re-read and retry */ }
+//
+// Pass WithRetryOnConflict to have the helper retry the whole
+// read-modify-write-verify cycle automatically instead of returning this error.
+var ErrConcurrentModification = errors.New("concurrent modification detected: DNS zone changed between read and write")
+
 // InvalidArgumentsError is a client-side validation error returned before any
 // HTTP request is made, when method arguments are missing or inconsistent. It
 // reports every offending field at once (not just the first) so a caller can fix


### PR DESCRIPTION
Closes #119. Phase 3 (ergonomics & safety) of the go-namecheap-sdk 2.0 roadmap (#122). Kills the single most dangerous footgun in the SDK once, for every consumer — de-duplicates the private read-modify-write logic in terraform-provider-namecheap and mcp-server-namecheap. Builds on ctx (#110) and typed errors (#111).

## Problem
`domains.dns.setHosts` **replaces the entire record set**. Changing one record means GetHosts → mutate → SetHosts, and forgetting a record type (or racing another writer) silently drops records (issue #49).

## What
New `DomainsDNSService` helpers (ctx-first, `WithContext` suffix per the #114 surface): `AddRecordsWithContext`, `DeleteRecordsWithContext`, `UpsertRecordsWithContext`, and `PlanWithContext` (dry-run diff, **zero writes**).

### Field fidelity (the correctness heart)
- `RecordFromDetailed` maps every **settable** GetHosts field into the SetHosts shape (`Name→HostName`, `Type→RecordType`, `MXPref *int→*uint8`, `TTL`); read-only server-managed fields (`HostId`, `FriendlyName`, `AssociatedAppTitle`, `IsActive`, `IsDDNSEnabled`) are consciously dropped + documented.
- **Zone-level `EmailType` is always preserved** onto the SetHosts request, so a partial update never silently changes email routing.
- A `reflect`-based **`knownFields` guard test** fails loudly if a future field is added to the GetHosts structs without being mapped — the AC's "new API field fails the test instead of being silently dropped."

### Safety
- **Optimistic concurrency**: after the write, re-read and compare (normalized, order-independent multiset); a mismatch returns the typed, `errors.Is`-able `ErrConcurrentModification`. `WithRetryOnConflict(n)` bounds an auto-retry loop (tested: succeeds on the 2nd attempt).
- **Selectors**: `RecordSelector` exact-matches any combination of HostName/RecordType/Address/MXPref; an empty selector is rejected (no accidental mass-delete); a full wipe requires explicit `MatchAll: true`.
- Exported `NormalizeRecord` (TTL default **1799** = Namecheap's "automatic" value; the old field comment said 1800) + `RecordsEqual`, reusable by consumers and the verify/diff engine.

## Acceptance criteria
- [x] Add/Delete/Upsert preserve unrelated records across the round-trip; fixture covers every record type + EmailType; `knownFields` exhaustiveness guard.
- [x] Race detection → `ErrConcurrentModification`; `WithRetryOnConflict` succeeds on 2nd attempt.
- [x] Empty selector → error; `MatchAll` required for full wipe.
- [x] `Plan` returns correct add/delete/upsert/no-op diffs and performs zero writes (mock asserts no setHosts).
- [x] Normalization TTL/case/@ table-tested; `RecordsEqual` symmetric.
- [x] `SetHosts`/`GetHosts` unchanged; existing tests untouched and green.
- [x] README "Managing individual DNS records" (the #49 answer in ~5 lines + non-transactional warning); CHANGELOG; doc comments on all exported identifiers.

## Design note
Method names use the `WithContext` suffix (consistent with #114) rather than the issue's illustrative unsuffixed sketch (`AddRecords(...)`). One real API constraint surfaced: MX and MXE can't coexist under one `EmailType`, so the mutating-fidelity fixture uses MX + 11 types and MXE is covered by the Plan fixture + `TestRecordFromDetailed`.

## Verification (local, go 1.26.4 + golangci-lint 2.12.2)
`go vet` ✅ · `golangci-lint run` → 0 issues ✅ · `go mod verify` (no new deps, go.mod/go.sum unchanged) ✅ · `make test` unit + **race** ✅ (382 tests, 93.8% coverage).
