### PR TITLE
feat: add users and users.address API groups (getPricing, getBalances, add-funds, address book)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New `UsersService` (`client.Users`), context-first with the `WithContext`
+  suffix and no non-context wrappers: `GetPricingWithContext`,
+  `GetBalancesWithContext`, `CreateAddFundsRequestWithContext`,
+  `GetAddFundsStatusWithContext`, `ChangePasswordWithContext` and
+  `UpdateWithContext`. Every struct field is cross-checked against
+  `docs/namecheap-api-v2.md`; each method carries the Namecheap doc URL (#117).
+- `GetPricing` models the deeply nested price sheet as navigable typed structs
+  (`ProductType → ProductCategory → Product → Price` tiers) matching the doc's
+  element/attribute names, plus the flattening helper
+  `UsersGetPricingResult.PriceFor(action, productName, years)` for the common
+  single-tier lookup and `Price.EffectivePrice()`, which resolves the documented
+  precedence (server-resolved `Price` incl. promo/special → `YourPrice` →
+  `RegularPrice`). All monetary values are `Amount` (exact decimal strings), never
+  `float64`. Fixtures cover DOMAIN, SSLCERTIFICATE and WHOISGUARD (#117).
+- `GetBalances` returns typed decimal-safe amounts (`Amount`) and currency (#117).
+- Add-funds flow with `AddFundsStatus` constants (`CREATED`, `SUBMITTED`,
+  `COMPLETED`, `FAILED`, `EXPIRED`). `CreateAddFundsRequest` is classified
+  **non-idempotent** (charge-bearing): an ambiguous transport/server failure is
+  never retried (only Namecheap's pre-execution HTTP 405 is), so it can never
+  double-charge; reconcile via `GetAddFundsStatus` (#117).
+- `ChangePassword` supports both the old-password and reset-code methods; password
+  values are only ever placed in the outbound request parameters — never stored or
+  logged. Hook-level redaction is deferred to the logging layer (#113) (#117).
+- New `UsersAddressService` (`client.UsersAddress`) with full context-first CRUD:
+  `CreateWithContext`, `UpdateWithContext`, `DeleteWithContext`,
+  `GetInfoWithContext`, `GetListWithContext`, `SetDefaultWithContext` (#117).
+- `ContactInfo` ↔ address-book adapter, bidirectional and tested for no field
+  drift: `ContactInfo.ToAddressDetails`, `UsersAddressDetails.ToContactInfo` and
+  `UsersAddressGetInfoResult.ToContactInfo`, so a stored address can feed the
+  `domains.create` contact blocks. The two renamed correspondences
+  (`PostalCode` ↔ `Zip`, `OrganizationName` ↔ `Organization`) are mapped
+  explicitly (#117).
+- The reseller account-creation surface (`users.create`, `users.login`,
+  `users.resetPassword`) is deferred (planned, unscheduled) and documented in the
+  README coverage matrix with the reseller-only rationale (#117).
 - Record-level DNS helpers on `DomainsDNSService`, all context-first with the
   `WithContext` suffix and no non-context wrappers:
   `AddRecordsWithContext` (append, preserving all existing records),

--- a/README.md
+++ b/README.md
@@ -270,6 +270,143 @@ _, err := client.DomainsNS.CreateWithContext(ctx, "domain", "com", "ns1.domain.c
 _, err = client.DomainsNS.DeleteWithContext(ctx, "domain", "com", "ns1.domain.com")
 ```
 
+#### Users (`client.Users`)
+
+| Method | Description |
+|---|---|
+| `GetPricingWithContext(ctx, args)` | Get the full price sheet for a product type (DOMAIN/SSLCERTIFICATE/WHOISGUARD) |
+| `GetBalancesWithContext(ctx)` | Get account funds (decimal-safe amounts + currency) |
+| `CreateAddFundsRequestWithContext(ctx, args)` | Create a credit-card add-funds request (charge-bearing, non-idempotent) |
+| `GetAddFundsStatusWithContext(ctx, tokenID)` | Get the status of an add-funds request |
+| `ChangePasswordWithContext(ctx, args)` | Change the account password (old-password or reset-code method) |
+| `UpdateWithContext(ctx, args)` | Update the account contact information |
+
+The pricing response is a deeply nested tree (`ProductType → ProductCategory →
+Product → Price` tiers). Navigate it directly, or use `PriceFor` for the common
+single-tier lookup. Money is never parsed to `float64`: every amount is an
+`Amount` (the exact server decimal string). `Price.EffectivePrice()` resolves the
+documented precedence — server-resolved `Price` (which already reflects any
+promo/special), then `YourPrice` (account price), then `RegularPrice` (list
+price). The sheet is large and slow-changing, so fetch it once and cache it.
+
+```go
+// Example: check the balance before a bulk renew.
+// Amount is an exact decimal string, never a float64 — convert it to a decimal
+// type (here math/big.Rat) at the point you need the numeric comparison.
+balances, err := client.Users.GetBalancesWithContext(ctx)
+if err != nil {
+    log.Fatal(err)
+}
+result := balances.UserGetBalancesResult
+have, ok := new(big.Rat).SetString(result.AvailableBalance.String())
+need := big.NewRat(10000, 100) // 100.00
+if !ok || have.Cmp(need) < 0 {
+    log.Fatalf("insufficient funds: %s %s available, gate the batch",
+        result.Currency, result.AvailableBalance)
+}
+// ... proceed with the renew batch.
+```
+
+```go
+// Example: find the cheapest TLD among com/net/org for a 1-year registration.
+pricing, err := client.Users.GetPricingWithContext(ctx, &namecheap.UsersGetPricingArgs{
+    ProductType: namecheap.String("DOMAIN"),
+    ActionName:  namecheap.String("REGISTER"),
+})
+if err != nil {
+    log.Fatal(err)
+}
+result := pricing.UserGetPricingResult
+var cheapestTLD string
+var cheapest *big.Rat
+for _, tld := range []string{"com", "net", "org"} {
+    price, ok := result.PriceFor("REGISTER", tld, 1)
+    if !ok {
+        continue
+    }
+    // Compare as decimals, not strings: "8.88" < "10.50" numerically, but not
+    // lexicographically.
+    eff, ok := new(big.Rat).SetString(price.EffectivePrice().String())
+    if !ok {
+        continue
+    }
+    if cheapest == nil || eff.Cmp(cheapest) < 0 {
+        cheapestTLD, cheapest = tld, eff
+    }
+}
+fmt.Printf("cheapest: .%s at %s\n", cheapestTLD, cheapest.FloatString(2))
+```
+
+> **Note:** `AddFundsRequest` is charge-bearing and **non-idempotent** — an
+> ambiguous transport/server failure is never retried (only Namecheap's
+> pre-execution HTTP 405 rate-limit signal is), so it can never double-charge.
+> Reconcile an ambiguous failure with `GetAddFundsStatusWithContext`. The
+> `changePassword` password values are only ever placed in the outbound request
+> parameters — never stored, logged, or echoed in errors; hook-level redaction
+> lands with the logging layer in [#113](https://github.com/namecheap/go-namecheap-sdk/issues/113).
+
+##### Users API coverage matrix
+
+| `namecheap.users.*` command | Status |
+|---|---|
+| `getPricing` | Implemented |
+| `getBalances` | Implemented |
+| `createaddfundsrequest` | Implemented |
+| `getAddFundsStatus` | Implemented |
+| `changePassword` | Implemented |
+| `update` | Implemented |
+| `create` | Planned, unscheduled (reseller-only account creation; weak demand) |
+| `login` | Planned, unscheduled (validates only accounts made via `users.create`) |
+| `resetPassword` | Planned, unscheduled (reseller account-creation flow) |
+
+#### UsersAddress (`client.UsersAddress`)
+
+The address book stores reusable registrant profiles. An entry holds the same
+logical fields as a domain `ContactInfo`, so a stored address can feed the
+contact blocks of `domains.create`.
+
+| Method | Description |
+|---|---|
+| `CreateWithContext(ctx, details)` | Add a new address-book entry |
+| `UpdateWithContext(ctx, addressID, details)` | Update an existing entry |
+| `DeleteWithContext(ctx, addressID)` | Delete an entry |
+| `GetInfoWithContext(ctx, addressID)` | Get the full stored address |
+| `GetListWithContext(ctx)` | List every entry (id + name) |
+| `SetDefaultWithContext(ctx, addressID)` | Mark an entry as the account default |
+
+```go
+// Reuse a stored address as a domains.create contact block.
+info, err := client.UsersAddress.GetInfoWithContext(ctx, 777)
+if err != nil {
+    log.Fatal(err)
+}
+contact := info.GetAddressInfoResult.ToContactInfo()
+_, err = client.Domains.CreateWithContext(ctx, &namecheap.DomainsCreateArgs{
+    DomainName: "example.com",
+    Years:      1,
+    Registrant: contact, Tech: contact, Admin: contact, AuxBilling: contact,
+})
+```
+
+The `ContactInfo` ↔ address-book adapter maps the twelve shared logical fields in
+both directions (`ContactInfo.ToAddressDetails`, `UsersAddressDetails.ToContactInfo`,
+`UsersAddressGetInfoResult.ToContactInfo`). Two field names differ between the two
+API shapes and are mapped explicitly: `PostalCode` ↔ `Zip` and `OrganizationName`
+↔ `Organization`. The address book also carries five fields `ContactInfo` has no
+counterpart for (`AddressName`, `DefaultYN`, `StateProvinceChoice`, `PhoneExt`,
+`Fax`); set `StateProvinceChoice` yourself before create/update, as it is required.
+
+##### UsersAddress API coverage matrix
+
+| `namecheap.users.address.*` command | Status |
+|---|---|
+| `create` | Implemented |
+| `update` | Implemented |
+| `delete` | Implemented |
+| `getInfo` | Implemented |
+| `getList` | Implemented |
+| `setDefault` | Implemented |
+
 ### Error handling
 
 When the API rejects a call it returns a typed `*namecheap.APIError` carrying the

--- a/namecheap/doc.go
+++ b/namecheap/doc.go
@@ -1,10 +1,10 @@
 // Package namecheap provides a Go client for the Namecheap API.
 //
 // Construct a Client with NewClient and call the service methods on
-// Client.Domains, Client.DomainsDNS and Client.DomainsNS. Every call takes a
-// context.Context as its first argument; cancelling it aborts the in-flight
-// HTTP request, a pending rate-limit or concurrency wait, and any inter-retry
-// backoff sleep.
+// Client.Domains, Client.DomainsDNS, Client.DomainsNS, Client.Users and
+// Client.UsersAddress. Every call takes a context.Context as its first argument;
+// cancelling it aborts the in-flight HTTP request, a pending rate-limit or
+// concurrency wait, and any inter-retry backoff sleep.
 //
 // # Error handling
 //

--- a/namecheap/namecheap.go
+++ b/namecheap/namecheap.go
@@ -63,6 +63,9 @@ type Client struct {
 	Domains    *DomainsService
 	DomainsNS  *DomainsNSService
 	DomainsDNS *DomainsDNSService
+
+	Users        *UsersService
+	UsersAddress *UsersAddressService
 }
 
 type service struct {
@@ -104,6 +107,8 @@ func NewClient(options *ClientOptions) *Client {
 	client.Domains = (*DomainsService)(&client.common)
 	client.DomainsDNS = (*DomainsDNSService)(&client.common)
 	client.DomainsNS = (*DomainsNSService)(&client.common)
+	client.Users = (*UsersService)(&client.common)
+	client.UsersAddress = (*UsersAddressService)(&client.common)
 
 	return client
 }

--- a/namecheap/users.go
+++ b/namecheap/users.go
@@ -1,0 +1,13 @@
+package namecheap
+
+// UsersService groups the namecheap.users.* API commands: pricing and account
+// funds (GetPricingWithContext, GetBalancesWithContext), the add-funds flow
+// (CreateAddFundsRequestWithContext, GetAddFundsStatusWithContext), and account
+// maintenance (ChangePasswordWithContext, UpdateWithContext).
+//
+// The reseller account-creation surface (namecheap.users.create,
+// namecheap.users.login and namecheap.users.resetPassword) is intentionally not
+// implemented; see the coverage matrix in README.md for the rationale.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/users/
+type UsersService service

--- a/namecheap/users_add_funds.go
+++ b/namecheap/users_add_funds.go
@@ -1,0 +1,187 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+)
+
+// AddFundsStatus is the state of an add-funds request as reported by
+// namecheap.users.getAddFundsStatus. The documented values are listed in
+// docs/namecheap-api-v2.md (line 1256).
+type AddFundsStatus string
+
+// Documented add-funds statuses (docs/namecheap-api-v2.md line 1256).
+const (
+	// AddFundsStatusCreated means the request was created but not yet submitted.
+	AddFundsStatusCreated AddFundsStatus = "CREATED"
+	// AddFundsStatusSubmitted means the payment was submitted and is processing.
+	AddFundsStatusSubmitted AddFundsStatus = "SUBMITTED"
+	// AddFundsStatusCompleted means the funds were added successfully.
+	AddFundsStatusCompleted AddFundsStatus = "COMPLETED"
+	// AddFundsStatusFailed means the request failed.
+	AddFundsStatusFailed AddFundsStatus = "FAILED"
+	// AddFundsStatusExpired means the request expired before completion.
+	AddFundsStatusExpired AddFundsStatus = "EXPIRED"
+)
+
+// PaymentTypeCreditcard is the only documented PaymentType for
+// createaddfundsrequest (docs/namecheap-api-v2.md line 1224).
+const PaymentTypeCreditcard = "Creditcard"
+
+// UsersCreateAddFundsRequestResponse is the raw envelope for
+// namecheap.users.createaddfundsrequest.
+type UsersCreateAddFundsRequestResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *UsersCreateAddFundsRequestCommandResponse `xml:"CommandResponse"`
+}
+
+// UsersCreateAddFundsRequestCommandResponse wraps the createaddfundsrequest
+// result.
+type UsersCreateAddFundsRequestCommandResponse struct {
+	CreateAddFundsRequestResult *UsersCreateAddFundsRequestResult `xml:"CreateAddFundsRequestResult"`
+}
+
+// UsersCreateAddFundsRequestResult is the outcome of an add-funds request. Field
+// names follow the response table in docs/namecheap-api-v2.md (lines 1230-1234).
+type UsersCreateAddFundsRequestResult struct {
+	// TokenID is the unique ID used to redirect the user to the add-funds page and
+	// to poll GetAddFundsStatusWithContext.
+	TokenID *string `xml:"TokenID,attr"`
+	// RedirectURL is the URL for submitting credit-card details.
+	RedirectURL *string `xml:"RedirectURL,attr"`
+	// ReturnURL is the URL the user is redirected to after payment.
+	ReturnURL *string `xml:"ReturnURL,attr"`
+}
+
+// UsersCreateAddFundsRequestArgs are the arguments for
+// CreateAddFundsRequestWithContext. Field names and required status follow the
+// request table in docs/namecheap-api-v2.md (lines 1221-1226).
+//
+// The doc's "Username" parameter is not exposed here: the transport reserves the
+// "Username" request parameter for the authenticated account (ClientOptions.
+// UserName) and sets it on every call, so funds are always added to the
+// authenticated user's account and a separate field would be silently overwritten.
+type UsersCreateAddFundsRequestArgs struct {
+	// PaymentType is the payment method. Required; the only documented value is
+	// PaymentTypeCreditcard.
+	PaymentType string
+	// Amount is the amount to add, as an exact decimal string (see Amount).
+	// Required.
+	Amount Amount
+	// ReturnURL is the URL to redirect the user to after payment. Required. It is
+	// sent as the "ReturnUrl" request parameter (the response echoes it back as
+	// "ReturnURL").
+	ReturnURL string
+}
+
+// CreateAddFundsRequestWithContext creates a credit-card add-funds request.
+//
+// It is a charge-bearing, non-idempotent call: on an ambiguous transport or
+// server-side failure the SDK does NOT retry (a resend could create a duplicate
+// funding request / double charge), so the caller must reconcile such failures
+// via GetAddFundsStatusWithContext or the account history. Only Namecheap's
+// pre-execution HTTP 405 rate-limit signal is retried. This mirrors the money
+// rule established for domains create/renew in #114.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/users/create-add-funds-request/
+func (us *UsersService) CreateAddFundsRequestWithContext(ctx context.Context, args *UsersCreateAddFundsRequestArgs) (*UsersCreateAddFundsRequestCommandResponse, error) {
+	if args == nil {
+		return nil, &InvalidArgumentsError{Fields: []string{"args"}, Reason: "args must not be nil"}
+	}
+	if err := args.validate(); err != nil {
+		return nil, err
+	}
+
+	var response UsersCreateAddFundsRequestResponse
+	// idempotent=false: never retry a charge-bearing call on an ambiguous error.
+	_, err := us.client.doXML(ctx, args.params(), &response, false)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}
+
+// validate reports every missing required field at once.
+func (a *UsersCreateAddFundsRequestArgs) validate() error {
+	missing := make([]string, 0, 3)
+	if a.PaymentType == "" {
+		missing = append(missing, "PaymentType")
+	}
+	if a.Amount == "" {
+		missing = append(missing, "Amount")
+	}
+	if a.ReturnURL == "" {
+		missing = append(missing, "ReturnUrl")
+	}
+	if len(missing) > 0 {
+		return &InvalidArgumentsError{Fields: missing}
+	}
+	return nil
+}
+
+// params flattens the validated args into the request map. The "Username"
+// parameter is supplied by the transport from the authenticated credentials.
+func (a *UsersCreateAddFundsRequestArgs) params() map[string]string {
+	return map[string]string{
+		"Command":     "namecheap.users.createaddfundsrequest",
+		"PaymentType": a.PaymentType,
+		"Amount":      a.Amount.String(),
+		"ReturnUrl":   a.ReturnURL,
+	}
+}
+
+// UsersGetAddFundsStatusResponse is the raw envelope for
+// namecheap.users.getAddFundsStatus.
+type UsersGetAddFundsStatusResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *UsersGetAddFundsStatusCommandResponse `xml:"CommandResponse"`
+}
+
+// UsersGetAddFundsStatusCommandResponse wraps the getAddFundsStatus result.
+type UsersGetAddFundsStatusCommandResponse struct {
+	GetAddFundsStatusResult *UsersGetAddFundsStatusResult `xml:"GetAddFundsStatusResult"`
+}
+
+// UsersGetAddFundsStatusResult is the status of an add-funds request. Field names
+// follow the response table in docs/namecheap-api-v2.md (lines 1252-1256).
+type UsersGetAddFundsStatusResult struct {
+	// TransactionID is the unique integer identifying the transaction.
+	TransactionID *int `xml:"TransactionID,attr"`
+	// Amount is the amount added, as an exact decimal string (see Amount).
+	Amount *Amount `xml:"Amount,attr"`
+	// Status is the request status, one of the AddFundsStatus constants.
+	Status AddFundsStatus `xml:"Status,attr"`
+}
+
+// GetAddFundsStatusWithContext returns the status of an add-funds request
+// previously created with CreateAddFundsRequestWithContext.
+//
+// It is a read-only, idempotent call: unlike the create call it is safe to retry,
+// and it is the reconciliation path for an ambiguous create failure.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/users/get-add-funds-status/
+func (us *UsersService) GetAddFundsStatusWithContext(ctx context.Context, tokenID string) (*UsersGetAddFundsStatusCommandResponse, error) {
+	if tokenID == "" {
+		return nil, &InvalidArgumentsError{Fields: []string{"TokenId"}}
+	}
+
+	var response UsersGetAddFundsStatusResponse
+	params := map[string]string{
+		"Command": "namecheap.users.getAddFundsStatus",
+		"TokenId": tokenID,
+	}
+
+	_, err := us.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/users_add_funds_test.go
+++ b/namecheap/users_add_funds_test.go
@@ -1,0 +1,166 @@
+package namecheap
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const createAddFundsResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.users.createaddfundsrequest">
+		<CreateAddFundsRequestResult TokenID="1234567890" RedirectURL="https://sandbox.namecheap.com/addfunds?token=1234567890" ReturnURL="https://example.com/done" />
+	</CommandResponse>
+</ApiResponse>`
+
+const getAddFundsStatusResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.users.getAddFundsStatus">
+		<GetAddFundsStatusResult TransactionID="998877" Amount="50.00" Status="COMPLETED" />
+	</CommandResponse>
+</ApiResponse>`
+
+func validAddFundsArgs() *UsersCreateAddFundsRequestArgs {
+	return &UsersCreateAddFundsRequestArgs{
+		PaymentType: PaymentTypeCreditcard,
+		Amount:      Amount("50.00"),
+		ReturnURL:   "https://example.com/done",
+	}
+}
+
+func TestUsersService_CreateAddFundsRequest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		var sent url.Values
+		client := usersMockClient(t, createAddFundsResponse, &sent)
+
+		resp, err := client.Users.CreateAddFundsRequestWithContext(context.Background(), validAddFundsArgs())
+		mustNoError(t, err)
+
+		assert.Equal(t, "namecheap.users.createaddfundsrequest", sent.Get("Command"))
+		assert.Equal(t, "Creditcard", sent.Get("PaymentType"))
+		assert.Equal(t, "50.00", sent.Get("Amount"))
+		assert.Equal(t, "https://example.com/done", sent.Get("ReturnUrl"))
+		// The target account is the authenticated user, set by the transport.
+		assert.Equal(t, ncUserName, sent.Get("Username"))
+
+		result := resp.CreateAddFundsRequestResult
+		mustNotNil(t, result)
+		assert.Equal(t, "1234567890", *result.TokenID)
+		assert.Equal(t, "https://sandbox.namecheap.com/addfunds?token=1234567890", *result.RedirectURL)
+		assert.Equal(t, "https://example.com/done", *result.ReturnURL)
+	})
+
+	t.Run("nil args", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.Users.CreateAddFundsRequestWithContext(context.Background(), nil)
+		assertInvalidArguments(t, err, "args")
+	})
+
+	t.Run("missing required fields reported all at once no http", func(t *testing.T) {
+		t.Parallel()
+		var called int32
+		server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			atomic.AddInt32(&called, 1)
+		}))
+		defer server.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = server.URL
+
+		_, err := client.Users.CreateAddFundsRequestWithContext(context.Background(), &UsersCreateAddFundsRequestArgs{})
+		assertInvalidArguments(t, err, "PaymentType", "Amount", "ReturnUrl")
+		assert.Equal(t, int32(0), atomic.LoadInt32(&called), "no charge-bearing call may happen when validation fails")
+	})
+}
+
+// TestUsersService_CreateAddFundsRequest_NonIdempotent proves the charge-bearing
+// createaddfundsrequest is NOT retried on an ambiguous retryable server error —
+// exactly one attempt is made — mirroring the #114 idempotency test for
+// domains.create.
+func TestUsersService_CreateAddFundsRequest_NonIdempotent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("server error single attempt", func(t *testing.T) {
+		t.Parallel()
+		var calls int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&calls, 1)
+			_, _ = w.Write([]byte(apiErrorXML(5050900, "Server exception")))
+		}))
+		defer server.Close()
+
+		client := newResilienceClient(server.URL, func(o *ClientOptions) {
+			o.RateLimit = &RateLimitOptions{Disabled: true}
+			o.Retry = &RetryOptions{MaxAttempts: 4, BaseDelay: time.Millisecond, MaxDelay: 2 * time.Millisecond}
+		})
+
+		_, err := client.Users.CreateAddFundsRequestWithContext(context.Background(), validAddFundsArgs())
+		assertAPIError(t, err, 5050900)
+		assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "an ambiguous server error must not be retried on a charge-bearing call")
+		assert.NotContains(t, err.Error(), "after")
+	})
+
+	t.Run("transport timeout single attempt", func(t *testing.T) {
+		t.Parallel()
+		rt := &countingErrRT{err: timeoutError{}}
+		client := newResilienceClient("http://127.0.0.1:0", func(o *ClientOptions) {
+			o.Transport = rt
+			o.RateLimit = &RateLimitOptions{Disabled: true}
+			o.Retry = &RetryOptions{MaxAttempts: 4, BaseDelay: time.Millisecond, MaxDelay: 2 * time.Millisecond}
+		})
+
+		_, err := client.Users.CreateAddFundsRequestWithContext(context.Background(), validAddFundsArgs())
+		assert.Error(t, err)
+		assert.Equal(t, 1, rt.count(), "an ambiguous timeout must not be retried on a charge-bearing call")
+	})
+}
+
+func TestUsersService_GetAddFundsStatus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		var sent url.Values
+		client := usersMockClient(t, getAddFundsStatusResponse, &sent)
+
+		resp, err := client.Users.GetAddFundsStatusWithContext(context.Background(), "1234567890")
+		mustNoError(t, err)
+
+		assert.Equal(t, "namecheap.users.getAddFundsStatus", sent.Get("Command"))
+		assert.Equal(t, "1234567890", sent.Get("TokenId"))
+
+		result := resp.GetAddFundsStatusResult
+		mustNotNil(t, result)
+		assert.Equal(t, 998877, *result.TransactionID)
+		assert.Equal(t, Amount("50.00"), *result.Amount)
+		assert.Equal(t, AddFundsStatusCompleted, result.Status)
+	})
+
+	t.Run("empty token", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.Users.GetAddFundsStatusWithContext(context.Background(), "")
+		assertInvalidArguments(t, err, "TokenId")
+	})
+}
+
+func TestAddFundsStatusConstants(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, AddFundsStatus("CREATED"), AddFundsStatusCreated)
+	assert.Equal(t, AddFundsStatus("SUBMITTED"), AddFundsStatusSubmitted)
+	assert.Equal(t, AddFundsStatus("COMPLETED"), AddFundsStatusCompleted)
+	assert.Equal(t, AddFundsStatus("FAILED"), AddFundsStatusFailed)
+	assert.Equal(t, AddFundsStatus("EXPIRED"), AddFundsStatusExpired)
+}

--- a/namecheap/users_address.go
+++ b/namecheap/users_address.go
@@ -1,0 +1,177 @@
+package namecheap
+
+// UsersAddressService groups the namecheap.users.address.* API commands: the
+// address-book CRUD used to store reusable registrant profiles
+// (CreateWithContext, UpdateWithContext, DeleteWithContext, GetInfoWithContext,
+// GetListWithContext, SetDefaultWithContext).
+//
+// An address-book entry stores the same logical fields as a domain ContactInfo,
+// so an entry can feed the contact blocks of domains.create. Convert between the
+// two shapes with ContactInfo.ToAddressDetails and UsersAddressDetails.ToContactInfo
+// (and UsersAddressGetInfoResult.ToContactInfo for a fetched entry).
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/users/address/
+type UsersAddressService service
+
+// UsersAddressDetails holds the mutable fields of an address-book entry shared by
+// create and update. Field names and required/optional status follow the
+// address.create request table in docs/namecheap-api-v2.md (lines 1347-1365); the
+// same fields (plus AddressId) drive address.update (lines 1460-1477).
+//
+// Field naming differs from the domain ContactInfo shape: the address book uses
+// "Zip" (not "PostalCode") and "Organization" (not "OrganizationName"), and it
+// carries five fields ContactInfo has no counterpart for: AddressName, DefaultYN,
+// StateProvinceChoice, PhoneExt and Fax. The adapter maps only the twelve shared
+// logical fields (see ToContactInfo / ContactInfo.ToAddressDetails).
+type UsersAddressDetails struct {
+	// AddressName is the address label. Required.
+	AddressName string
+	// DefaultYN, when non-nil, sets (true -> "1") or clears (false -> "0") the
+	// default flag. Nil omits the parameter. Optional.
+	DefaultYN *bool
+	// EmailAddress is the contact e-mail address. Required.
+	EmailAddress string
+	// FirstName is the contact's first name. Required.
+	FirstName string
+	// LastName is the contact's last name. Required.
+	LastName string
+	// JobTitle is the contact's job designation. Optional.
+	JobTitle string
+	// Organization is the contact's organization. Optional.
+	Organization string
+	// Address1 is the primary street address. Required.
+	Address1 string
+	// Address2 is the secondary street address. Optional.
+	Address2 string
+	// City is the contact's city. Required.
+	City string
+	// StateProvince is the state or province. Required.
+	StateProvince string
+	// StateProvinceChoice is the state/province choice. Required. Address-book
+	// only; ContactInfo has no counterpart.
+	StateProvinceChoice string
+	// Zip is the postal/ZIP code. Required. (ContactInfo calls this PostalCode.)
+	Zip string
+	// Country is the two-letter country code. Required.
+	Country string
+	// Phone is the phone number in +NNN.NNNNNNNNNN format. Required.
+	Phone string
+	// PhoneExt is the phone extension. Optional.
+	PhoneExt string
+	// Fax is the fax number. Optional.
+	Fax string
+}
+
+// requiredAddressFields returns the eleven always-required fields paired with
+// their values (the doc marks these Required for both create and update). Optional
+// fields (JobTitle, Organization, Address2, PhoneExt, Fax) and the DefaultYN flag
+// are excluded.
+func (d UsersAddressDetails) requiredAddressFields() []requiredContactField {
+	return []requiredContactField{
+		{"AddressName", d.AddressName},
+		{"EmailAddress", d.EmailAddress},
+		{"FirstName", d.FirstName},
+		{"LastName", d.LastName},
+		{"Address1", d.Address1},
+		{"City", d.City},
+		{"StateProvince", d.StateProvince},
+		{"StateProvinceChoice", d.StateProvinceChoice},
+		{"Zip", d.Zip},
+		{"Country", d.Country},
+		{"Phone", d.Phone},
+	}
+}
+
+// missingFields returns the names of every required field that is empty, so a
+// caller sees the complete list in a single error.
+func (d UsersAddressDetails) missingFields() []string {
+	req := d.requiredAddressFields()
+	missing := make([]string, 0, len(req))
+	for _, f := range req {
+		if f.value == "" {
+			missing = append(missing, f.suffix)
+		}
+	}
+	return missing
+}
+
+// apply flattens the details into params. Required fields are always written
+// (callers validate first); optional fields are written only when non-empty, and
+// DefaultYN only when set.
+func (d UsersAddressDetails) apply(params map[string]string) {
+	params["AddressName"] = d.AddressName
+	params["EmailAddress"] = d.EmailAddress
+	params["FirstName"] = d.FirstName
+	params["LastName"] = d.LastName
+	params["Address1"] = d.Address1
+	params["City"] = d.City
+	params["StateProvince"] = d.StateProvince
+	params["StateProvinceChoice"] = d.StateProvinceChoice
+	params["Zip"] = d.Zip
+	params["Country"] = d.Country
+	params["Phone"] = d.Phone
+	setIfNotEmpty(params, "JobTitle", d.JobTitle)
+	setIfNotEmpty(params, "Organization", d.Organization)
+	setIfNotEmpty(params, "Address2", d.Address2)
+	setIfNotEmpty(params, "PhoneExt", d.PhoneExt)
+	setIfNotEmpty(params, "Fax", d.Fax)
+	if d.DefaultYN != nil {
+		params["DefaultYN"] = oneZero(*d.DefaultYN)
+	}
+}
+
+// ToContactInfo converts the twelve shared logical fields of an address-book
+// entry into a domain ContactInfo, so a stored address can feed the contact
+// blocks of domains.create. The name mappings are: Zip -> PostalCode and
+// Organization -> OrganizationName; the other ten fields map by identical name.
+// Address-book-only fields (AddressName, DefaultYN, StateProvinceChoice,
+// PhoneExt, Fax) have no ContactInfo counterpart and are dropped.
+func (d UsersAddressDetails) ToContactInfo() ContactInfo {
+	return ContactInfo{
+		FirstName:        d.FirstName,
+		LastName:         d.LastName,
+		Address1:         d.Address1,
+		City:             d.City,
+		StateProvince:    d.StateProvince,
+		PostalCode:       d.Zip,
+		Country:          d.Country,
+		Phone:            d.Phone,
+		EmailAddress:     d.EmailAddress,
+		OrganizationName: d.Organization,
+		JobTitle:         d.JobTitle,
+		Address2:         d.Address2,
+	}
+}
+
+// ToAddressDetails converts a domain ContactInfo into an address-book entry under
+// the given addressName, applying the inverse mappings of ToContactInfo
+// (PostalCode -> Zip, OrganizationName -> Organization). The address-book-only
+// fields ContactInfo cannot supply (DefaultYN, StateProvinceChoice, PhoneExt,
+// Fax) are left at their zero values for the caller to set; StateProvinceChoice
+// in particular is required by the API, so set it before create/update.
+func (c ContactInfo) ToAddressDetails(addressName string) UsersAddressDetails {
+	return UsersAddressDetails{
+		AddressName:   addressName,
+		EmailAddress:  c.EmailAddress,
+		FirstName:     c.FirstName,
+		LastName:      c.LastName,
+		JobTitle:      c.JobTitle,
+		Organization:  c.OrganizationName,
+		Address1:      c.Address1,
+		Address2:      c.Address2,
+		City:          c.City,
+		StateProvince: c.StateProvince,
+		Zip:           c.PostalCode,
+		Country:       c.Country,
+		Phone:         c.Phone,
+	}
+}
+
+// oneZero maps a boolean onto Namecheap's "1"/"0" flag convention (used by
+// DefaultYN).
+func oneZero(v bool) string {
+	if v {
+		return "1"
+	}
+	return "0"
+}

--- a/namecheap/users_address_adapter_test.go
+++ b/namecheap/users_address_adapter_test.go
@@ -1,0 +1,97 @@
+package namecheap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestContactInfoAddressRoundTrip proves the ContactInfo <-> address-book adapter
+// preserves every shared logical field in both directions with no drift.
+func TestContactInfoAddressRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ContactInfo -> address -> ContactInfo", func(t *testing.T) {
+		t.Parallel()
+		original := validContactInfo()
+		back := original.ToAddressDetails("Home").ToContactInfo()
+		assert.Equal(t, original, back, "no ContactInfo field may drift through the address shape")
+	})
+
+	t.Run("address -> ContactInfo -> address", func(t *testing.T) {
+		t.Parallel()
+		// Only the twelve shared fields plus AddressName are populated; the
+		// address-only extras (DefaultYN, StateProvinceChoice, PhoneExt, Fax) are
+		// left zero so a full-equality round-trip is meaningful.
+		original := UsersAddressDetails{
+			AddressName:   "Home",
+			EmailAddress:  "john@example.com",
+			FirstName:     "John",
+			LastName:      "Smith",
+			JobTitle:      "Dev",
+			Organization:  "NameCheap.com",
+			Address1:      "8939 S.cross Blvd",
+			Address2:      "Suite 600",
+			City:          "Phoenix",
+			StateProvince: "AZ",
+			Zip:           "85284",
+			Country:       "US",
+			Phone:         "+1.6613102107",
+		}
+		back := original.ToContactInfo().ToAddressDetails(original.AddressName)
+		assert.Equal(t, original, back, "no shared field may drift through the ContactInfo shape")
+	})
+}
+
+// TestContactInfoAddressFieldMapping pins the two renamed correspondences that
+// differ between the domain-contact and address-book shapes.
+func TestContactInfoAddressFieldMapping(t *testing.T) {
+	t.Parallel()
+
+	c := validContactInfo()
+	d := c.ToAddressDetails("Home")
+
+	// PostalCode <-> Zip and OrganizationName <-> Organization are the renamed pair.
+	assert.Equal(t, c.PostalCode, d.Zip)
+	assert.Equal(t, c.OrganizationName, d.Organization)
+	// The other ten shared fields map by identical name.
+	assert.Equal(t, c.FirstName, d.FirstName)
+	assert.Equal(t, c.EmailAddress, d.EmailAddress)
+	assert.Equal(t, c.Address1, d.Address1)
+
+	// And the inverse direction restores the ContactInfo names.
+	got := d.ToContactInfo()
+	assert.Equal(t, d.Zip, got.PostalCode)
+	assert.Equal(t, d.Organization, got.OrganizationName)
+}
+
+// TestGetInfoResultToContactInfo proves a fetched address entry converts to a
+// ContactInfo that can feed domains.create, applying the same field mapping.
+func TestGetInfoResultToContactInfo(t *testing.T) {
+	t.Parallel()
+
+	result := &UsersAddressGetInfoResult{
+		FirstName:     String("John"),
+		LastName:      String("Smith"),
+		Address1:      String("8939 S.cross Blvd"),
+		Address2:      String("Suite 600"),
+		City:          String("Phoenix"),
+		StateProvince: String("AZ"),
+		Zip:           String("85284"),
+		Country:       String("US"),
+		Phone:         String("+1.6613102107"),
+		EmailAddress:  String("john@example.com"),
+		Organization:  String("NameCheap.com"),
+		JobTitle:      String("Dev"),
+	}
+
+	got := result.ToContactInfo()
+	assert.Equal(t, validContactInfo(), got)
+}
+
+// TestGetInfoResultToContactInfoNil guards the nil receiver.
+func TestGetInfoResultToContactInfoNil(t *testing.T) {
+	t.Parallel()
+	var result *UsersAddressGetInfoResult
+	assert.Equal(t, ContactInfo{}, result.ToContactInfo())
+}

--- a/namecheap/users_address_create.go
+++ b/namecheap/users_address_create.go
@@ -1,0 +1,59 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+)
+
+// UsersAddressCreateResponse is the raw envelope for
+// namecheap.users.address.create.
+type UsersAddressCreateResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *UsersAddressCreateCommandResponse `xml:"CommandResponse"`
+}
+
+// UsersAddressCreateCommandResponse wraps the create result. The doc lists no
+// response table for address.create (docs/namecheap-api-v2.md lines 1339-1365);
+// the result element carries the new address id and a Success flag on the wire.
+type UsersAddressCreateCommandResponse struct {
+	AddressCreateResult *UsersAddressCreateResult `xml:"AddressCreateResult"`
+}
+
+// UsersAddressCreateResult is the outcome of an address create.
+type UsersAddressCreateResult struct {
+	// Success reports whether the address was created.
+	Success *bool `xml:"Success,attr"`
+	// AddressID is the unique integer identifying the new address profile.
+	AddressID *int `xml:"AddressID,attr"`
+}
+
+// CreateWithContext adds a new entry to the user's address book.
+//
+// It is a non-idempotent write but not charge-bearing; it uses the standard
+// idempotent transport. Every required field is validated before the request is
+// sent (see UsersAddressDetails); a violation returns an *InvalidArgumentsError
+// listing all missing fields at once.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/users/address/create/
+func (uas *UsersAddressService) CreateWithContext(ctx context.Context, details *UsersAddressDetails) (*UsersAddressCreateCommandResponse, error) {
+	if details == nil {
+		return nil, &InvalidArgumentsError{Fields: []string{"details"}, Reason: "details must not be nil"}
+	}
+	if missing := details.missingFields(); len(missing) > 0 {
+		return nil, &InvalidArgumentsError{Fields: missing}
+	}
+
+	params := map[string]string{"Command": "namecheap.users.address.create"}
+	details.apply(params)
+
+	var response UsersAddressCreateResponse
+	_, err := uas.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/users_address_create_test.go
+++ b/namecheap/users_address_create_test.go
@@ -1,0 +1,167 @@
+package namecheap
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const addressCreateResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.users.address.create">
+		<AddressCreateResult Success="true" AddressID="777" />
+	</CommandResponse>
+</ApiResponse>`
+
+// addressGetInfoResponse echoes back exactly the fields validAddressDetails
+// sends, so a Create -> GetInfo round-trip can assert field equality.
+const addressGetInfoResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.users.address.getInfo">
+		<GetAddressInfoResult>
+			<AddressId>777</AddressId>
+			<AddressName>Home</AddressName>
+			<DefaultYN>0</DefaultYN>
+			<EmailAddress>john@example.com</EmailAddress>
+			<FirstName>John</FirstName>
+			<LastName>Smith</LastName>
+			<JobTitle>Dev</JobTitle>
+			<Organization>NameCheap.com</Organization>
+			<Address1>8939 S.cross Blvd</Address1>
+			<Address2>Suite 600</Address2>
+			<City>Phoenix</City>
+			<StateProvince>AZ</StateProvince>
+			<StateProvinceChoice>S</StateProvinceChoice>
+			<Zip>85284</Zip>
+			<Country>US</Country>
+			<Phone>+1.6613102107</Phone>
+			<PhoneExt>123</PhoneExt>
+			<Fax>+1.6613102108</Fax>
+		</GetAddressInfoResult>
+	</CommandResponse>
+</ApiResponse>`
+
+func TestUsersAddressService_Create(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success sends every field", func(t *testing.T) {
+		t.Parallel()
+		var sent url.Values
+		client := usersMockClient(t, addressCreateResponse, &sent)
+
+		details := validAddressDetails()
+		details.DefaultYN = Bool(true)
+
+		resp, err := client.UsersAddress.CreateWithContext(context.Background(), details)
+		mustNoError(t, err)
+
+		assert.Equal(t, "namecheap.users.address.create", sent.Get("Command"))
+		assert.Equal(t, "Home", sent.Get("AddressName"))
+		assert.Equal(t, "1", sent.Get("DefaultYN"))
+		assert.Equal(t, "John", sent.Get("FirstName"))
+		assert.Equal(t, "85284", sent.Get("Zip"))
+		assert.Equal(t, "S", sent.Get("StateProvinceChoice"))
+		assert.Equal(t, "NameCheap.com", sent.Get("Organization"))
+
+		mustNotNil(t, resp.AddressCreateResult)
+		assert.True(t, *resp.AddressCreateResult.Success)
+		assert.Equal(t, 777, *resp.AddressCreateResult.AddressID)
+	})
+
+	t.Run("default flag omitted when nil", func(t *testing.T) {
+		t.Parallel()
+		var sent url.Values
+		client := usersMockClient(t, addressCreateResponse, &sent)
+
+		_, err := client.UsersAddress.CreateWithContext(context.Background(), validAddressDetails())
+		mustNoError(t, err)
+		_, hasDefault := sent["DefaultYN"]
+		assert.False(t, hasDefault)
+	})
+
+	t.Run("nil details", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.UsersAddress.CreateWithContext(context.Background(), nil)
+		assertInvalidArguments(t, err, "details")
+	})
+
+	t.Run("missing required fields reported all at once", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		details := validAddressDetails()
+		details.AddressName = ""
+		details.EmailAddress = ""
+		details.StateProvinceChoice = ""
+
+		_, err := client.UsersAddress.CreateWithContext(context.Background(), details)
+		assertInvalidArguments(t, err, "AddressName", "EmailAddress", "StateProvinceChoice")
+	})
+
+	t.Run("api error mapped to APIError", func(t *testing.T) {
+		t.Parallel()
+		client := usersMockClient(t, apiErrorXML(4022336, "Failed to save user's address"), nil)
+		_, err := client.UsersAddress.CreateWithContext(context.Background(), validAddressDetails())
+		assertAPIError(t, err, 4022336)
+	})
+}
+
+// TestUsersAddressService_CreateThenGetInfoEquality drives a Create followed by a
+// GetInfo against a mock that routes by Command, and asserts every field written
+// by Create round-trips back through GetInfo unchanged.
+func TestUsersAddressService_CreateThenGetInfoEquality(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		q, _ := url.ParseQuery(string(raw))
+		switch q.Get("Command") {
+		case "namecheap.users.address.create":
+			_, _ = w.Write([]byte(addressCreateResponse))
+		case "namecheap.users.address.getInfo":
+			_, _ = w.Write([]byte(addressGetInfoResponse))
+		default:
+			http.Error(w, "unexpected command", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	client := setupClient(nil)
+	client.BaseURL = server.URL
+
+	details := validAddressDetails()
+	createResp, err := client.UsersAddress.CreateWithContext(context.Background(), details)
+	mustNoError(t, err)
+	addressID := *createResp.AddressCreateResult.AddressID
+
+	infoResp, err := client.UsersAddress.GetInfoWithContext(context.Background(), addressID)
+	mustNoError(t, err)
+	got := infoResp.GetAddressInfoResult
+	mustNotNil(t, got)
+
+	assert.Equal(t, 777, *got.AddressID)
+	assert.Equal(t, details.AddressName, *got.AddressName)
+	assert.Equal(t, details.EmailAddress, *got.EmailAddress)
+	assert.Equal(t, details.FirstName, *got.FirstName)
+	assert.Equal(t, details.LastName, *got.LastName)
+	assert.Equal(t, details.JobTitle, *got.JobTitle)
+	assert.Equal(t, details.Organization, *got.Organization)
+	assert.Equal(t, details.Address1, *got.Address1)
+	assert.Equal(t, details.Address2, *got.Address2)
+	assert.Equal(t, details.City, *got.City)
+	assert.Equal(t, details.StateProvince, *got.StateProvince)
+	assert.Equal(t, details.StateProvinceChoice, *got.StateProvinceChoice)
+	assert.Equal(t, details.Zip, *got.Zip)
+	assert.Equal(t, details.Country, *got.Country)
+	assert.Equal(t, details.Phone, *got.Phone)
+	assert.Equal(t, details.PhoneExt, *got.PhoneExt)
+	assert.Equal(t, details.Fax, *got.Fax)
+	assert.False(t, *got.DefaultYN)
+}

--- a/namecheap/users_address_delete.go
+++ b/namecheap/users_address_delete.go
@@ -1,0 +1,58 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// UsersAddressDeleteResponse is the raw envelope for
+// namecheap.users.address.delete.
+type UsersAddressDeleteResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *UsersAddressDeleteCommandResponse `xml:"CommandResponse"`
+}
+
+// UsersAddressDeleteCommandResponse wraps the delete result.
+type UsersAddressDeleteCommandResponse struct {
+	AddressDeleteResult *UsersAddressDeleteResult `xml:"AddressDeleteResult"`
+}
+
+// UsersAddressDeleteResult is the outcome of an address delete. Field names
+// follow the response table in docs/namecheap-api-v2.md (lines 1383-1387).
+type UsersAddressDeleteResult struct {
+	// Success reports whether the address was deleted.
+	Success *bool `xml:"Success,attr"`
+	// ProfileID is the unique integer representing the address profile.
+	ProfileID *int `xml:"ProfileID,attr"`
+	// Username is the account the address belonged to.
+	Username *string `xml:"Username,attr"`
+}
+
+// DeleteWithContext removes an address-book entry by id.
+//
+// It is a non-idempotent write but not charge-bearing; it uses the standard
+// idempotent transport. addressID must be positive.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/users/address/delete/
+func (uas *UsersAddressService) DeleteWithContext(ctx context.Context, addressID int) (*UsersAddressDeleteCommandResponse, error) {
+	if addressID <= 0 {
+		return nil, &InvalidArgumentsError{Fields: []string{"AddressId"}}
+	}
+
+	params := map[string]string{
+		"Command":   "namecheap.users.address.delete",
+		"AddressId": strconv.Itoa(addressID),
+	}
+
+	var response UsersAddressDeleteResponse
+	_, err := uas.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/users_address_delete_test.go
+++ b/namecheap/users_address_delete_test.go
@@ -1,0 +1,45 @@
+package namecheap
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const addressDeleteResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.users.address.delete">
+		<AddressDeleteResult Success="true" ProfileID="777" Username="testuser" />
+	</CommandResponse>
+</ApiResponse>`
+
+func TestUsersAddressService_Delete(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		var sent url.Values
+		client := usersMockClient(t, addressDeleteResponse, &sent)
+
+		resp, err := client.UsersAddress.DeleteWithContext(context.Background(), 777)
+		mustNoError(t, err)
+
+		assert.Equal(t, "namecheap.users.address.delete", sent.Get("Command"))
+		assert.Equal(t, "777", sent.Get("AddressId"))
+
+		mustNotNil(t, resp.AddressDeleteResult)
+		assert.True(t, *resp.AddressDeleteResult.Success)
+		assert.Equal(t, 777, *resp.AddressDeleteResult.ProfileID)
+		assert.Equal(t, "testuser", *resp.AddressDeleteResult.Username)
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.UsersAddress.DeleteWithContext(context.Background(), 0)
+		assertInvalidArguments(t, err, "AddressId")
+	})
+}

--- a/namecheap/users_address_get_info.go
+++ b/namecheap/users_address_get_info.go
@@ -1,0 +1,122 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// UsersAddressGetInfoResponse is the raw envelope for
+// namecheap.users.address.getInfo.
+type UsersAddressGetInfoResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *UsersAddressGetInfoCommandResponse `xml:"CommandResponse"`
+}
+
+// UsersAddressGetInfoCommandResponse wraps the getInfo result.
+type UsersAddressGetInfoCommandResponse struct {
+	GetAddressInfoResult *UsersAddressGetInfoResult `xml:"GetAddressInfoResult"`
+}
+
+// UsersAddressGetInfoResult is the full stored address. The doc gives no response
+// table for address.getInfo (docs/namecheap-api-v2.md lines 1391-1408, only error
+// codes), so the fields mirror the create request fields (lines 1347-1365), which
+// getInfo echoes back; on the wire they are child elements. Every field is a
+// pointer so a field the server omits stays nil rather than an empty value.
+type UsersAddressGetInfoResult struct {
+	// AddressID is the unique integer identifying the address profile.
+	AddressID *int `xml:"AddressId"`
+	// AddressName is the address label.
+	AddressName *string `xml:"AddressName"`
+	// DefaultYN reports whether this is the default address.
+	DefaultYN *bool `xml:"DefaultYN"`
+	// EmailAddress is the contact e-mail address.
+	EmailAddress *string `xml:"EmailAddress"`
+	// FirstName is the contact's first name.
+	FirstName *string `xml:"FirstName"`
+	// LastName is the contact's last name.
+	LastName *string `xml:"LastName"`
+	// JobTitle is the contact's job designation.
+	JobTitle *string `xml:"JobTitle"`
+	// Organization is the contact's organization.
+	Organization *string `xml:"Organization"`
+	// Address1 is the primary street address.
+	Address1 *string `xml:"Address1"`
+	// Address2 is the secondary street address.
+	Address2 *string `xml:"Address2"`
+	// City is the contact's city.
+	City *string `xml:"City"`
+	// StateProvince is the state or province.
+	StateProvince *string `xml:"StateProvince"`
+	// StateProvinceChoice is the state/province choice.
+	StateProvinceChoice *string `xml:"StateProvinceChoice"`
+	// Zip is the postal/ZIP code.
+	Zip *string `xml:"Zip"`
+	// Country is the two-letter country code.
+	Country *string `xml:"Country"`
+	// Phone is the phone number in +NNN.NNNNNNNNNN format.
+	Phone *string `xml:"Phone"`
+	// PhoneExt is the phone extension.
+	PhoneExt *string `xml:"PhoneExt"`
+	// Fax is the fax number.
+	Fax *string `xml:"Fax"`
+}
+
+// GetInfoWithContext returns the full stored address for the given id.
+//
+// It is a read-only, idempotent call. addressID must be positive.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/users/address/get-info/
+func (uas *UsersAddressService) GetInfoWithContext(ctx context.Context, addressID int) (*UsersAddressGetInfoCommandResponse, error) {
+	if addressID <= 0 {
+		return nil, &InvalidArgumentsError{Fields: []string{"AddressId"}}
+	}
+
+	params := map[string]string{
+		"Command":   "namecheap.users.address.getInfo",
+		"AddressId": strconv.Itoa(addressID),
+	}
+
+	var response UsersAddressGetInfoResponse
+	_, err := uas.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}
+
+// ToContactInfo converts a fetched address into a domain ContactInfo so the
+// stored entry can feed the contact blocks of domains.create. It applies the same
+// field mapping as UsersAddressDetails.ToContactInfo (Zip -> PostalCode,
+// Organization -> OrganizationName) and treats a nil field as an empty string.
+func (r *UsersAddressGetInfoResult) ToContactInfo() ContactInfo {
+	if r == nil {
+		return ContactInfo{}
+	}
+	return ContactInfo{
+		FirstName:        derefString(r.FirstName),
+		LastName:         derefString(r.LastName),
+		Address1:         derefString(r.Address1),
+		City:             derefString(r.City),
+		StateProvince:    derefString(r.StateProvince),
+		PostalCode:       derefString(r.Zip),
+		Country:          derefString(r.Country),
+		Phone:            derefString(r.Phone),
+		EmailAddress:     derefString(r.EmailAddress),
+		OrganizationName: derefString(r.Organization),
+		JobTitle:         derefString(r.JobTitle),
+		Address2:         derefString(r.Address2),
+	}
+}
+
+// derefString returns *p, or "" when p is nil.
+func derefString(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}

--- a/namecheap/users_address_get_info_test.go
+++ b/namecheap/users_address_get_info_test.go
@@ -1,0 +1,45 @@
+package namecheap
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUsersAddressService_GetInfo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success parse and request", func(t *testing.T) {
+		t.Parallel()
+		var sent url.Values
+		client := usersMockClient(t, addressGetInfoResponse, &sent)
+
+		resp, err := client.UsersAddress.GetInfoWithContext(context.Background(), 777)
+		mustNoError(t, err)
+
+		assert.Equal(t, "namecheap.users.address.getInfo", sent.Get("Command"))
+		assert.Equal(t, "777", sent.Get("AddressId"))
+
+		got := resp.GetAddressInfoResult
+		mustNotNil(t, got)
+		assert.Equal(t, "Home", *got.AddressName)
+		assert.Equal(t, "85284", *got.Zip)
+		assert.Equal(t, "NameCheap.com", *got.Organization)
+	})
+
+	t.Run("invalid id no http", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.UsersAddress.GetInfoWithContext(context.Background(), 0)
+		assertInvalidArguments(t, err, "AddressId")
+	})
+
+	t.Run("api error mapped to APIError", func(t *testing.T) {
+		t.Parallel()
+		client := usersMockClient(t, apiErrorXML(4022336, "Failed to retrieve user's address"), nil)
+		_, err := client.UsersAddress.GetInfoWithContext(context.Background(), 777)
+		assertAPIError(t, err, 4022336)
+	})
+}

--- a/namecheap/users_address_get_list.go
+++ b/namecheap/users_address_get_list.go
@@ -1,0 +1,56 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+)
+
+// UsersAddressGetListResponse is the raw envelope for
+// namecheap.users.address.getList.
+type UsersAddressGetListResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *UsersAddressGetListCommandResponse `xml:"CommandResponse"`
+}
+
+// UsersAddressGetListCommandResponse wraps the list of address entries.
+//
+// Unlike domains.getList, the doc's address.getList
+// (docs/namecheap-api-v2.md lines 1412-1428) defines no request parameters and no
+// paging block, so none is modeled here: the response is a flat list of every
+// address on the account.
+type UsersAddressGetListCommandResponse struct {
+	AddressGetListResult *[]UsersAddressListEntry `xml:"AddressGetListResult>List"`
+}
+
+// UsersAddressListEntry is one address-book entry in the list. Field names follow
+// the getList response table in docs/namecheap-api-v2.md (lines 1424-1425).
+type UsersAddressListEntry struct {
+	// AddressID is the unique integer representing the address profile.
+	AddressID *int `xml:"AddressId,attr"`
+	// AddressName is the name of the address profile.
+	AddressName *string `xml:"AddressName,attr"`
+}
+
+// GetListWithContext returns every address-book entry (id and name) on the
+// account.
+//
+// It is a read-only, idempotent call and takes no parameters. Per the doc the
+// response is not paged.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/users/address/get-list/
+func (uas *UsersAddressService) GetListWithContext(ctx context.Context) (*UsersAddressGetListCommandResponse, error) {
+	var response UsersAddressGetListResponse
+	params := map[string]string{
+		"Command": "namecheap.users.address.getList",
+	}
+
+	_, err := uas.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/users_address_get_list_test.go
+++ b/namecheap/users_address_get_list_test.go
@@ -1,0 +1,50 @@
+package namecheap
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const addressGetListResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.users.address.getList">
+		<AddressGetListResult>
+			<List AddressId="777" AddressName="Home" />
+			<List AddressId="778" AddressName="Office" />
+			<List AddressId="779" AddressName="Billing" />
+		</AddressGetListResult>
+	</CommandResponse>
+</ApiResponse>`
+
+func TestUsersAddressService_GetList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success parses all entries", func(t *testing.T) {
+		t.Parallel()
+		var sent url.Values
+		client := usersMockClient(t, addressGetListResponse, &sent)
+
+		resp, err := client.UsersAddress.GetListWithContext(context.Background())
+		mustNoError(t, err)
+		assert.Equal(t, "namecheap.users.address.getList", sent.Get("Command"))
+
+		mustNotNil(t, resp.AddressGetListResult)
+		entries := *resp.AddressGetListResult
+		mustLen(t, entries, 3)
+		assert.Equal(t, 777, *entries[0].AddressID)
+		assert.Equal(t, "Home", *entries[0].AddressName)
+		assert.Equal(t, 779, *entries[2].AddressID)
+		assert.Equal(t, "Billing", *entries[2].AddressName)
+	})
+
+	t.Run("api error mapped to APIError", func(t *testing.T) {
+		t.Parallel()
+		client := usersMockClient(t, apiErrorXML(4011103, "API access denied"), nil)
+		_, err := client.UsersAddress.GetListWithContext(context.Background())
+		assertAPIError(t, err, 4011103)
+	})
+}

--- a/namecheap/users_address_set_default.go
+++ b/namecheap/users_address_set_default.go
@@ -1,0 +1,56 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// UsersAddressSetDefaultResponse is the raw envelope for
+// namecheap.users.address.setDefault.
+type UsersAddressSetDefaultResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *UsersAddressSetDefaultCommandResponse `xml:"CommandResponse"`
+}
+
+// UsersAddressSetDefaultCommandResponse wraps the setDefault result.
+type UsersAddressSetDefaultCommandResponse struct {
+	AddressSetDefaultResult *UsersAddressSetDefaultResult `xml:"AddressSetDefaultResult"`
+}
+
+// UsersAddressSetDefaultResult is the outcome of a setDefault. Field names follow
+// the response table in docs/namecheap-api-v2.md (lines 1443-1446).
+type UsersAddressSetDefaultResult struct {
+	// Success reports whether the default address was set.
+	Success *bool `xml:"Success,attr"`
+	// AddressID is the unique integer representing the address profile.
+	AddressID *int `xml:"AddressID,attr"`
+}
+
+// SetDefaultWithContext marks an address-book entry as the account default.
+//
+// It is a non-idempotent write but not charge-bearing; it uses the standard
+// idempotent transport. addressID must be positive.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/users/address/set-default/
+func (uas *UsersAddressService) SetDefaultWithContext(ctx context.Context, addressID int) (*UsersAddressSetDefaultCommandResponse, error) {
+	if addressID <= 0 {
+		return nil, &InvalidArgumentsError{Fields: []string{"AddressId"}}
+	}
+
+	params := map[string]string{
+		"Command":   "namecheap.users.address.setDefault",
+		"AddressId": strconv.Itoa(addressID),
+	}
+
+	var response UsersAddressSetDefaultResponse
+	_, err := uas.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/users_address_set_default_test.go
+++ b/namecheap/users_address_set_default_test.go
@@ -1,0 +1,44 @@
+package namecheap
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const addressSetDefaultResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.users.address.setDefault">
+		<AddressSetDefaultResult Success="true" AddressID="778" />
+	</CommandResponse>
+</ApiResponse>`
+
+func TestUsersAddressService_SetDefault(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		var sent url.Values
+		client := usersMockClient(t, addressSetDefaultResponse, &sent)
+
+		resp, err := client.UsersAddress.SetDefaultWithContext(context.Background(), 778)
+		mustNoError(t, err)
+
+		assert.Equal(t, "namecheap.users.address.setDefault", sent.Get("Command"))
+		assert.Equal(t, "778", sent.Get("AddressId"))
+
+		mustNotNil(t, resp.AddressSetDefaultResult)
+		assert.True(t, *resp.AddressSetDefaultResult.Success)
+		assert.Equal(t, 778, *resp.AddressSetDefaultResult.AddressID)
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.UsersAddress.SetDefaultWithContext(context.Background(), -1)
+		assertInvalidArguments(t, err, "AddressId")
+	})
+}

--- a/namecheap/users_address_update.go
+++ b/namecheap/users_address_update.go
@@ -1,0 +1,66 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// UsersAddressUpdateResponse is the raw envelope for
+// namecheap.users.address.update.
+type UsersAddressUpdateResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *UsersAddressUpdateCommandResponse `xml:"CommandResponse"`
+}
+
+// UsersAddressUpdateCommandResponse wraps the update result.
+type UsersAddressUpdateCommandResponse struct {
+	AddressUpdateResult *UsersAddressUpdateResult `xml:"AddressUpdateResult"`
+}
+
+// UsersAddressUpdateResult is the outcome of an address update.
+type UsersAddressUpdateResult struct {
+	// Success reports whether the address was updated.
+	Success *bool `xml:"Success,attr"`
+	// AddressID is the unique integer identifying the updated address profile.
+	AddressID *int `xml:"AddressID,attr"`
+}
+
+// UpdateWithContext updates an existing address-book entry identified by
+// addressID with the given details.
+//
+// It is a non-idempotent write but not charge-bearing; it uses the standard
+// idempotent transport. addressID must be positive and every required field of
+// details is validated before the request is sent (see UsersAddressDetails).
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/users/address/update/
+func (uas *UsersAddressService) UpdateWithContext(ctx context.Context, addressID int, details *UsersAddressDetails) (*UsersAddressUpdateCommandResponse, error) {
+	if details == nil {
+		return nil, &InvalidArgumentsError{Fields: []string{"details"}, Reason: "details must not be nil"}
+	}
+	missing := make([]string, 0, len(details.requiredAddressFields())+1)
+	if addressID <= 0 {
+		missing = append(missing, "AddressId")
+	}
+	missing = append(missing, details.missingFields()...)
+	if len(missing) > 0 {
+		return nil, &InvalidArgumentsError{Fields: missing}
+	}
+
+	params := map[string]string{
+		"Command":   "namecheap.users.address.update",
+		"AddressId": strconv.Itoa(addressID),
+	}
+	details.apply(params)
+
+	var response UsersAddressUpdateResponse
+	_, err := uas.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/users_address_update_test.go
+++ b/namecheap/users_address_update_test.go
@@ -1,0 +1,56 @@
+package namecheap
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const addressUpdateResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.users.address.update">
+		<AddressUpdateResult Success="true" AddressID="777" />
+	</CommandResponse>
+</ApiResponse>`
+
+func TestUsersAddressService_Update(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		var sent url.Values
+		client := usersMockClient(t, addressUpdateResponse, &sent)
+
+		resp, err := client.UsersAddress.UpdateWithContext(context.Background(), 777, validAddressDetails())
+		mustNoError(t, err)
+
+		assert.Equal(t, "namecheap.users.address.update", sent.Get("Command"))
+		assert.Equal(t, "777", sent.Get("AddressId"))
+		assert.Equal(t, "Home", sent.Get("AddressName"))
+		assert.Equal(t, "S", sent.Get("StateProvinceChoice"))
+
+		mustNotNil(t, resp.AddressUpdateResult)
+		assert.True(t, *resp.AddressUpdateResult.Success)
+		assert.Equal(t, 777, *resp.AddressUpdateResult.AddressID)
+	})
+
+	t.Run("nil details", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.UsersAddress.UpdateWithContext(context.Background(), 777, nil)
+		assertInvalidArguments(t, err, "details")
+	})
+
+	t.Run("invalid id and missing fields reported together", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		details := validAddressDetails()
+		details.FirstName = ""
+
+		_, err := client.UsersAddress.UpdateWithContext(context.Background(), 0, details)
+		assertInvalidArguments(t, err, "AddressId", "FirstName")
+	})
+}

--- a/namecheap/users_change_password.go
+++ b/namecheap/users_change_password.go
@@ -1,0 +1,113 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+)
+
+// UsersChangePasswordResponse is the raw envelope for
+// namecheap.users.changePassword.
+type UsersChangePasswordResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *UsersChangePasswordCommandResponse `xml:"CommandResponse"`
+}
+
+// UsersChangePasswordCommandResponse wraps the changePassword result.
+type UsersChangePasswordCommandResponse struct {
+	UserChangePasswordResult *UsersChangePasswordResult `xml:"UserChangePasswordResult"`
+}
+
+// UsersChangePasswordResult is the outcome of a password change. Field names
+// follow the response table in docs/namecheap-api-v2.md (lines 1179-1182).
+type UsersChangePasswordResult struct {
+	// Success reports whether the password was changed.
+	Success *bool `xml:"Success,attr"`
+	// UserID is the unique integer representing the user.
+	UserID *int `xml:"UserID,attr"`
+}
+
+// UsersChangePasswordArgs are the arguments for ChangePasswordWithContext. It
+// supports both documented methods (docs/namecheap-api-v2.md lines 1163-1175):
+// old-password (OldPassword + NewPassword) and reset-code (ResetCode +
+// NewPassword). Provide exactly one of OldPassword or ResetCode.
+//
+// Secret handling. OldPassword, ResetCode and NewPassword are placed only in the
+// outbound request parameters; they are never stored on the client, logged, or
+// echoed in errors by this SDK. The SDK has no logging/hook layer yet (that is
+// issue #113); once #113 lands, hook-level redaction of these fields is enforced
+// there. Do not add ad-hoc logging of these values.
+type UsersChangePasswordArgs struct {
+	// OldPassword is the user's current password (method 1). Mutually exclusive
+	// with ResetCode.
+	OldPassword string
+	// ResetCode is the reset code from namecheap.users.resetPassword (method 2).
+	// Mutually exclusive with OldPassword.
+	ResetCode string
+	// NewPassword is the new password. Required for both methods.
+	NewPassword string
+}
+
+// ChangePasswordWithContext changes the password of the user account, using
+// either the old password or a reset code (see UsersChangePasswordArgs).
+//
+// It is a non-idempotent account write but not charge-bearing; it uses the
+// standard idempotent transport (a transient failure is safely retried, since a
+// repeated password change to the same NewPassword is harmless).
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/users/change-password/
+func (us *UsersService) ChangePasswordWithContext(ctx context.Context, args *UsersChangePasswordArgs) (*UsersChangePasswordCommandResponse, error) {
+	if args == nil {
+		return nil, &InvalidArgumentsError{Fields: []string{"args"}, Reason: "args must not be nil"}
+	}
+	if err := args.validate(); err != nil {
+		return nil, err
+	}
+
+	var response UsersChangePasswordResponse
+	_, err := us.client.DoXMLWithContext(ctx, args.params(), &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}
+
+// validate enforces the required fields and the exactly-one-credential rule.
+func (a *UsersChangePasswordArgs) validate() error {
+	if a.NewPassword == "" {
+		return &InvalidArgumentsError{Fields: []string{"NewPassword"}}
+	}
+	hasOld := a.OldPassword != ""
+	hasReset := a.ResetCode != ""
+	switch {
+	case hasOld && hasReset:
+		return &InvalidArgumentsError{
+			Fields: []string{"OldPassword", "ResetCode"},
+			Reason: "provide exactly one of OldPassword or ResetCode, not both",
+		}
+	case !hasOld && !hasReset:
+		return &InvalidArgumentsError{
+			Fields: []string{"OldPassword", "ResetCode"},
+			Reason: "provide exactly one of OldPassword or ResetCode",
+		}
+	}
+	return nil
+}
+
+// params flattens the validated args into the request map. Only the chosen
+// credential is sent.
+func (a *UsersChangePasswordArgs) params() map[string]string {
+	params := map[string]string{
+		"Command":     "namecheap.users.changePassword",
+		"NewPassword": a.NewPassword,
+	}
+	if a.OldPassword != "" {
+		params["OldPassword"] = a.OldPassword
+	} else {
+		params["ResetCode"] = a.ResetCode
+	}
+	return params
+}

--- a/namecheap/users_change_password_test.go
+++ b/namecheap/users_change_password_test.go
@@ -1,0 +1,92 @@
+package namecheap
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const changePasswordResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.users.changePassword">
+		<UserChangePasswordResult Success="true" UserID="4242" />
+	</CommandResponse>
+</ApiResponse>`
+
+func TestUsersService_ChangePassword(t *testing.T) {
+	t.Parallel()
+
+	t.Run("old password method", func(t *testing.T) {
+		t.Parallel()
+		var sent url.Values
+		client := usersMockClient(t, changePasswordResponse, &sent)
+
+		resp, err := client.Users.ChangePasswordWithContext(context.Background(), &UsersChangePasswordArgs{
+			OldPassword: "oldSecret",
+			NewPassword: "newSecret",
+		})
+		mustNoError(t, err)
+
+		assert.Equal(t, "namecheap.users.changePassword", sent.Get("Command"))
+		assert.Equal(t, "oldSecret", sent.Get("OldPassword"))
+		assert.Equal(t, "newSecret", sent.Get("NewPassword"))
+		_, hasReset := sent["ResetCode"]
+		assert.False(t, hasReset, "ResetCode must not be sent for the old-password method")
+
+		result := resp.UserChangePasswordResult
+		mustNotNil(t, result)
+		assert.True(t, *result.Success)
+		assert.Equal(t, 4242, *result.UserID)
+	})
+
+	t.Run("reset code method", func(t *testing.T) {
+		t.Parallel()
+		var sent url.Values
+		client := usersMockClient(t, changePasswordResponse, &sent)
+
+		_, err := client.Users.ChangePasswordWithContext(context.Background(), &UsersChangePasswordArgs{
+			ResetCode:   "reset-123",
+			NewPassword: "newSecret",
+		})
+		mustNoError(t, err)
+		assert.Equal(t, "reset-123", sent.Get("ResetCode"))
+		assert.Equal(t, "newSecret", sent.Get("NewPassword"))
+		_, hasOld := sent["OldPassword"]
+		assert.False(t, hasOld, "OldPassword must not be sent for the reset-code method")
+	})
+
+	t.Run("nil args", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.Users.ChangePasswordWithContext(context.Background(), nil)
+		assertInvalidArguments(t, err, "args")
+	})
+
+	t.Run("missing new password", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.Users.ChangePasswordWithContext(context.Background(), &UsersChangePasswordArgs{OldPassword: "x"})
+		assertInvalidArguments(t, err, "NewPassword")
+	})
+
+	t.Run("no credential", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.Users.ChangePasswordWithContext(context.Background(), &UsersChangePasswordArgs{NewPassword: "x"})
+		assertInvalidArguments(t, err, "OldPassword", "ResetCode")
+	})
+
+	t.Run("both credentials rejected", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.Users.ChangePasswordWithContext(context.Background(), &UsersChangePasswordArgs{
+			OldPassword: "x",
+			ResetCode:   "y",
+			NewPassword: "z",
+		})
+		assertInvalidArguments(t, err, "OldPassword", "ResetCode")
+	})
+}

--- a/namecheap/users_get_balances.go
+++ b/namecheap/users_get_balances.go
@@ -1,0 +1,61 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+)
+
+// UsersGetBalancesResponse is the raw envelope for namecheap.users.getBalances.
+type UsersGetBalancesResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *UsersGetBalancesCommandResponse `xml:"CommandResponse"`
+}
+
+// UsersGetBalancesCommandResponse wraps the getBalances result.
+type UsersGetBalancesCommandResponse struct {
+	UserGetBalancesResult *UsersGetBalancesResult `xml:"UserGetBalancesResult"`
+}
+
+// UsersGetBalancesResult holds the account funds. Field names follow the
+// getBalances response table in docs/namecheap-api-v2.md (lines 1146-1153). Every
+// monetary field is an Amount (an exact decimal string) so a balance used to gate
+// a charge is never mangled by binary floating point; Currency is a plain string.
+type UsersGetBalancesResult struct {
+	// Currency is the currency the amounts are listed in, e.g. "USD".
+	Currency string `xml:"Currency,attr"`
+	// AvailableBalance is the total amount available in the account.
+	AvailableBalance Amount `xml:"AvailableBalance,attr"`
+	// AccountBalance is the total amount in the account (per the doc, the same as
+	// AvailableBalance).
+	AccountBalance Amount `xml:"AccountBalance,attr"`
+	// EarnedAmount is the amount earned from Marketplace sales.
+	EarnedAmount Amount `xml:"EarnedAmount,attr"`
+	// WithdrawableAmount is the amount available for withdrawal.
+	WithdrawableAmount Amount `xml:"WithdrawableAmount,attr"`
+	// FundsRequiredForAutoRenew is the amount required for auto-renewal.
+	FundsRequiredForAutoRenew Amount `xml:"FundsRequiredForAutoRenew,attr"`
+}
+
+// GetBalancesWithContext returns the funds in the user's account, decimal-safe.
+//
+// It is a read-only, idempotent call and takes no parameters. It is the
+// precondition check for every money-bearing operation: read the balance and
+// gate a bulk renew/create/transfer on it before spending.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/users/get-balances/
+func (us *UsersService) GetBalancesWithContext(ctx context.Context) (*UsersGetBalancesCommandResponse, error) {
+	var response UsersGetBalancesResponse
+	params := map[string]string{
+		"Command": "namecheap.users.getBalances",
+	}
+
+	_, err := us.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/users_get_balances_test.go
+++ b/namecheap/users_get_balances_test.go
@@ -1,0 +1,49 @@
+package namecheap
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const getBalancesResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.users.getBalances">
+		<UserGetBalancesResult Currency="USD" AvailableBalance="123.45" AccountBalance="123.45" EarnedAmount="15.00" WithdrawableAmount="100.00" FundsRequiredForAutoRenew="42.50" />
+	</CommandResponse>
+</ApiResponse>`
+
+func TestUsersService_GetBalances(t *testing.T) {
+	t.Parallel()
+
+	var sent url.Values
+	client := usersMockClient(t, getBalancesResponse, &sent)
+
+	resp, err := client.Users.GetBalancesWithContext(context.Background())
+	mustNoError(t, err)
+	assert.Equal(t, "namecheap.users.getBalances", sent.Get("Command"))
+
+	result := resp.UserGetBalancesResult
+	mustNotNil(t, result)
+	assert.Equal(t, "USD", result.Currency)
+
+	// 123.45 has no exact binary float representation; assert the exact string is
+	// preserved by the Amount type (never parsed to float64).
+	assert.Equal(t, Amount("123.45"), result.AvailableBalance)
+	assert.Equal(t, "123.45", result.AvailableBalance.String())
+	assert.Equal(t, Amount("123.45"), result.AccountBalance)
+	assert.Equal(t, Amount("15.00"), result.EarnedAmount)
+	assert.Equal(t, Amount("100.00"), result.WithdrawableAmount)
+	assert.Equal(t, Amount("42.50"), result.FundsRequiredForAutoRenew)
+}
+
+func TestUsersService_GetBalances_APIError(t *testing.T) {
+	t.Parallel()
+
+	client := usersMockClient(t, apiErrorXML(4011103, "API Key is invalid or API access has not been enabled"), nil)
+	_, err := client.Users.GetBalancesWithContext(context.Background())
+	assertAPIError(t, err, 4011103)
+}

--- a/namecheap/users_get_pricing.go
+++ b/namecheap/users_get_pricing.go
@@ -1,0 +1,225 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strings"
+)
+
+// UsersGetPricingResponse is the raw envelope for namecheap.users.getPricing.
+type UsersGetPricingResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *UsersGetPricingCommandResponse `xml:"CommandResponse"`
+}
+
+// UsersGetPricingCommandResponse wraps the getPricing result.
+type UsersGetPricingCommandResponse struct {
+	UserGetPricingResult *UsersGetPricingResult `xml:"UserGetPricingResult"`
+}
+
+// UsersGetPricingResult is the root of the deeply nested price sheet. It holds
+// one entry per requested product type (DOMAIN, SSLCERTIFICATE, WHOISGUARD).
+//
+// The response is large and slow-changing: it is safe (and recommended) to fetch
+// it once and cache it rather than call getPricing on a hot path. Consumers own
+// the caching policy (see the "Out of scope" note in issue #117).
+type UsersGetPricingResult struct {
+	// ProductTypes lists the pricing tree for each product type in the response,
+	// e.g. "domains". Element/attribute names follow the getPricing response table
+	// in docs/namecheap-api-v2.md (lines 1123-1132).
+	ProductTypes []PricingProductType `xml:"ProductType"`
+}
+
+// PricingProductType is one product type node (the doc's "ProductType Name",
+// line 1125) and its categories.
+type PricingProductType struct {
+	// Name is the product-type identifier, e.g. "domains".
+	Name string `xml:"Name,attr"`
+	// ProductCategories are the actions/categories under this type, e.g.
+	// "register", "renew", "transfer".
+	ProductCategories []PricingProductCategory `xml:"ProductCategory"`
+}
+
+// PricingProductCategory is one category node (the doc's "ProductCategory Name",
+// line 1126), typically corresponding to an action such as register/renew.
+type PricingProductCategory struct {
+	// Name is the category/action identifier, e.g. "register".
+	Name string `xml:"Name,attr"`
+	// Products are the individual products under this category, e.g. one per TLD.
+	Products []PricingProduct `xml:"Product"`
+}
+
+// PricingProduct is one product node (the doc's "Product Name", line 1127) and
+// its per-duration price tiers.
+type PricingProduct struct {
+	// Name is the product identifier, e.g. the TLD "com".
+	Name string `xml:"Name,attr"`
+	// Prices are the price tiers for this product, one per duration.
+	Prices []Price `xml:"Price"`
+}
+
+// Price is a single price tier. Field names and money semantics follow the
+// getPricing response table in docs/namecheap-api-v2.md (lines 1128-1132). Every
+// monetary field is an Amount (an exact decimal string) so a charge-bearing price
+// is never silently mangled by binary floating point.
+type Price struct {
+	// Duration is the term length, e.g. 1 (see DurationType for the unit).
+	Duration int `xml:"Duration,attr"`
+	// DurationType is the unit of Duration, e.g. "YEAR".
+	DurationType string `xml:"DurationType,attr"`
+	// Price is the server-resolved final price. Per the doc (line 1130) it is
+	// derived from "regular, userprice, special, promo, or tier price", so any
+	// active promotion is already reflected here. See EffectivePrice.
+	Price Amount `xml:"Price,attr"`
+	// RegularPrice is the public list price (doc line 1131).
+	RegularPrice Amount `xml:"RegularPrice,attr"`
+	// YourPrice is the account/user-specific price (doc line 1132).
+	YourPrice Amount `xml:"YourPrice,attr"`
+}
+
+// UsersGetPricingArgs are the arguments for GetPricingWithContext. Field names
+// and required/optional status follow the getPricing request table in
+// docs/namecheap-api-v2.md (lines 1113-1119).
+type UsersGetPricingArgs struct {
+	// ProductType selects the price sheet to return. Required. Canonical values
+	// are "DOMAIN", "SSLCERTIFICATE" and "WHOISGUARD".
+	ProductType *string
+	// ProductCategory optionally narrows the result to a single category.
+	ProductCategory *string
+	// ActionName optionally narrows the result to a single action, e.g.
+	// "REGISTER", "RENEW" or "TRANSFER".
+	ActionName *string
+	// ProductName optionally narrows the result to a single product, e.g. "com".
+	ProductName *string
+	// PromotionCode is an optional promotional (coupon) code applied to the sheet.
+	PromotionCode *string
+}
+
+// GetPricingWithContext returns Namecheap's price sheet for a product type.
+//
+// It is a read-only, idempotent call. The response is deeply nested
+// (ProductType -> ProductCategory -> Product -> Price tiers) and models the doc's
+// element/attribute names exactly; use PriceFor for the common single-tier
+// lookup. Because the sheet is large and changes rarely, prefer fetching it once
+// and caching it over calling this on a hot path.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/users/get-pricing/
+func (us *UsersService) GetPricingWithContext(ctx context.Context, args *UsersGetPricingArgs) (*UsersGetPricingCommandResponse, error) {
+	if args == nil || args.ProductType == nil || *args.ProductType == "" {
+		return nil, &InvalidArgumentsError{Fields: []string{"ProductType"}}
+	}
+
+	var response UsersGetPricingResponse
+	_, err := us.client.DoXMLWithContext(ctx, args.params(), &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}
+
+// params flattens the validated args into the request map.
+func (a *UsersGetPricingArgs) params() map[string]string {
+	params := map[string]string{
+		"Command":     "namecheap.users.getPricing",
+		"ProductType": *a.ProductType,
+	}
+	setIfNotNil(params, "ProductCategory", a.ProductCategory)
+	setIfNotNil(params, "ActionName", a.ActionName)
+	setIfNotNil(params, "ProductName", a.ProductName)
+	setIfNotNil(params, "PromotionCode", a.PromotionCode)
+	return params
+}
+
+// PriceFor resolves the price tier for an action (a product category such as
+// "REGISTER"), a product name (such as "com") and a term length in years. It is
+// the flattening helper for the 90% lookup: it walks every product type, matches
+// the category by action, the product by name and the tier by an annual duration
+// equal to years. Matching is case-insensitive so "REGISTER"/"register" and
+// "COM"/"com" both resolve. It returns the matching Price and true, or the zero
+// Price and false when nothing matches.
+func (r *UsersGetPricingResult) PriceFor(action, productName string, years int) (Price, bool) {
+	if r == nil {
+		return Price{}, false
+	}
+	for i := range r.ProductTypes {
+		categories := r.ProductTypes[i].ProductCategories
+		for j := range categories {
+			if !strings.EqualFold(categories[j].Name, action) {
+				continue
+			}
+			if p, ok := categories[j].priceFor(productName, years); ok {
+				return p, true
+			}
+		}
+	}
+	return Price{}, false
+}
+
+// priceFor resolves the tier for productName/years within a single category.
+func (c *PricingProductCategory) priceFor(productName string, years int) (Price, bool) {
+	for i := range c.Products {
+		if !strings.EqualFold(c.Products[i].Name, productName) {
+			continue
+		}
+		return c.Products[i].priceFor(years)
+	}
+	return Price{}, false
+}
+
+// priceFor resolves the annual tier for years within a single product.
+func (p *PricingProduct) priceFor(years int) (Price, bool) {
+	for i := range p.Prices {
+		if p.Prices[i].Duration == years && strings.EqualFold(p.Prices[i].DurationType, "YEAR") {
+			return p.Prices[i], true
+		}
+	}
+	return Price{}, false
+}
+
+// EffectivePrice returns the amount a caller would actually pay for this tier,
+// applying the documented precedence over the tier's price attributes
+// (docs/namecheap-api-v2.md lines 1130-1132):
+//
+//  1. Price        — the server-resolved final price, which per the doc (line
+//  1130. already reflects "regular, userprice, special, promo, or tier
+//     price"; this is where an active promotion surfaces;
+//  2. YourPrice    — the account/user-specific price (line 1132);
+//  3. RegularPrice — the public list price (line 1131).
+//
+// The first attribute that is present and represents a positive amount wins; a
+// missing or zero-valued attribute falls through to the next. When none is
+// positive it returns RegularPrice unchanged (possibly empty), so the caller
+// still sees the raw server value rather than a fabricated one.
+func (p Price) EffectivePrice() Amount {
+	for _, a := range []Amount{p.Price, p.YourPrice, p.RegularPrice} {
+		if isPositiveAmount(a) {
+			return a
+		}
+	}
+	return p.RegularPrice
+}
+
+// isPositiveAmount reports whether a is a present, positive money value. It is
+// decimal-safe: it never parses the amount to a float (see Amount), it only
+// checks for the presence of a non-zero digit, so "0.00" and "" are false while
+// "8.88" and "10.00" are true.
+func isPositiveAmount(a Amount) bool {
+	for _, r := range strings.TrimSpace(string(a)) {
+		if r >= '1' && r <= '9' {
+			return true
+		}
+	}
+	return false
+}
+
+// setIfNotNil writes key=*value into params only when value is non-nil and the
+// pointed-to string is non-empty.
+func setIfNotNil(params map[string]string, key string, value *string) {
+	if value != nil && *value != "" {
+		params[key] = *value
+	}
+}

--- a/namecheap/users_get_pricing_test.go
+++ b/namecheap/users_get_pricing_test.go
@@ -1,0 +1,262 @@
+package namecheap
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// pricingDomainResponse is a realistic captured-style DOMAIN price sheet. The
+// register tiers for com/net/org are crafted to exercise EffectivePrice
+// precedence: com has a promo Price, net falls through to YourPrice (Price zero),
+// org falls through to RegularPrice (Price empty, YourPrice zero). Extra
+// attributes (Currency, PricingType, ...) mirror the live API and must be ignored.
+const pricingDomainResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<RequestedCommand>namecheap.users.getPricing</RequestedCommand>
+	<CommandResponse Type="namecheap.users.getPricing">
+		<UserGetPricingResult>
+			<ProductType Name="domains">
+				<ProductCategory Name="register">
+					<Product Name="com">
+						<Price Duration="1" DurationType="YEAR" Price="8.88" PricingType="MULTIPLE" RegularPrice="10.87" RegularPriceType="MULTIPLE" YourPrice="9.99" YourPriceType="MULTIPLE" Currency="USD" />
+						<Price Duration="2" DurationType="YEAR" Price="17.76" RegularPrice="21.74" YourPrice="19.98" Currency="USD" />
+					</Product>
+					<Product Name="net">
+						<Price Duration="1" DurationType="YEAR" Price="0.0" RegularPrice="12.00" YourPrice="10.50" Currency="USD" />
+					</Product>
+					<Product Name="org">
+						<Price Duration="1" DurationType="YEAR" Price="" RegularPrice="9.18" YourPrice="0.00" Currency="USD" />
+					</Product>
+				</ProductCategory>
+				<ProductCategory Name="renew">
+					<Product Name="com">
+						<Price Duration="1" DurationType="YEAR" Price="11.00" RegularPrice="12.88" YourPrice="11.50" Currency="USD" />
+					</Product>
+				</ProductCategory>
+			</ProductType>
+		</UserGetPricingResult>
+	</CommandResponse>
+	<Server>PHX01SBAPIEXT06</Server>
+	<GMTTimeDifference>--4:00</GMTTimeDifference>
+	<ExecutionTime>2.345</ExecutionTime>
+</ApiResponse>`
+
+const pricingSSLResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.users.getPricing">
+		<UserGetPricingResult>
+			<ProductType Name="ssl">
+				<ProductCategory Name="purchase">
+					<Product Name="positivessl">
+						<Price Duration="1" DurationType="YEAR" Price="9.00" RegularPrice="9.00" YourPrice="9.00" Currency="USD" />
+						<Price Duration="2" DurationType="YEAR" Price="16.00" RegularPrice="18.00" YourPrice="16.00" Currency="USD" />
+					</Product>
+				</ProductCategory>
+			</ProductType>
+		</UserGetPricingResult>
+	</CommandResponse>
+</ApiResponse>`
+
+const pricingWhoisguardResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.users.getPricing">
+		<UserGetPricingResult>
+			<ProductType Name="whoisguard">
+				<ProductCategory Name="renew">
+					<Product Name="whoisguard">
+						<Price Duration="1" DurationType="YEAR" Price="2.88" RegularPrice="2.88" YourPrice="2.88" Currency="USD" />
+					</Product>
+				</ProductCategory>
+			</ProductType>
+		</UserGetPricingResult>
+	</CommandResponse>
+</ApiResponse>`
+
+func TestUsersService_GetPricing_Domain(t *testing.T) {
+	t.Parallel()
+
+	var sent url.Values
+	client := usersMockClient(t, pricingDomainResponse, &sent)
+
+	resp, err := client.Users.GetPricingWithContext(context.Background(), &UsersGetPricingArgs{
+		ProductType:     String("DOMAIN"),
+		ProductCategory: String("REGISTER"),
+		ActionName:      String("REGISTER"),
+		ProductName:     String("com"),
+	})
+	mustNoError(t, err)
+
+	// Request carries the command and every provided narrowing parameter.
+	assert.Equal(t, "namecheap.users.getPricing", sent.Get("Command"))
+	assert.Equal(t, "DOMAIN", sent.Get("ProductType"))
+	assert.Equal(t, "REGISTER", sent.Get("ProductCategory"))
+	assert.Equal(t, "REGISTER", sent.Get("ActionName"))
+	assert.Equal(t, "com", sent.Get("ProductName"))
+
+	// The nested tree is fully navigable and keeps the doc's element/attr names.
+	result := resp.UserGetPricingResult
+	mustNotNil(t, result)
+	mustLen(t, result.ProductTypes, 1)
+	assert.Equal(t, "domains", result.ProductTypes[0].Name)
+	mustLen(t, result.ProductTypes[0].ProductCategories, 2)
+	register := result.ProductTypes[0].ProductCategories[0]
+	assert.Equal(t, "register", register.Name)
+	mustLen(t, register.Products, 3)
+	assert.Equal(t, "com", register.Products[0].Name)
+	mustLen(t, register.Products[0].Prices, 2)
+
+	// Money is preserved exactly as the server string (never float64).
+	comYear1 := register.Products[0].Prices[0]
+	assert.Equal(t, 1, comYear1.Duration)
+	assert.Equal(t, "YEAR", comYear1.DurationType)
+	assert.Equal(t, Amount("8.88"), comYear1.Price)
+	assert.Equal(t, Amount("10.87"), comYear1.RegularPrice)
+	assert.Equal(t, Amount("9.99"), comYear1.YourPrice)
+}
+
+func TestUsersService_GetPricing_PriceForPrecedence(t *testing.T) {
+	t.Parallel()
+
+	client := usersMockClient(t, pricingDomainResponse, nil)
+	resp, err := client.Users.GetPricingWithContext(context.Background(), &UsersGetPricingArgs{ProductType: String("DOMAIN")})
+	mustNoError(t, err)
+	result := resp.UserGetPricingResult
+	mustNotNil(t, result)
+
+	tests := []struct {
+		name      string
+		action    string
+		product   string
+		years     int
+		wantFound bool
+		wantEff   Amount // expected EffectivePrice
+	}{
+		{"promo wins (Price set)", "REGISTER", "com", 1, true, "8.88"},
+		{"user price when Price zero", "REGISTER", "net", 1, true, "10.50"},
+		{"regular when Price empty and user zero", "REGISTER", "org", 1, true, "9.18"},
+		{"multi-year tier", "REGISTER", "com", 2, true, "17.76"},
+		{"different action", "RENEW", "com", 1, true, "11.00"},
+		{"case-insensitive action and product", "register", "COM", 1, true, "8.88"},
+		{"unknown product", "REGISTER", "xyz", 1, false, ""},
+		{"unknown action", "TRANSFER", "com", 1, false, ""},
+		{"unknown duration", "REGISTER", "com", 5, false, ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			price, ok := result.PriceFor(tc.action, tc.product, tc.years)
+			assert.Equal(t, tc.wantFound, ok)
+			if tc.wantFound {
+				assert.Equal(t, tc.wantEff, price.EffectivePrice())
+			}
+		})
+	}
+}
+
+func TestUsersService_GetPricing_SSL(t *testing.T) {
+	t.Parallel()
+
+	client := usersMockClient(t, pricingSSLResponse, nil)
+	resp, err := client.Users.GetPricingWithContext(context.Background(), &UsersGetPricingArgs{ProductType: String("SSLCERTIFICATE")})
+	mustNoError(t, err)
+
+	result := resp.UserGetPricingResult
+	mustNotNil(t, result)
+	mustLen(t, result.ProductTypes, 1)
+	assert.Equal(t, "ssl", result.ProductTypes[0].Name)
+
+	price, ok := result.PriceFor("purchase", "positivessl", 2)
+	mustTrue(t, ok)
+	assert.Equal(t, Amount("16.00"), price.EffectivePrice())
+}
+
+func TestUsersService_GetPricing_Whoisguard(t *testing.T) {
+	t.Parallel()
+
+	client := usersMockClient(t, pricingWhoisguardResponse, nil)
+	resp, err := client.Users.GetPricingWithContext(context.Background(), &UsersGetPricingArgs{ProductType: String("WHOISGUARD")})
+	mustNoError(t, err)
+
+	result := resp.UserGetPricingResult
+	mustNotNil(t, result)
+	mustLen(t, result.ProductTypes, 1)
+	assert.Equal(t, "whoisguard", result.ProductTypes[0].Name)
+
+	price, ok := result.PriceFor("renew", "whoisguard", 1)
+	mustTrue(t, ok)
+	assert.Equal(t, Amount("2.88"), price.EffectivePrice())
+}
+
+func TestUsersService_GetPricing_Validation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil args no http", func(t *testing.T) {
+		t.Parallel()
+		var called int32
+		server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			atomic.AddInt32(&called, 1)
+		}))
+		defer server.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = server.URL
+
+		_, err := client.Users.GetPricingWithContext(context.Background(), nil)
+		assertInvalidArguments(t, err, "ProductType")
+		assert.Equal(t, int32(0), atomic.LoadInt32(&called))
+	})
+
+	t.Run("empty ProductType", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.Users.GetPricingWithContext(context.Background(), &UsersGetPricingArgs{ProductType: String("")})
+		assertInvalidArguments(t, err, "ProductType")
+	})
+
+	t.Run("optional params omitted when unset", func(t *testing.T) {
+		t.Parallel()
+		var sent url.Values
+		client := usersMockClient(t, pricingDomainResponse, &sent)
+		_, err := client.Users.GetPricingWithContext(context.Background(), &UsersGetPricingArgs{ProductType: String("DOMAIN")})
+		mustNoError(t, err)
+		assert.Equal(t, "DOMAIN", sent.Get("ProductType"))
+		_, hasCategory := sent["ProductCategory"]
+		assert.False(t, hasCategory)
+		_, hasAction := sent["ActionName"]
+		assert.False(t, hasAction)
+	})
+}
+
+// TestPrice_EffectivePrice unit-tests the precedence directly on Price values,
+// independent of parsing, to pin the promo > user > regular fallback.
+func TestPrice_EffectivePrice(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		p    Price
+		want Amount
+	}{
+		{"promo", Price{Price: "8.88", YourPrice: "9.99", RegularPrice: "10.87"}, "8.88"},
+		{"user when Price zero string", Price{Price: "0.00", YourPrice: "9.99", RegularPrice: "10.87"}, "9.99"},
+		{"user when Price empty", Price{Price: "", YourPrice: "9.99", RegularPrice: "10.87"}, "9.99"},
+		{"regular when only regular set", Price{Price: "0.0", YourPrice: "", RegularPrice: "10.87"}, "10.87"},
+		{"regular fallthrough all zero", Price{Price: "0.00", YourPrice: "0.00", RegularPrice: "0.00"}, "0.00"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.p.EffectivePrice())
+		})
+	}
+}

--- a/namecheap/users_test.go
+++ b/namecheap/users_test.go
@@ -1,0 +1,120 @@
+package namecheap
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The existing test suite depends only on testify/assert (require is not
+// vendored). These fail-fast helpers give the require.* semantics the users tests
+// need — abort the current test on failure so a following pointer dereference is
+// safe — without adding a dependency.
+
+// mustNoError aborts the test when err is non-nil.
+func mustNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// mustNotNil aborts the test when v is nil (including a typed nil pointer/slice).
+func mustNotNil(t *testing.T, v any) {
+	t.Helper()
+	if v == nil {
+		t.Fatal("expected non-nil value, got nil")
+	}
+	switch rv := reflect.ValueOf(v); rv.Kind() {
+	case reflect.Pointer, reflect.Map, reflect.Slice, reflect.Interface, reflect.Chan, reflect.Func:
+		if rv.IsNil() {
+			t.Fatal("expected non-nil value, got typed nil")
+		}
+	}
+}
+
+// mustLen aborts the test when v (a slice/array/map/string) does not have length n.
+func mustLen(t *testing.T, v any, n int) {
+	t.Helper()
+	if got := reflect.ValueOf(v).Len(); got != n {
+		t.Fatalf("expected length %d, got %d", n, got)
+	}
+}
+
+// mustTrue aborts the test when ok is false.
+func mustTrue(t *testing.T, ok bool) {
+	t.Helper()
+	if !ok {
+		t.Fatal("expected true, got false")
+	}
+}
+
+// assertInvalidArguments asserts err is an *InvalidArgumentsError whose Fields
+// contain every name in wantFields.
+func assertInvalidArguments(t *testing.T, err error, wantFields ...string) {
+	t.Helper()
+	var argErr *InvalidArgumentsError
+	if !assert.True(t, errors.As(err, &argErr), "expected *InvalidArgumentsError, got %v", err) {
+		return
+	}
+	for _, f := range wantFields {
+		assert.Contains(t, argErr.Fields, f)
+	}
+}
+
+// assertAPIError asserts err unwraps to an *APIError carrying wantNumber.
+func assertAPIError(t *testing.T, err error, wantNumber int) {
+	t.Helper()
+	var apiErr *APIError
+	if assert.True(t, errors.As(err, &apiErr), "expected *APIError, got %v", err) {
+		assert.Equal(t, wantNumber, apiErr.Number)
+	}
+}
+
+// usersMockClient returns a client pointed at a mock server that serves body and
+// records the last request's decoded form values into sent (when non-nil).
+func usersMockClient(t *testing.T, body string, sent *url.Values) *Client {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		if sent != nil {
+			q, _ := url.ParseQuery(string(raw))
+			*sent = q
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+
+	client := setupClient(nil)
+	client.BaseURL = server.URL
+	return client
+}
+
+// validAddressDetails returns a fully-populated address entry that passes
+// validation, ready to be tweaked per test.
+func validAddressDetails() *UsersAddressDetails {
+	return &UsersAddressDetails{
+		AddressName:         "Home",
+		EmailAddress:        "john@example.com",
+		FirstName:           "John",
+		LastName:            "Smith",
+		JobTitle:            "Dev",
+		Organization:        "NameCheap.com",
+		Address1:            "8939 S.cross Blvd",
+		Address2:            "Suite 600",
+		City:                "Phoenix",
+		StateProvince:       "AZ",
+		StateProvinceChoice: "S",
+		Zip:                 "85284",
+		Country:             "US",
+		Phone:               "+1.6613102107",
+		PhoneExt:            "123",
+		Fax:                 "+1.6613102108",
+	}
+}

--- a/namecheap/users_update.go
+++ b/namecheap/users_update.go
@@ -1,0 +1,137 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+)
+
+// UsersUpdateResponse is the raw envelope for namecheap.users.update.
+type UsersUpdateResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *UsersUpdateCommandResponse `xml:"CommandResponse"`
+}
+
+// UsersUpdateCommandResponse wraps the update result. The doc lists no response
+// table for users.update (docs/namecheap-api-v2.md lines 1186-1210); the result
+// element carries a Success flag on the wire.
+type UsersUpdateCommandResponse struct {
+	UserUpdateResult *UsersUpdateResult `xml:"UserUpdateResult"`
+}
+
+// UsersUpdateResult is the outcome of an account update.
+type UsersUpdateResult struct {
+	// Success reports whether the account was updated.
+	Success *bool `xml:"Success,attr"`
+}
+
+// UsersUpdateArgs are the arguments for UpdateWithContext. Field names and
+// required/optional status follow the update request table in
+// docs/namecheap-api-v2.md (lines 1196-1209).
+//
+// Note the field naming differs from the domain ContactInfo shape: this command
+// uses "Zip" (not "PostalCode"), "Organization" (not "OrganizationName") and adds
+// PhoneExt/Fax. It is the account owner's own profile, not a per-domain contact,
+// so no ContactInfo adapter is provided for it.
+type UsersUpdateArgs struct {
+	// FirstName is the account holder's first name. Required.
+	FirstName string
+	// LastName is the account holder's last name. Required.
+	LastName string
+	// JobTitle is the job designation. Optional.
+	JobTitle string
+	// Organization is the organization name. Optional.
+	Organization string
+	// Address1 is the primary street address. Required.
+	Address1 string
+	// Address2 is the secondary street address. Optional.
+	Address2 string
+	// City is the city. Required.
+	City string
+	// StateProvince is the state or province. Required.
+	StateProvince string
+	// Zip is the postal/ZIP code. Required.
+	Zip string
+	// Country is the two-letter country code. Required.
+	Country string
+	// EmailAddress is the account e-mail address. Required.
+	EmailAddress string
+	// Phone is the phone number in +NNN.NNNNNNNNNN format. Required.
+	Phone string
+	// PhoneExt is the phone extension. Optional.
+	PhoneExt string
+	// Fax is the fax number in +NNN.NNNNNNNNNN format. Optional.
+	Fax string
+}
+
+// UpdateWithContext updates the account contact information.
+//
+// It is a non-idempotent account write but not charge-bearing; it uses the
+// standard idempotent transport.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/users/update/
+func (us *UsersService) UpdateWithContext(ctx context.Context, args *UsersUpdateArgs) (*UsersUpdateCommandResponse, error) {
+	if args == nil {
+		return nil, &InvalidArgumentsError{Fields: []string{"args"}, Reason: "args must not be nil"}
+	}
+	if err := args.validate(); err != nil {
+		return nil, err
+	}
+
+	var response UsersUpdateResponse
+	_, err := us.client.DoXMLWithContext(ctx, args.params(), &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}
+
+// validate reports every missing required field at once.
+func (a *UsersUpdateArgs) validate() error {
+	required := []requiredContactField{
+		{"FirstName", a.FirstName},
+		{"LastName", a.LastName},
+		{"Address1", a.Address1},
+		{"City", a.City},
+		{"StateProvince", a.StateProvince},
+		{"Zip", a.Zip},
+		{"Country", a.Country},
+		{"EmailAddress", a.EmailAddress},
+		{"Phone", a.Phone},
+	}
+	missing := make([]string, 0, len(required))
+	for _, f := range required {
+		if f.value == "" {
+			missing = append(missing, f.suffix)
+		}
+	}
+	if len(missing) > 0 {
+		return &InvalidArgumentsError{Fields: missing}
+	}
+	return nil
+}
+
+// params flattens the validated args into the request map.
+func (a *UsersUpdateArgs) params() map[string]string {
+	params := map[string]string{
+		"Command":       "namecheap.users.update",
+		"FirstName":     a.FirstName,
+		"LastName":      a.LastName,
+		"Address1":      a.Address1,
+		"City":          a.City,
+		"StateProvince": a.StateProvince,
+		"Zip":           a.Zip,
+		"Country":       a.Country,
+		"EmailAddress":  a.EmailAddress,
+		"Phone":         a.Phone,
+	}
+	setIfNotEmpty(params, "JobTitle", a.JobTitle)
+	setIfNotEmpty(params, "Organization", a.Organization)
+	setIfNotEmpty(params, "Address2", a.Address2)
+	setIfNotEmpty(params, "PhoneExt", a.PhoneExt)
+	setIfNotEmpty(params, "Fax", a.Fax)
+	return params
+}

--- a/namecheap/users_update_test.go
+++ b/namecheap/users_update_test.go
@@ -1,0 +1,79 @@
+package namecheap
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const usersUpdateResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.users.update">
+		<UserUpdateResult Success="true" />
+	</CommandResponse>
+</ApiResponse>`
+
+func validUpdateArgs() *UsersUpdateArgs {
+	return &UsersUpdateArgs{
+		FirstName:     "John",
+		LastName:      "Smith",
+		Address1:      "8939 S.cross Blvd",
+		City:          "Phoenix",
+		StateProvince: "AZ",
+		Zip:           "85284",
+		Country:       "US",
+		EmailAddress:  "john@example.com",
+		Phone:         "+1.6613102107",
+	}
+}
+
+func TestUsersService_Update(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		var sent url.Values
+		client := usersMockClient(t, usersUpdateResponse, &sent)
+
+		args := validUpdateArgs()
+		args.Organization = "NameCheap.com"
+		args.PhoneExt = "42"
+
+		resp, err := client.Users.UpdateWithContext(context.Background(), args)
+		mustNoError(t, err)
+
+		assert.Equal(t, "namecheap.users.update", sent.Get("Command"))
+		assert.Equal(t, "John", sent.Get("FirstName"))
+		assert.Equal(t, "85284", sent.Get("Zip"))
+		assert.Equal(t, "NameCheap.com", sent.Get("Organization"))
+		assert.Equal(t, "42", sent.Get("PhoneExt"))
+		// An unset optional is never sent as a blank value.
+		_, hasFax := sent["Fax"]
+		assert.False(t, hasFax)
+
+		mustNotNil(t, resp.UserUpdateResult)
+		assert.True(t, *resp.UserUpdateResult.Success)
+	})
+
+	t.Run("nil args", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		_, err := client.Users.UpdateWithContext(context.Background(), nil)
+		assertInvalidArguments(t, err, "args")
+	})
+
+	t.Run("missing required fields reported all at once", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		args := validUpdateArgs()
+		args.FirstName = ""
+		args.EmailAddress = ""
+		args.Zip = ""
+
+		_, err := client.Users.UpdateWithContext(context.Background(), args)
+		assertInvalidArguments(t, err, "FirstName", "EmailAddress", "Zip")
+	})
+}


### PR DESCRIPTION
Closes #117. Phase 2 coverage on the go-namecheap-sdk 2.0 roadmap (#122). `GetPricing`/`GetBalances` are the precondition checks every money-bearing op needs; the address book gives reusable registrant profiles that simplify `domains.create`. Reuses `ContactInfo` (#114), `Amount` (#114), and the non-idempotent `doXML` path (#114).

## What — two new services (ctx-first, `WithContext` suffix)
### `UsersService`
- **`GetPricingWithContext`** — the deeply nested price sheet modeled as a navigable typed tree (ProductType → Category → Product → Price tiers), plus **`PriceFor(action, product, years)`** for the 90% one-call lookup. Precedence `Price → YourPrice → RegularPrice` (first positive, checked decimal-safe). All money is `Amount` (never float64). Documented as large/slow-changing.
- **`GetBalancesWithContext`** — decimal-safe amounts + currency.
- **`CreateAddFundsRequestWithContext`** (+ `GetAddFundsStatusWithContext`, status constants) — add-funds spends money → routed through `doXML(..., idempotent=false)`; tested for exactly one attempt on ambiguous server/timeout failures.
- **`ChangePasswordWithContext`**, **`UpdateWithContext`**.

### `UsersAddressService`
- Full CRUD: `Create`/`Update`/`Delete`/`GetInfo`/`GetList`/`SetDefault`.
- **Bidirectional `ContactInfo`↔address adapter** (`PostalCode`↔`Zip`, `OrganizationName`↔`Organization` mapped explicitly; `ToContactInfo` on the fetched entry) so a stored address feeds `domains.create` contact blocks — round-trip tested for no field drift.

## Scope & dependency notes
- **Deferred (documented in the coverage matrix as planned/unscheduled)**: `users.create` / `users.login` / `users.resetPassword` — reseller-only surface, weak demand.
- **Password redaction**: passwords live only in the outbound request, never stored/logged. The issue's "redaction grep-test" depends on the hook layer from **#113** (observability, not yet landed) — that specific test is deferred to #113; a doc note flags it. Everything else in the AC is delivered.

## Acceptance criteria
- [x] `GetPricing` parses DOMAIN / SSLCERTIFICATE / WHOISGUARD fixtures; `PriceFor` precedence table-tested.
- [x] `GetBalances` decimal-safe amounts + currency (exact-string preservation tested).
- [x] Address CRUD round-trip (`Create`→`GetInfo` field equality), `SetDefault`, list.
- [x] `AddFundsRequest`/`GetAddFundsStatus` with status constants; add-funds non-idempotent (tested).
- [x] `ContactInfo`↔address adapter tested both directions (no drift).
- [x] Structs cross-checked against the doc (line ranges cited in commit); deferred commands documented.
- [~] `ChangePassword` redaction grep-test deferred to #113 (no hook layer yet); passwords never stored/logged.
- [x] README coverage matrix + "check balance before bulk renew" and "cheapest TLD" examples; CHANGELOG; doc comments everywhere.

## Verification (local, go 1.26.4 + golangci-lint 2.12.2)
`go vet` ✅ · `golangci-lint run` → 0 issues ✅ · `go mod verify` (no new deps, go.mod/go.sum/vendor unchanged) ✅ · `make test` unit + **race** ✅ (113 tests, 94.1% coverage).
