### PR TITLE
feat: add ssl API group — full certificate lifecycle (13 commands)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New `SSLService` (`client.SSL`), context-first with the `WithContext` suffix,
+  covering the full `namecheap.ssl.*` group — all 13 commands across three phases:
+  inventory (`GetListWithContext`, `GetInfoWithContext`, `ParseCSRWithContext`),
+  activation (`ActivateWithContext`, `GetApproverEmailListWithContext`,
+  `ResendApproverEmailWithContext`, `EditDCVMethodWithContext`) and the
+  charge-bearing money operations (`CreateWithContext`, `RenewWithContext`,
+  `ReissueWithContext`, `PurchaseMoreSansWithContext`,
+  `RevokeCertificateWithContext`, `ResendFulfillmentEmailWithContext`).
+  Args/response structs match `docs/namecheap-api-v2.md` (ssl section, lines
+  785-1101); the 13th command is `editDCVMethod` per the doc (the issue's
+  "editDNSDSCRecords" is a typo) (#116).
+- Typed `DCVMethod` enum (`DCVMethodHTTP`, `DCVMethodDNS`, `DCVMethodEmail`) with
+  client-side, per-method required-field validation for `Activate` and
+  `EditDCVMethod`: an invalid method cannot be expressed as a valid value, and
+  email validation requires an `ApproverEmail`, reported together with every other
+  missing field via `*InvalidArgumentsError` (table-tested method × missing-field).
+  The doc names a `DCVMethod` parameter but enumerates no values, so the wire
+  tokens are grounded in the documented Namecheap DCV flow (flagged in code and
+  README) (#116).
+- Grounded `CertStatus` type mirroring the documented certificate-status
+  vocabulary (`ACTIVE`/`NEWPURCHASE`/`NEWRENEWAL`/`PURCHASED`/`PURCHASEERROR`/
+  `CANCELLED`/`UNKNOWN`, doc lines 948-957) with `ClassifyStatus`, plus
+  `SSLGetInfoResult.IsIssued()` (true only for `ACTIVE`) and
+  `IsExpiringSoon(within)`. All expiry math lives in one tested, timezone-safe
+  helper with an inclusive boundary (boundary-tested exactly at the threshold);
+  the raw status string is exposed verbatim (#116).
+- SSL money operations `Create`, `Renew`, `Reissue` and `PurchaseMoreSans` are
+  **non-idempotent**: they use the same retry classification as `domains.create`
+  (`doXML(..., false)`), so an ambiguous transport/server failure is never
+  auto-retried (only the pre-execution HTTP 405 rate-limit signal is). Read,
+  approver and revoke/resend calls are idempotent. A test asserts no re-fire after
+  a simulated server error (call-count == 1) for `Create` and `Reissue` (#116).
+- Multi-SAN (host-block) support on `Activate` and `EditDCVMethod`: N SAN entries
+  serialize deterministically (indexed `SANDomainName[i]`/`SANDCVMethod[i]` for
+  activate; comma-separated `DNSNames`/`DCVMethods` for editDCVMethod) and are
+  round-trip tested with 3+ SANs across mixed DCV methods (#116).
+- Key/CSR generation is documented as an explicit non-goal: the SDK transports the
+  CSR string only and never generates or stores private keys (README points at
+  `crypto/x509` for generating a CSR) (#116).
 - New `DomainsTransferService` (`client.DomainsTransfer`), context-first with the
   `WithContext` suffix, covering the full `namecheap.domains.transfer.*` group:
   `CreateWithContext`, `GetStatusWithContext`, `UpdateStatusWithContext` and

--- a/README.md
+++ b/README.md
@@ -462,6 +462,119 @@ counterpart for (`AddressName`, `DefaultYN`, `StateProvinceChoice`, `PhoneExt`,
 | `getList` | Implemented |
 | `setDefault` | Implemented |
 
+#### SSL (`client.SSL`)
+
+The `ssl.*` group covers the full certificate lifecycle across three phases:
+inventory (read), activation, and the charge-bearing money operations.
+
+| Method | Description |
+|---|---|
+| `GetListWithContext(ctx, args)` | List certificates (status filter, search, paging, sort) |
+| `GetInfoWithContext(ctx, certificateID, returnCert, returnType)` | Get one certificate's detail (status, expiry, provider) |
+| `ParseCSRWithContext(ctx, csr, certificateType)` | Decode the fields of a CSR |
+| `ActivateWithContext(ctx, args)` | Activate a purchased certificate (CSR, web-server type, DCV method, multi-SAN) |
+| `GetApproverEmailListWithContext(ctx, domainName, certificateType)` | List approver emails for a domain |
+| `ResendApproverEmailWithContext(ctx, certificateID)` | Resend approver email / retry HTTP-DNS validation |
+| `EditDCVMethodWithContext(ctx, args)` | Change the domain-control-validation method (single or multi-domain) |
+| `CreateWithContext(ctx, args)` | Purchase a new certificate (charge-bearing) |
+| `RenewWithContext(ctx, args)` | Renew a certificate (charge-bearing) |
+| `ReissueWithContext(ctx, args)` | Reissue a certificate (non-idempotent) |
+| `PurchaseMoreSansWithContext(ctx, args)` | Buy additional SAN slots (charge-bearing) |
+| `RevokeCertificateWithContext(ctx, certificateID, certificateType)` | Revoke a re-issued certificate |
+| `ResendFulfillmentEmailWithContext(ctx, certificateID)` | Resend the fulfilment email |
+
+```go
+// End-to-end: purchase, activate with DNS (CNAME) DCV, then poll until issued.
+// You generate the private key and CSR yourself; the SDK only transports the CSR
+// string and never sees or stores key material (see the note below).
+created, err := client.SSL.CreateWithContext(ctx, &namecheap.SSLCreateArgs{
+    Years: 1,
+    Type:  "PositiveSSL",
+})
+if err != nil {
+    log.Fatal(err) // charge-bearing: never auto-retried on an ambiguous failure
+}
+certID := *created.SSLCreateResult.CertificateID
+
+// Activate with DNS-based domain control validation.
+_, err = client.SSL.ActivateWithContext(ctx, &namecheap.SSLActivateArgs{
+    CertificateID:     certID,
+    CSR:               csrPEM, // your PEM-encoded CSR string
+    AdminEmailAddress: "[email protected]",
+    WebServerType:     "nginx",
+    DCVMethod:         namecheap.DCVMethodDNS,
+})
+if err != nil {
+    log.Fatal(err)
+}
+
+// Poll GetInfo until the certificate is issued (Active). IsExpiringSoon and
+// IsIssued do the status/expiry reasoning for you.
+for {
+    info, err := client.SSL.GetInfoWithContext(ctx, certID, "", "")
+    if err != nil {
+        log.Fatal(err)
+    }
+    if info.SSLGetInfoResult.IsIssued() {
+        break
+    }
+    select {
+    case <-ctx.Done():
+        log.Fatal(ctx.Err())
+    case <-time.After(60 * time.Second):
+    }
+}
+```
+
+> **DCV method is a typed enum.** `DCVMethodHTTP`, `DCVMethodDNS` and
+> `DCVMethodEmail` cannot be mistyped, and per-method required-field validation
+> runs client-side before any network call — email validation requires an
+> `ApproverEmail`, reported (with every other missing field) via
+> `*InvalidArgumentsError`. The doc names a `DCVMethod` parameter but does **not**
+> enumerate its values, and the activate section documents no DCV/SAN parameters
+> at all; the two non-email tokens (`HTTP_CSR_HASH`, `CNAME_CSR_HASH`) and the
+> email-address wire value are grounded in the documented Namecheap DCV flow, and
+> the multi-SAN blocks (`SANDomainName[i]` / `SANDCVMethod[i]`) follow the
+> documented multi-domain activation contract.
+>
+> **Certificate status is typed and grounded.** Unlike transfer status, the doc
+> *does* enumerate the certificate status vocabulary, so `CertStatus`
+> (`ACTIVE` / `NEWPURCHASE` / `NEWRENEWAL` / `PURCHASED` / `PURCHASEERROR` /
+> `CANCELLED` / `UNKNOWN`) mirrors it exactly — no fabricated codes. The raw
+> status string is exposed verbatim; `ClassifyStatus`, `IsIssued()` (true only for
+> `ACTIVE`) and `IsExpiringSoon(within)` (inclusive boundary, timezone-safe) read
+> it for you.
+>
+> **Money operations are non-idempotent.** `Create`, `Renew`, `Reissue` and
+> `PurchaseMoreSans` are never auto-retried on an ambiguous transport/server
+> failure (only the pre-execution HTTP 405 rate-limit signal is), the same money
+> rule as `domains.create`. The read/inventory and validation calls are
+> idempotent and retry as usual.
+>
+> **Keys and CSRs are the consumer's job.** This SDK only transports the CSR
+> string you provide; it never generates, parses, or stores private keys.
+> Generate a key pair and CSR yourself — for example with the standard library's
+> `crypto/x509` (`x509.CreateCertificateRequest`) and `encoding/pem` — and pass
+> the PEM-encoded CSR to `ActivateWithContext` / `ReissueWithContext`.
+
+##### SSL API coverage matrix
+
+| `namecheap.ssl.*` command | Status |
+|---|---|
+| `create` | Implemented |
+| `getList` | Implemented |
+| `parseCSR` | Implemented |
+| `getApproverEmailList` | Implemented |
+| `activate` | Implemented |
+| `resendApproverEmail` | Implemented |
+| `getInfo` | Implemented |
+| `renew` | Implemented |
+| `reissue` | Implemented |
+| `resendfulfillmentemail` | Implemented |
+| `purchasemoresans` | Implemented |
+| `revokecertificate` | Implemented |
+| `editDCVMethod` | Implemented |
+
 ### Error handling
 
 When the API rejects a call it returns a typed `*namecheap.APIError` carrying the

--- a/namecheap/namecheap.go
+++ b/namecheap/namecheap.go
@@ -102,6 +102,8 @@ type Client struct {
 
 	Users        *UsersService
 	UsersAddress *UsersAddressService
+
+	SSL *SSLService
 }
 
 type service struct {
@@ -151,6 +153,7 @@ func NewClient(options *ClientOptions) *Client {
 	client.DomainsTransfer = (*DomainsTransferService)(&client.common)
 	client.Users = (*UsersService)(&client.common)
 	client.UsersAddress = (*UsersAddressService)(&client.common)
+	client.SSL = (*SSLService)(&client.common)
 
 	return client
 }

--- a/namecheap/ssl.go
+++ b/namecheap/ssl.go
@@ -1,0 +1,176 @@
+package namecheap
+
+import (
+	"strings"
+	"time"
+)
+
+// SSLService groups the namecheap.ssl.* API commands, covering the full
+// certificate lifecycle: inventory (GetListWithContext, GetInfoWithContext,
+// ParseCSRWithContext), activation (ActivateWithContext,
+// GetApproverEmailListWithContext, ResendApproverEmailWithContext,
+// EditDCVMethodWithContext) and the charge-bearing money operations
+// (CreateWithContext, RenewWithContext, ReissueWithContext,
+// PurchaseMoreSansWithContext, RevokeCertificateWithContext,
+// ResendFulfillmentEmailWithContext).
+//
+// Keys and CSRs (non-goal). This SDK only transports the CSR string a consumer
+// supplies; it never generates, parses locally, or stores private keys. Generate
+// a key and CSR yourself (for example with crypto/x509 and encoding/pem) and pass
+// the PEM-encoded CSR to ActivateWithContext / ReissueWithContext. Nothing in
+// this package holds key material.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/ssl/
+type SSLService service
+
+// DCVMethod is a typed domain-control-validation (DCV) method selector used by
+// ActivateWithContext and EditDCVMethodWithContext. Because it is a fixed enum,
+// an invalid method cannot be expressed as a valid value; a bad string is
+// rejected client-side by argument validation (see IsValid).
+//
+// Grounding and the documented gap. The Namecheap API doc
+// (docs/namecheap-api-v2.md, ssl section) names a DCVMethod parameter for
+// editDCVMethod (line 1087) but does NOT enumerate its accepted values, nor does
+// the activate section (lines 895-912) document its DCV parameters at all. This
+// SDK therefore does not fabricate a code table: it grounds the two non-email
+// methods in the documented Namecheap DCV tokens sent on the wire
+// (HTTP_CSR_HASH, CNAME_CSR_HASH) and, for email validation, sends the approver
+// email address as the DCV value (the documented approver-email flow). The gap is
+// flagged here and in README.md.
+type DCVMethod string
+
+const (
+	// DCVMethodHTTP selects HTTP file-based validation. Its wire token is
+	// "HTTP_CSR_HASH". No approver email is required.
+	DCVMethodHTTP DCVMethod = "HTTP_CSR_HASH"
+	// DCVMethodDNS selects DNS CNAME-based validation. Its wire token is
+	// "CNAME_CSR_HASH". No approver email is required.
+	DCVMethodDNS DCVMethod = "CNAME_CSR_HASH"
+	// DCVMethodEmail selects email-based validation. It requires an approver email
+	// address, which is what the SDK places on the wire as the DCV value (see
+	// dcvWireValue); the "EMAIL" string itself is a client-side selector only.
+	DCVMethodEmail DCVMethod = "EMAIL"
+)
+
+// IsValid reports whether m is one of the three supported DCV methods.
+func (m DCVMethod) IsValid() bool {
+	switch m {
+	case DCVMethodHTTP, DCVMethodDNS, DCVMethodEmail:
+		return true
+	default:
+		return false
+	}
+}
+
+// SANEntry is one Subject Alternative Name (additional domain / host block) in a
+// multi-domain (SAN) activation or DCV edit, carrying its own domain-control
+// validation method. A single certificate can validate each SAN independently.
+type SANEntry struct {
+	// DomainName is the SAN / additional domain to validate. Required.
+	DomainName string
+	// DCVMethod is the DCV method for this SAN. Required.
+	DCVMethod DCVMethod
+	// ApproverEmail is the approver email address; required only when DCVMethod is
+	// DCVMethodEmail.
+	ApproverEmail string
+}
+
+// dcvWireValue returns the wire value that expresses method for a single domain.
+// HTTP and DNS map to their documented tokens; email validation puts the approver
+// email address on the wire (the documented approver-email flow).
+func dcvWireValue(method DCVMethod, approverEmail string) string {
+	switch method {
+	case DCVMethodEmail:
+		return approverEmail
+	case DCVMethodHTTP, DCVMethodDNS:
+		return string(method)
+	default:
+		return string(method)
+	}
+}
+
+// dcvMissingFields returns the names (prefixed by label) of the fields method
+// requires but that are missing, so a caller can list every offending field at
+// once. Email DCV requires an approver email; HTTP and DNS DCV require no extra
+// field. An unrecognised method reports label+"DCVMethod" so an invalid value is
+// surfaced client-side before any network call.
+func dcvMissingFields(label string, method DCVMethod, approverEmail string) []string {
+	switch method {
+	case DCVMethodHTTP, DCVMethodDNS:
+		return nil
+	case DCVMethodEmail:
+		if strings.TrimSpace(approverEmail) == "" {
+			return []string{label + "ApproverEmail"}
+		}
+		return nil
+	default:
+		return []string{label + "DCVMethod"}
+	}
+}
+
+// CertStatus is a typed SSL certificate status. Unlike domain-transfer statuses,
+// the Namecheap API doc DOES enumerate the certificate status vocabulary
+// (docs/namecheap-api-v2.md lines 948-957), so these constants are grounded in
+// that documented set rather than fabricated. The raw status string is always
+// exposed verbatim on the response (see SSLGetInfoResult.Status); ClassifyStatus
+// maps it, case-insensitively, onto one of these constants.
+type CertStatus string
+
+const (
+	// CertStatusUnknown is used for an empty or unrecognised status string. It is
+	// never treated as issued.
+	CertStatusUnknown CertStatus = "UNKNOWN"
+	// CertStatusActive means the certificate is activated and issued (doc line 952).
+	// This is the state IsIssued reports true for.
+	CertStatusActive CertStatus = "ACTIVE"
+	// CertStatusNewPurchase is the initial state after purchase; ssl.activate is the
+	// next step (doc line 953).
+	CertStatusNewPurchase CertStatus = "NEWPURCHASE"
+	// CertStatusNewRenewal is the initial state after a renewal purchase (doc line 954).
+	CertStatusNewRenewal CertStatus = "NEWRENEWAL"
+	// CertStatusPurchased means the certificate is activated and awaiting issuance
+	// (doc line 955) — activated but not yet issued.
+	CertStatusPurchased CertStatus = "PURCHASED"
+	// CertStatusPurchaseError means an error occurred while processing the
+	// certificate (doc line 956).
+	CertStatusPurchaseError CertStatus = "PURCHASEERROR"
+	// CertStatusCancelled means the certificate was cancelled (doc line 957).
+	CertStatusCancelled CertStatus = "CANCELLED"
+)
+
+// ClassifyStatus maps a raw certificate status string onto a CertStatus using
+// the documented status vocabulary (docs/namecheap-api-v2.md lines 948-957). It
+// is case-insensitive and whitespace-trimming; an empty or unrecognised value
+// yields CertStatusUnknown. No status code is invented.
+func ClassifyStatus(status string) CertStatus {
+	switch strings.ToUpper(strings.TrimSpace(status)) {
+	case "ACTIVE":
+		return CertStatusActive
+	case "NEWPURCHASE":
+		return CertStatusNewPurchase
+	case "NEWRENEWAL":
+		return CertStatusNewRenewal
+	case "PURCHASED":
+		return CertStatusPurchased
+	case "PURCHASEERROR":
+		return CertStatusPurchaseError
+	case "CANCELLED":
+		return CertStatusCancelled
+	default:
+		return CertStatusUnknown
+	}
+}
+
+// expiresWithin is the single, tested place that decides whether an expiry
+// instant falls within a lead time of a reference "now". It returns true when
+// expiry is at or before now+within (an inclusive boundary), so a certificate
+// that expires exactly at the threshold — or that has already expired — counts as
+// expiring soon. A zero expiry (never parsed) returns false. Comparison is on
+// absolute instants, so it is timezone-safe regardless of how expiry or now were
+// constructed.
+func expiresWithin(expiry time.Time, within time.Duration, now time.Time) bool {
+	if expiry.IsZero() {
+		return false
+	}
+	return !expiry.After(now.Add(within))
+}

--- a/namecheap/ssl_activate.go
+++ b/namecheap/ssl_activate.go
@@ -1,0 +1,183 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// SSLActivateResponse is the raw envelope for namecheap.ssl.activate.
+type SSLActivateResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *SSLActivateCommandResponse `xml:"CommandResponse"`
+}
+
+// SSLActivateCommandResponse wraps the activate result.
+type SSLActivateCommandResponse struct {
+	SSLActivateResult *SSLActivateResult `xml:"SSLActivateResult"`
+}
+
+// SSLActivateResult is the outcome of an activation. The doc's activate section
+// (docs/namecheap-api-v2.md lines 895-912) does not tabulate the response fields;
+// these follow the fields a certificate activation returns, with the HTTP-DCV
+// file details surfaced for the HTTP validation flow.
+type SSLActivateResult struct {
+	// ID is the unique integer identifying the certificate.
+	ID *int `xml:"ID,attr"`
+	// IsSuccess reports whether the activation request was accepted.
+	IsSuccess *bool `xml:"IsSuccess,attr"`
+	// HTTPDCValidationFileName is the file name for the HTTP DCV text file, when
+	// HTTP validation is in use.
+	HTTPDCValidationFileName *string `xml:"HttpDCValidation>FileName"`
+	// HTTPDCValidationFileContent is the content for the HTTP DCV text file, when
+	// HTTP validation is in use.
+	HTTPDCValidationFileContent *string `xml:"HttpDCValidation>FileContent"`
+}
+
+// SSLActivateArgs are the arguments for ActivateWithContext.
+//
+// Documented fields (doc lines 903-910): CertificateID, CSR, AdminEmailAddress,
+// WebServerType and UniqueValue. The doc does NOT enumerate the activate DCV or
+// multi-SAN parameters, so DCVMethod / ApproverEmail (primary domain) and SANs
+// (additional domains) follow the documented Namecheap multi-domain activation
+// contract; the gap is flagged on DCVMethod and in README.md.
+type SSLActivateArgs struct {
+	// CertificateID is the certificate to activate. Required.
+	CertificateID int
+	// CSR is the PEM-encoded Certificate Signing Request. Required. The SDK
+	// transports it verbatim and never inspects or stores key material.
+	CSR string
+	// AdminEmailAddress is where the signed certificate file is sent. Required.
+	AdminEmailAddress string
+	// WebServerType is the server software type (apacheopenssl, nginx, iis, ...).
+	// Optional.
+	WebServerType string
+	// UniqueValue is an optional unique identifier for the issue/reissue request.
+	UniqueValue string
+
+	// DCVMethod is the domain-control-validation method for the primary common
+	// name. Optional; when set it is validated per-method (email requires
+	// ApproverEmail).
+	DCVMethod DCVMethod
+	// ApproverEmail is the primary domain's approver email; required only when
+	// DCVMethod is DCVMethodEmail.
+	ApproverEmail string
+
+	// SANs are the additional domains (host blocks) for a multi-domain (SAN)
+	// certificate, each with its own DCV method. Optional; each entry is validated
+	// and serialized as an indexed parameter block.
+	SANs []SANEntry
+}
+
+// ActivateWithContext activates a newly purchased SSL certificate.
+//
+// It is idempotent from a billing standpoint (activation is not charge-bearing)
+// and retries on transient failures. Arguments are validated client-side first,
+// reporting every missing field at once via *InvalidArgumentsError — activation
+// failures are slow and opaque server-side, so obvious omissions are caught before
+// any network call.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/ssl/activate/
+func (ss *SSLService) ActivateWithContext(ctx context.Context, args *SSLActivateArgs) (*SSLActivateCommandResponse, error) {
+	if args == nil {
+		return nil, &InvalidArgumentsError{Fields: []string{"args"}, Reason: "args must not be nil"}
+	}
+	if err := args.validate(); err != nil {
+		return nil, err
+	}
+
+	var response SSLActivateResponse
+	_, err := ss.client.DoXMLWithContext(ctx, args.params(), &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}
+
+// validate reports every missing/invalid field at once, including per-DCV-method
+// requirements for the primary domain and each SAN.
+func (a *SSLActivateArgs) validate() error {
+	missing := make([]string, 0, 4)
+	if a.CertificateID < 1 {
+		missing = append(missing, "CertificateID")
+	}
+	if a.CSR == "" {
+		missing = append(missing, "CSR")
+	}
+	if a.AdminEmailAddress == "" {
+		missing = append(missing, "AdminEmailAddress")
+	}
+	if a.DCVMethod != "" {
+		missing = append(missing, dcvMissingFields("", a.DCVMethod, a.ApproverEmail)...)
+	}
+	missing = append(missing, missingSANFields(a.SANs)...)
+	if len(missing) > 0 {
+		return &InvalidArgumentsError{Fields: missing}
+	}
+	return nil
+}
+
+// params flattens the validated args into the request map, serializing the
+// documented scalar fields and the DCV / multi-SAN blocks.
+func (a *SSLActivateArgs) params() map[string]string {
+	params := map[string]string{
+		"Command":           "namecheap.ssl.activate",
+		"CertificateID":     strconv.Itoa(a.CertificateID),
+		"CSR":               a.CSR,
+		"AdminEmailAddress": a.AdminEmailAddress,
+	}
+	setIfNotEmpty(params, "WebServerType", a.WebServerType)
+	setIfNotEmpty(params, "UniqueValue", a.UniqueValue)
+	if a.DCVMethod != "" {
+		params["DCVMethod"] = dcvWireValue(a.DCVMethod, a.ApproverEmail)
+	}
+	applySANParams(params, a.SANs)
+	return params
+}
+
+// missingSANFields returns every missing field across all SAN entries, prefixed
+// with an SANs[i]. label so a caller can fix them in one pass.
+func missingSANFields(sans []SANEntry) []string {
+	var missing []string
+	for i, san := range sans {
+		label := fmt.Sprintf("SANs[%d].", i)
+		if san.DomainName == "" {
+			missing = append(missing, label+"DomainName")
+		}
+		if san.DCVMethod == "" {
+			missing = append(missing, label+"DCVMethod")
+		} else {
+			missing = append(missing, dcvMissingFields(label, san.DCVMethod, san.ApproverEmail)...)
+		}
+	}
+	return missing
+}
+
+// applySANParams serializes each SAN entry as an indexed parameter block
+// (SANDomainName[i] / SANDCVMethod[i]), so N host blocks round-trip
+// deterministically. The doc does not enumerate these names; they follow the
+// documented multi-domain activation contract (flagged in README.md).
+func applySANParams(params map[string]string, sans []SANEntry) {
+	for i, san := range sans {
+		params[fmt.Sprintf("SANDomainName[%d]", i)] = san.DomainName
+		params[fmt.Sprintf("SANDCVMethod[%d]", i)] = dcvWireValue(san.DCVMethod, san.ApproverEmail)
+	}
+}
+
+// sanCommaLists renders a slice of SAN entries as the parallel comma-separated
+// DNSNames and DCVMethods lists used by editDCVMethod (doc lines 1088-1089).
+func sanCommaLists(sans []SANEntry) (names, methods string) {
+	n := make([]string, 0, len(sans))
+	m := make([]string, 0, len(sans))
+	for _, san := range sans {
+		n = append(n, san.DomainName)
+		m = append(m, dcvWireValue(san.DCVMethod, san.ApproverEmail))
+	}
+	return strings.Join(n, ","), strings.Join(m, ",")
+}

--- a/namecheap/ssl_activate_test.go
+++ b/namecheap/ssl_activate_test.go
@@ -1,0 +1,203 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const sslActivateOKResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.ssl.activate">
+		<SSLActivateResult ID="123456" IsSuccess="true">
+			<HttpDCValidation ValueAvailable="true">
+				<FileName>A1B2C3.txt</FileName>
+				<FileContent>hash-content</FileContent>
+			</HttpDCValidation>
+		</SSLActivateResult>
+	</CommandResponse>
+</ApiResponse>`
+
+func newSSLCaptureServer(t *testing.T, body string) (*httptest.Server, *url.Values) {
+	t.Helper()
+	sent := &url.Values{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		parsed, _ := url.ParseQuery(string(raw))
+		*sent = parsed
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+	return server, sent
+}
+
+// TestSSLService_Activate_PerDCVMethod runs one activation per DCV method and
+// asserts the DCV method serializes to the correct wire value, plus a successful
+// response parse (including the HTTP DCV file block).
+func TestSSLService_Activate_PerDCVMethod(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		method   DCVMethod
+		approver string
+		wantWire string
+	}{
+		{"http", DCVMethodHTTP, "", "HTTP_CSR_HASH"},
+		{"dns", DCVMethodDNS, "", "CNAME_CSR_HASH"},
+		{"email", DCVMethodEmail, "[email protected]", "[email protected]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			server, sent := newSSLCaptureServer(t, sslActivateOKResponse)
+			client := setupClient(nil)
+			client.BaseURL = server.URL
+
+			resp, err := client.SSL.ActivateWithContext(context.Background(), &SSLActivateArgs{
+				CertificateID:     123456,
+				CSR:               "csr-data",
+				AdminEmailAddress: "[email protected]",
+				WebServerType:     "nginx",
+				DCVMethod:         tc.method,
+				ApproverEmail:     tc.approver,
+			})
+			if err != nil {
+				t.Fatal("unexpected error", err)
+			}
+
+			assert.Equal(t, "namecheap.ssl.activate", sent.Get("Command"))
+			assert.Equal(t, "123456", sent.Get("CertificateID"))
+			assert.Equal(t, "csr-data", sent.Get("CSR"))
+			assert.Equal(t, "[email protected]", sent.Get("AdminEmailAddress"))
+			assert.Equal(t, "nginx", sent.Get("WebServerType"))
+			assert.Equal(t, tc.wantWire, sent.Get("DCVMethod"))
+
+			result := resp.SSLActivateResult
+			assert.Equal(t, 123456, *result.ID)
+			assert.True(t, *result.IsSuccess)
+			assert.Equal(t, "A1B2C3.txt", *result.HTTPDCValidationFileName)
+			assert.Equal(t, "hash-content", *result.HTTPDCValidationFileContent)
+		})
+	}
+}
+
+// TestSSLService_Activate_MultiSAN round-trips 3 SAN host blocks through the
+// indexed serialization and back out of the captured request.
+func TestSSLService_Activate_MultiSAN(t *testing.T) {
+	t.Parallel()
+
+	server, sent := newSSLCaptureServer(t, sslActivateOKResponse)
+	client := setupClient(nil)
+	client.BaseURL = server.URL
+
+	sans := []SANEntry{
+		{DomainName: "a.example.com", DCVMethod: DCVMethodHTTP},
+		{DomainName: "b.example.com", DCVMethod: DCVMethodDNS},
+		{DomainName: "c.example.com", DCVMethod: DCVMethodEmail, ApproverEmail: "[email protected]"},
+	}
+
+	_, err := client.SSL.ActivateWithContext(context.Background(), &SSLActivateArgs{
+		CertificateID:     123456,
+		CSR:               "csr-data",
+		AdminEmailAddress: "[email protected]",
+		DCVMethod:         DCVMethodHTTP,
+		SANs:              sans,
+	})
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
+
+	wantNames := []string{"a.example.com", "b.example.com", "c.example.com"}
+	wantMethods := []string{"HTTP_CSR_HASH", "CNAME_CSR_HASH", "[email protected]"}
+	for i := range sans {
+		assert.Equal(t, wantNames[i], sent.Get(fmt.Sprintf("SANDomainName[%d]", i)))
+		assert.Equal(t, wantMethods[i], sent.Get(fmt.Sprintf("SANDCVMethod[%d]", i)))
+	}
+}
+
+// TestSSLService_Activate_Validation table-tests that every missing required and
+// per-DCV-method field is reported at once, before any HTTP call.
+func TestSSLService_Activate_Validation(t *testing.T) {
+	t.Parallel()
+
+	client := setupClient(nil)
+	client.BaseURL = "http://127.0.0.1:0"
+
+	cases := []struct {
+		name string
+		args *SSLActivateArgs
+		want []string
+	}{
+		{
+			"all_required_missing",
+			&SSLActivateArgs{},
+			[]string{"CertificateID", "CSR", "AdminEmailAddress"},
+		},
+		{
+			"email_dcv_missing_approver",
+			&SSLActivateArgs{CertificateID: 1, CSR: "c", AdminEmailAddress: "[email protected]", DCVMethod: DCVMethodEmail},
+			[]string{"ApproverEmail"},
+		},
+		{
+			"san_missing_fields",
+			&SSLActivateArgs{
+				CertificateID: 1, CSR: "c", AdminEmailAddress: "[email protected]",
+				SANs: []SANEntry{{DCVMethod: DCVMethodEmail}},
+			},
+			[]string{"SANs[0].DomainName", "SANs[0].ApproverEmail"},
+		},
+		{
+			"san_missing_method",
+			&SSLActivateArgs{
+				CertificateID: 1, CSR: "c", AdminEmailAddress: "[email protected]",
+				SANs: []SANEntry{{DomainName: "x.com"}},
+			},
+			[]string{"SANs[0].DCVMethod"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := client.SSL.ActivateWithContext(context.Background(), tc.args)
+			var argErr *InvalidArgumentsError
+			if assert.True(t, errors.As(err, &argErr)) {
+				assert.Equal(t, tc.want, argErr.Fields)
+			}
+		})
+	}
+
+	t.Run("nil_args", func(t *testing.T) {
+		t.Parallel()
+		_, err := client.SSL.ActivateWithContext(context.Background(), nil)
+		var argErr *InvalidArgumentsError
+		assert.True(t, errors.As(err, &argErr))
+	})
+}
+
+func TestSSLService_Activate_APIError(t *testing.T) {
+	t.Parallel()
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(apiErrorXML(4011103, "Access denied")))
+	}))
+	defer mockServer.Close()
+
+	client := setupClient(nil)
+	client.BaseURL = mockServer.URL
+
+	_, err := client.SSL.ActivateWithContext(context.Background(), &SSLActivateArgs{
+		CertificateID: 1, CSR: "c", AdminEmailAddress: "[email protected]",
+	})
+	var apiErr *APIError
+	if assert.True(t, errors.As(err, &apiErr)) {
+		assert.Equal(t, 4011103, apiErr.Number)
+	}
+}

--- a/namecheap/ssl_create.go
+++ b/namecheap/ssl_create.go
@@ -1,0 +1,111 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// SSLCreateResponse is the raw envelope for namecheap.ssl.create.
+type SSLCreateResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *SSLCreateCommandResponse `xml:"CommandResponse"`
+}
+
+// SSLCreateCommandResponse wraps the create result.
+type SSLCreateCommandResponse struct {
+	SSLCreateResult *SSLCreateResult `xml:"SSLCreateResult"`
+}
+
+// SSLCreateResult is the outcome of a purchase. Fields follow the create response
+// table in docs/namecheap-api-v2.md (lines 804-812).
+type SSLCreateResult struct {
+	// IsSuccess reports whether the SSL order was successful.
+	IsSuccess *bool `xml:"IsSuccess,attr"`
+	// OrderID is the unique integer identifying the order.
+	OrderID *int `xml:"OrderID,attr"`
+	// TransactionID is the unique integer identifying the transaction.
+	TransactionID *int `xml:"TransactionID,attr"`
+	// ChargedAmount is the amount charged, kept as an exact decimal string (see Amount).
+	ChargedAmount *Amount `xml:"ChargedAmount,attr"`
+	// CertificateID is the unique integer identifying the SSL certificate.
+	CertificateID *int `xml:"CertificateID,attr"`
+	// Created is the date the certificate was created (MM/DD/YYYY).
+	Created *DateTime `xml:"Created,attr"`
+	// SSLType is the type of SSL certificate created.
+	SSLType *string `xml:"SSLType,attr"`
+}
+
+// SSLCreateArgs are the arguments for CreateWithContext. Field names and required
+// status follow the create request table in docs/namecheap-api-v2.md
+// (lines 795-800).
+type SSLCreateArgs struct {
+	// Years is the certificate term; allowed values 1..5. Required.
+	Years int
+	// Type is the SSL product name. Required.
+	Type string
+	// SANStoADD is the number of add-on domains for a multi-domain certificate.
+	// Optional; a value <= 0 is omitted.
+	SANStoADD int
+	// PromotionCode is an optional promotional code.
+	PromotionCode string
+}
+
+// CreateWithContext purchases a new SSL certificate.
+//
+// It is a charge-bearing, non-idempotent call: on an ambiguous transport or
+// server-side failure the SDK does NOT retry (a resend could double-charge), so
+// the caller must reconcile such failures via GetListWithContext / the account
+// order history. Only Namecheap's pre-execution HTTP 405 rate-limit signal is
+// retried. This mirrors the money rule established for domains.create.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/ssl/create/
+func (ss *SSLService) CreateWithContext(ctx context.Context, args *SSLCreateArgs) (*SSLCreateCommandResponse, error) {
+	if args == nil {
+		return nil, &InvalidArgumentsError{Fields: []string{"args"}, Reason: "args must not be nil"}
+	}
+	if err := args.validate(); err != nil {
+		return nil, err
+	}
+
+	var response SSLCreateResponse
+	// idempotent=false: never retry a charge-bearing call on an ambiguous error.
+	_, err := ss.client.doXML(ctx, args.params(), &response, false)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}
+
+// validate reports every missing required field at once and range-checks Years.
+func (a *SSLCreateArgs) validate() error {
+	missing := make([]string, 0, 2)
+	if a.Years < 1 || a.Years > 5 {
+		missing = append(missing, "Years")
+	}
+	if a.Type == "" {
+		missing = append(missing, "Type")
+	}
+	if len(missing) > 0 {
+		return &InvalidArgumentsError{Fields: missing}
+	}
+	return nil
+}
+
+// params flattens the validated args into the request map.
+func (a *SSLCreateArgs) params() map[string]string {
+	params := map[string]string{
+		"Command": "namecheap.ssl.create",
+		"Years":   strconv.Itoa(a.Years),
+		"Type":    a.Type,
+	}
+	if a.SANStoADD > 0 {
+		params["SANStoADD"] = strconv.Itoa(a.SANStoADD)
+	}
+	setIfNotEmpty(params, "PromotionCode", a.PromotionCode)
+	return params
+}

--- a/namecheap/ssl_create_test.go
+++ b/namecheap/ssl_create_test.go
@@ -1,0 +1,120 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const sslCreateOKResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.ssl.create">
+		<SSLCreateResult IsSuccess="true" OrderID="11223344" TransactionID="55667788" ChargedAmount="9.9800" CertificateID="123456" Created="09/22/2020" SSLType="PositiveSSL" />
+	</CommandResponse>
+</ApiResponse>`
+
+func TestSSLService_Create(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = w.Write([]byte(sslCreateOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.SSL.CreateWithContext(context.Background(), &SSLCreateArgs{
+			Years:         2,
+			Type:          "PositiveSSL",
+			SANStoADD:     3,
+			PromotionCode: "PROMO",
+		})
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.ssl.create", sentBody.Get("Command"))
+		assert.Equal(t, "2", sentBody.Get("Years"))
+		assert.Equal(t, "PositiveSSL", sentBody.Get("Type"))
+		assert.Equal(t, "3", sentBody.Get("SANStoADD"))
+		assert.Equal(t, "PROMO", sentBody.Get("PromotionCode"))
+
+		result := resp.SSLCreateResult
+		assert.True(t, *result.IsSuccess)
+		assert.Equal(t, 11223344, *result.OrderID)
+		assert.Equal(t, Amount("9.9800"), *result.ChargedAmount)
+		assert.Equal(t, 123456, *result.CertificateID)
+	})
+
+	t.Run("validation_no_http", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "http://127.0.0.1:0"
+
+		_, err := client.SSL.CreateWithContext(context.Background(), &SSLCreateArgs{Years: 9})
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Equal(t, []string{"Years", "Type"}, argErr.Fields)
+		}
+
+		_, err = client.SSL.CreateWithContext(context.Background(), nil)
+		assert.True(t, errors.As(err, &argErr))
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(apiErrorXML(2011170, "Promotion code invalid")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.SSL.CreateWithContext(context.Background(), &SSLCreateArgs{Years: 1, Type: "PositiveSSL"})
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2011170, apiErr.Number)
+		}
+	})
+
+	// TestSSLService_Create non-idempotency: a retryable server error must NOT be
+	// re-fired for the charge-bearing create call (exactly one attempt), proving
+	// the doXML(..., false) classification.
+	t.Run("non_idempotent_no_retry", func(t *testing.T) {
+		t.Parallel()
+		var calls int32
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&calls, 1)
+			_, _ = w.Write([]byte(apiErrorXML(5050900, "Server exception")))
+		}))
+		defer mockServer.Close()
+
+		client := newResilienceClient(mockServer.URL, func(o *ClientOptions) {
+			o.RateLimit = &RateLimitOptions{Disabled: true}
+			o.Retry = &RetryOptions{MaxAttempts: 4, BaseDelay: time.Millisecond, MaxDelay: 2 * time.Millisecond}
+		})
+
+		_, err := client.SSL.CreateWithContext(context.Background(), &SSLCreateArgs{Years: 1, Type: "PositiveSSL"})
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 5050900, apiErr.Number)
+		}
+		assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "a charge-bearing create must not be retried on an ambiguous server error")
+	})
+}

--- a/namecheap/ssl_edit_dcv_method.go
+++ b/namecheap/ssl_edit_dcv_method.go
@@ -1,0 +1,124 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// SSLEditDCVMethodResponse is the raw envelope for namecheap.ssl.editDCVMethod.
+type SSLEditDCVMethodResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *SSLEditDCVMethodCommandResponse `xml:"CommandResponse"`
+}
+
+// SSLEditDCVMethodCommandResponse wraps the editDCVMethod result.
+type SSLEditDCVMethodCommandResponse struct {
+	SSLEditDCVMethodResult *SSLEditDCVMethodResult `xml:"SSLEditDCVMethodResult"`
+}
+
+// SSLEditDCVMethodResult is the outcome of a DCV-method edit. Fields follow the
+// response table in docs/namecheap-api-v2.md (lines 1093-1099).
+type SSLEditDCVMethodResult struct {
+	// ID is the unique integer identifying the certificate.
+	ID *int `xml:"ID,attr"`
+	// IsSuccess reports whether the certificate DCV was updated.
+	IsSuccess *bool `xml:"IsSuccess,attr"`
+	// HTTPDCValidation carries the HTTP DCV file details when HTTP validation is set.
+	HTTPDCValidation *SSLHTTPDCValidation `xml:"HttpDCValidation"`
+}
+
+// SSLHTTPDCValidation carries the HTTP domain-control-validation file details.
+type SSLHTTPDCValidation struct {
+	// ValueAvailable reports whether an HTTP_CSR_HASH was set for at least one domain.
+	ValueAvailable *bool `xml:"ValueAvailable,attr"`
+	// FileName is the file name for the HTTP DCV text file.
+	FileName *string `xml:"FileName"`
+	// FileContent is the content for the HTTP DCV text file.
+	FileContent *string `xml:"FileContent"`
+}
+
+// SSLEditDCVMethodArgs are the arguments for EditDCVMethodWithContext. Field names
+// follow the editDCVMethod request table in docs/namecheap-api-v2.md
+// (lines 1084-1089).
+//
+// Use either the single-domain form (set DCVMethod, plus ApproverEmail for email
+// validation) or the multi-domain form (set SANs, serialized to the comma-
+// separated DNSNames / DCVMethods lists). At least one of the two must be present.
+type SSLEditDCVMethodArgs struct {
+	// CertificateID is the certificate to update. Required.
+	CertificateID int
+	// DCVMethod is the single-domain DCV method (doc line 1087). Set this OR SANs.
+	DCVMethod DCVMethod
+	// ApproverEmail is the approver email for single-domain email validation;
+	// required only when DCVMethod is DCVMethodEmail.
+	ApproverEmail string
+	// SANs is the multi-domain form: each domain plus its DCV method, serialized as
+	// the parallel DNSNames / DCVMethods comma lists (doc lines 1088-1089).
+	SANs []SANEntry
+}
+
+// EditDCVMethodWithContext sets a new domain-control-validation method for a
+// certificate (or retries validation). It is idempotent and retries on transient
+// failures. Arguments are validated client-side first, listing every missing field
+// at once.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/ssl/edit-dcv-method/
+func (ss *SSLService) EditDCVMethodWithContext(ctx context.Context, args *SSLEditDCVMethodArgs) (*SSLEditDCVMethodCommandResponse, error) {
+	if args == nil {
+		return nil, &InvalidArgumentsError{Fields: []string{"args"}, Reason: "args must not be nil"}
+	}
+	if err := args.validate(); err != nil {
+		return nil, err
+	}
+
+	var response SSLEditDCVMethodResponse
+	_, err := ss.client.DoXMLWithContext(ctx, args.params(), &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}
+
+// validate reports every missing/invalid field at once. It requires a positive
+// CertificateID and exactly one populated form (single DCVMethod or SANs), then
+// applies per-method requirements.
+func (a *SSLEditDCVMethodArgs) validate() error {
+	missing := make([]string, 0, 2)
+	if a.CertificateID < 1 {
+		missing = append(missing, "CertificateID")
+	}
+	switch {
+	case len(a.SANs) > 0:
+		missing = append(missing, missingSANFields(a.SANs)...)
+	case a.DCVMethod != "":
+		missing = append(missing, dcvMissingFields("", a.DCVMethod, a.ApproverEmail)...)
+	default:
+		missing = append(missing, "DCVMethod")
+	}
+	if len(missing) > 0 {
+		return &InvalidArgumentsError{Fields: missing}
+	}
+	return nil
+}
+
+// params flattens the validated args into the request map, choosing the single-
+// domain or multi-domain serialization.
+func (a *SSLEditDCVMethodArgs) params() map[string]string {
+	params := map[string]string{
+		"Command":       "namecheap.ssl.editDCVMethod",
+		"CertificateID": strconv.Itoa(a.CertificateID),
+	}
+	if len(a.SANs) > 0 {
+		names, methods := sanCommaLists(a.SANs)
+		params["DNSNames"] = names
+		params["DCVMethods"] = methods
+	} else {
+		params["DCVMethod"] = dcvWireValue(a.DCVMethod, a.ApproverEmail)
+	}
+	return params
+}

--- a/namecheap/ssl_edit_dcv_method_test.go
+++ b/namecheap/ssl_edit_dcv_method_test.go
@@ -1,0 +1,146 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const sslEditDCVMethodOKResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.ssl.editDCVMethod">
+		<SSLEditDCVMethodResult ID="123456" IsSuccess="true">
+			<HttpDCValidation ValueAvailable="true">
+				<FileName>ABCDEF.txt</FileName>
+				<FileContent>hash-content</FileContent>
+			</HttpDCValidation>
+		</SSLEditDCVMethodResult>
+	</CommandResponse>
+</ApiResponse>`
+
+func TestSSLService_EditDCVMethod(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single_domain_success", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = w.Write([]byte(sslEditDCVMethodOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.SSL.EditDCVMethodWithContext(context.Background(), &SSLEditDCVMethodArgs{
+			CertificateID: 123456,
+			DCVMethod:     DCVMethodDNS,
+		})
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.ssl.editDCVMethod", sentBody.Get("Command"))
+		assert.Equal(t, "123456", sentBody.Get("CertificateID"))
+		assert.Equal(t, "CNAME_CSR_HASH", sentBody.Get("DCVMethod"))
+		assert.Empty(t, sentBody.Get("DNSNames"))
+
+		result := resp.SSLEditDCVMethodResult
+		assert.Equal(t, 123456, *result.ID)
+		assert.True(t, *result.IsSuccess)
+		assert.True(t, *result.HTTPDCValidation.ValueAvailable)
+		assert.Equal(t, "ABCDEF.txt", *result.HTTPDCValidation.FileName)
+	})
+
+	t.Run("multi_domain_comma_lists", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = w.Write([]byte(sslEditDCVMethodOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.SSL.EditDCVMethodWithContext(context.Background(), &SSLEditDCVMethodArgs{
+			CertificateID: 123456,
+			SANs: []SANEntry{
+				{DomainName: "a.com", DCVMethod: DCVMethodHTTP},
+				{DomainName: "b.com", DCVMethod: DCVMethodDNS},
+				{DomainName: "c.com", DCVMethod: DCVMethodEmail, ApproverEmail: "[email protected]"},
+			},
+		})
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "a.com,b.com,c.com", sentBody.Get("DNSNames"))
+		assert.Equal(t, "HTTP_CSR_HASH,CNAME_CSR_HASH,[email protected]", sentBody.Get("DCVMethods"))
+		assert.Empty(t, sentBody.Get("DCVMethod"))
+	})
+
+	t.Run("validation_no_http", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "http://127.0.0.1:0"
+
+		cases := []struct {
+			name string
+			args *SSLEditDCVMethodArgs
+			want []string
+		}{
+			{"missing_cert_and_method", &SSLEditDCVMethodArgs{}, []string{"CertificateID", "DCVMethod"}},
+			{"missing_method_only", &SSLEditDCVMethodArgs{CertificateID: 1}, []string{"DCVMethod"}},
+			{"email_single_missing_approver", &SSLEditDCVMethodArgs{CertificateID: 1, DCVMethod: DCVMethodEmail}, []string{"ApproverEmail"}},
+			{"san_email_missing_approver", &SSLEditDCVMethodArgs{CertificateID: 1, SANs: []SANEntry{{DomainName: "x.com", DCVMethod: DCVMethodEmail}}}, []string{"SANs[0].ApproverEmail"}},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				_, err := client.SSL.EditDCVMethodWithContext(context.Background(), tc.args)
+				var argErr *InvalidArgumentsError
+				if assert.True(t, errors.As(err, &argErr)) {
+					assert.Equal(t, tc.want, argErr.Fields)
+				}
+			})
+		}
+	})
+
+	t.Run("nil_args", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "http://127.0.0.1:0"
+		_, err := client.SSL.EditDCVMethodWithContext(context.Background(), nil)
+		var argErr *InvalidArgumentsError
+		assert.True(t, errors.As(err, &argErr))
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(apiErrorXML(2030166, "Domain invalid")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.SSL.EditDCVMethodWithContext(context.Background(), &SSLEditDCVMethodArgs{CertificateID: 1, DCVMethod: DCVMethodHTTP})
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2030166, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/ssl_get_approver_email_list.go
+++ b/namecheap/ssl_get_approver_email_list.go
@@ -1,0 +1,61 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+)
+
+// SSLGetApproverEmailListResponse is the raw envelope for
+// namecheap.ssl.getApproverEmailList.
+type SSLGetApproverEmailListResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *SSLGetApproverEmailListCommandResponse `xml:"CommandResponse"`
+}
+
+// SSLGetApproverEmailListCommandResponse wraps the getApproverEmailList result.
+// Fields follow the response table in docs/namecheap-api-v2.md (lines 887-891).
+type SSLGetApproverEmailListCommandResponse struct {
+	// DomainEmails are the domain WHOIS email addresses.
+	DomainEmails []string `xml:"GetApproverEmailListResult>Domainemails>email"`
+	// GenericEmails are the generic email addresses for the domain.
+	GenericEmails []string `xml:"GetApproverEmailListResult>Genericemails>email"`
+	// ManualEmails are additional approver emails from the provider.
+	ManualEmails []string `xml:"GetApproverEmailListResult>Manualemails>email"`
+}
+
+// GetApproverEmailListWithContext returns the approver email list for the given
+// domain and certificate type. It is an idempotent read and retries on transient
+// failures.
+//
+// Both domainName and certificateType are required (doc lines 882-883).
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/ssl/get-approver-email-list/
+func (ss *SSLService) GetApproverEmailListWithContext(ctx context.Context, domainName, certificateType string) (*SSLGetApproverEmailListCommandResponse, error) {
+	missing := make([]string, 0, 2)
+	if domainName == "" {
+		missing = append(missing, "DomainName")
+	}
+	if certificateType == "" {
+		missing = append(missing, "CertificateType")
+	}
+	if len(missing) > 0 {
+		return nil, &InvalidArgumentsError{Fields: missing}
+	}
+
+	params := map[string]string{
+		"Command":         "namecheap.ssl.getApproverEmailList",
+		"DomainName":      domainName,
+		"CertificateType": certificateType,
+	}
+
+	var response SSLGetApproverEmailListResponse
+	_, err := ss.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/ssl_get_approver_email_list_test.go
+++ b/namecheap/ssl_get_approver_email_list_test.go
@@ -1,0 +1,92 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const sslGetApproverEmailListOKResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.ssl.getApproverEmailList">
+		<GetApproverEmailListResult>
+			<Domainemails>
+				<email>[email protected]</email>
+			</Domainemails>
+			<Genericemails>
+				<email>[email protected]</email>
+				<email>[email protected]</email>
+			</Genericemails>
+			<Manualemails>
+				<email>[email protected]</email>
+			</Manualemails>
+		</GetApproverEmailListResult>
+	</CommandResponse>
+</ApiResponse>`
+
+func TestSSLService_GetApproverEmailList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = w.Write([]byte(sslGetApproverEmailListOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.SSL.GetApproverEmailListWithContext(context.Background(), "example.com", "PositiveSSL")
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.ssl.getApproverEmailList", sentBody.Get("Command"))
+		assert.Equal(t, "example.com", sentBody.Get("DomainName"))
+		assert.Equal(t, "PositiveSSL", sentBody.Get("CertificateType"))
+
+		assert.Equal(t, []string{"[email protected]"}, resp.DomainEmails)
+		assert.Equal(t, []string{"[email protected]", "[email protected]"}, resp.GenericEmails)
+		assert.Equal(t, []string{"[email protected]"}, resp.ManualEmails)
+	})
+
+	t.Run("missing_fields_no_http", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "http://127.0.0.1:0"
+
+		_, err := client.SSL.GetApproverEmailListWithContext(context.Background(), "", "")
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Equal(t, []string{"DomainName", "CertificateType"}, argErr.Fields)
+		}
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(apiErrorXML(2019166, "Domain not found")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.SSL.GetApproverEmailListWithContext(context.Background(), "example.com", "PositiveSSL")
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2019166, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/ssl_get_info.go
+++ b/namecheap/ssl_get_info.go
@@ -1,0 +1,107 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+	"time"
+)
+
+// SSLGetInfoResponse is the raw envelope for namecheap.ssl.getInfo.
+type SSLGetInfoResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *SSLGetInfoCommandResponse `xml:"CommandResponse"`
+}
+
+// SSLGetInfoCommandResponse wraps the getInfo result.
+type SSLGetInfoCommandResponse struct {
+	SSLGetInfoResult *SSLGetInfoResult `xml:"SSLGetInfoResult"`
+}
+
+// SSLGetInfoResult is the detail of a single certificate. The doc's getInfo
+// section (docs/namecheap-api-v2.md lines 934-957) enumerates the certificate
+// Status vocabulary but not the full response field set; the fields below follow
+// the documented status vocabulary plus the identity/expiry attributes the
+// certificate carries. The raw Status string is exposed verbatim (classify it
+// with CertStatus / ClassifyStatus).
+type SSLGetInfoResult struct {
+	// CertificateID is the unique integer identifying the certificate.
+	CertificateID *int `xml:"CertificateID,attr"`
+	// Status is the raw certificate status string, one of the documented values
+	// (doc lines 948-957). Classify it with the CertStatus helper.
+	Status string `xml:"Status,attr"`
+	// Type is the certificate product type.
+	Type *string `xml:"Type,attr"`
+	// CommonName is the primary host the certificate is issued for.
+	CommonName *string `xml:"CommonName,attr"`
+	// Provider is the issuing certificate authority / provider name.
+	Provider *string `xml:"Provider,attr"`
+	// IssuedOn is the date the certificate was issued (MM/DD/YYYY), when present.
+	IssuedOn *DateTime `xml:"IssuedOn,attr"`
+	// Expires is the date the certificate expires (MM/DD/YYYY), when present. It is
+	// the input to IsExpiringSoon.
+	Expires *DateTime `xml:"Expires,attr"`
+}
+
+// CertStatus classifies the result's raw Status string into a typed CertStatus
+// (see ClassifyStatus). It returns CertStatusUnknown for a nil result or an empty
+// / unrecognised status.
+func (r *SSLGetInfoResult) CertStatus() CertStatus {
+	if r == nil {
+		return CertStatusUnknown
+	}
+	return ClassifyStatus(r.Status)
+}
+
+// IsIssued reports whether the certificate is issued and usable, i.e. its status
+// classifies to CertStatusActive (the documented "Active" state, doc line 952).
+// The documented "Purchased" state means activated-but-awaiting-issuance and is
+// deliberately NOT reported as issued.
+func (r *SSLGetInfoResult) IsIssued() bool {
+	return r.CertStatus() == CertStatusActive
+}
+
+// IsExpiringSoon reports whether the certificate expires within the given lead
+// time from now. The boundary is inclusive (an expiry exactly at now+within
+// counts), an already-expired certificate returns true, and a missing/zero expiry
+// returns false. All expiry math lives in the tested expiresWithin helper and is
+// timezone-safe. A nil result returns false.
+func (r *SSLGetInfoResult) IsExpiringSoon(within time.Duration) bool {
+	if r == nil || r.Expires == nil {
+		return false
+	}
+	return expiresWithin(r.Expires.Time, within, time.Now())
+}
+
+// GetInfoWithContext retrieves detailed information about the certificate
+// identified by certificateID. It is an idempotent read and retries on transient
+// failures.
+//
+// returnCertificate, when non-empty, is sent as the Returncertificate flag and
+// returnType (e.g. "Individual" or "PKCS7") as Returntype (doc lines 945-946);
+// pass "" for both to omit them.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/ssl/get-info/
+func (ss *SSLService) GetInfoWithContext(ctx context.Context, certificateID int, returnCertificate, returnType string) (*SSLGetInfoCommandResponse, error) {
+	if certificateID < 1 {
+		return nil, &InvalidArgumentsError{Fields: []string{"CertificateID"}, Reason: "CertificateID must be a positive integer"}
+	}
+
+	params := map[string]string{
+		"Command":       "namecheap.ssl.getInfo",
+		"CertificateID": strconv.Itoa(certificateID),
+	}
+	setIfNotEmpty(params, "Returncertificate", returnCertificate)
+	setIfNotEmpty(params, "Returntype", returnType)
+
+	var response SSLGetInfoResponse
+	_, err := ss.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/ssl_get_info_test.go
+++ b/namecheap/ssl_get_info_test.go
@@ -1,0 +1,105 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func sslGetInfoOKResponse(status, expires string) string {
+	return `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.ssl.getInfo">
+		<SSLGetInfoResult CertificateID="123456" Status="` + status + `" Type="PositiveSSL" CommonName="example.com" Provider="Comodo" IssuedOn="09/22/2020" Expires="` + expires + `" />
+	</CommandResponse>
+</ApiResponse>`
+}
+
+func TestSSLService_GetInfo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse_and_issued", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			// Expiry far in the future so IsExpiringSoon(30d) is false.
+			_, _ = w.Write([]byte(sslGetInfoOKResponse("Active", "09/22/2099")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.SSL.GetInfoWithContext(context.Background(), 123456, "true", "Individual")
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.ssl.getInfo", sentBody.Get("Command"))
+		assert.Equal(t, "123456", sentBody.Get("CertificateID"))
+		assert.Equal(t, "true", sentBody.Get("Returncertificate"))
+		assert.Equal(t, "Individual", sentBody.Get("Returntype"))
+
+		result := resp.SSLGetInfoResult
+		assert.Equal(t, 123456, *result.CertificateID)
+		assert.Equal(t, "example.com", *result.CommonName)
+		assert.Equal(t, CertStatusActive, result.CertStatus())
+		assert.True(t, result.IsIssued())
+		assert.False(t, result.IsExpiringSoon(30*24*time.Hour))
+	})
+
+	t.Run("expiring_soon_detected", func(t *testing.T) {
+		t.Parallel()
+		soon := time.Now().Add(5 * 24 * time.Hour).Format("01/02/2006")
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(sslGetInfoOKResponse("Active", soon)))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.SSL.GetInfoWithContext(context.Background(), 123456, "", "")
+		assert.NoError(t, err)
+		assert.True(t, resp.SSLGetInfoResult.IsExpiringSoon(30*24*time.Hour))
+	})
+
+	t.Run("invalid_id_no_http", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "http://127.0.0.1:0"
+
+		_, err := client.SSL.GetInfoWithContext(context.Background(), 0, "", "")
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "CertificateID")
+		}
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(apiErrorXML(2033409, "Order not found")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.SSL.GetInfoWithContext(context.Background(), 999, "", "")
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2033409, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/ssl_get_list.go
+++ b/namecheap/ssl_get_list.go
@@ -1,0 +1,150 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"strconv"
+)
+
+// sslAllowedListTypes is the documented ListType filter vocabulary for
+// namecheap.ssl.getList (docs/namecheap-api-v2.md line 826).
+var sslAllowedListTypes = []string{
+	"ALL", "Processing", "EmailSent", "TechnicalProblem", "InProgress",
+	"Completed", "Deactivated", "Active", "Cancelled", "NewPurchase", "NewRenewal",
+}
+
+// sslAllowedSortBy is the documented SortBy vocabulary for
+// namecheap.ssl.getList (docs/namecheap-api-v2.md line 830).
+var sslAllowedSortBy = []string{
+	"PURCHASEDATE", "PURCHASEDATE_DESC", "SSLTYPE", "SSLTYPE_DESC",
+	"EXPIREDATETIME", "EXPIREDATETIME_DESC", "Host_Name", "Host_Name_DESC",
+}
+
+// SSLGetListResponse is the raw envelope for namecheap.ssl.getList.
+type SSLGetListResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *SSLGetListCommandResponse `xml:"CommandResponse"`
+}
+
+// SSLGetListCommandResponse wraps the getList result and its paging block.
+type SSLGetListCommandResponse struct {
+	// SSLCertificates is the page of certificates returned.
+	SSLCertificates *[]SSLListCertificate `xml:"SSLListResult>SSL"`
+	// Paging is the standard pagination block.
+	Paging *SSLPaging `xml:"Paging"`
+}
+
+// SSLPaging is the standard Namecheap pagination block for a paged SSL list.
+type SSLPaging struct {
+	TotalItems  *int `xml:"TotalItems"`
+	CurrentPage *int `xml:"CurrentPage"`
+	PageSize    *int `xml:"PageSize"`
+}
+
+// SSLListCertificate is one certificate row in a getList page. Fields follow the
+// getList response table in docs/namecheap-api-v2.md (lines 836-840); Status is
+// additionally exposed so the documented ListType status filter can be correlated
+// with each row (see the CertStatus vocabulary, doc lines 948-957).
+type SSLListCertificate struct {
+	// CertificateID is the unique integer identifying the certificate.
+	CertificateID *int `xml:"CertificateID,attr"`
+	// HostName is the common name the certificate is used for.
+	HostName *string `xml:"HostName,attr"`
+	// SSLType is the certificate product type.
+	SSLType *string `xml:"SSLType,attr"`
+	// PurchaseDate is the date the certificate was purchased (MM/DD/YYYY).
+	PurchaseDate *DateTime `xml:"PurchaseDate,attr"`
+	// ExpireDate is the date the certificate expires (MM/DD/YYYY).
+	ExpireDate *DateTime `xml:"ExpireDate,attr"`
+	// Status is the raw certificate status string; classify it with ClassifyStatus.
+	Status *string `xml:"Status,attr"`
+}
+
+// SSLGetListArgs are the optional filters for GetListWithContext. Field names and
+// allowed values follow the getList request table in docs/namecheap-api-v2.md
+// (lines 824-830). A nil field is omitted and the API default applies.
+//
+// The doc has no dedicated expiry-window filter parameter; to inventory expiring
+// certificates, sort by expiry (SortBy = "EXPIREDATETIME") and filter client-side
+// on ExpireDate, or select a status via ListType.
+type SSLGetListArgs struct {
+	// ListType filters by certificate status; one of sslAllowedListTypes. Default: All.
+	ListType *string
+	// SearchTerm is a keyword to look for. Optional.
+	SearchTerm *string
+	// Page is the 1-based page to return. Default: 1.
+	Page *int
+	// PageSize is the number of certificates per page; 10..100. Default: 20.
+	PageSize *int
+	// SortBy orders the results; one of sslAllowedSortBy. Optional.
+	SortBy *string
+}
+
+// GetListWithContext returns a paged, filtered list of the account's SSL
+// certificates. It is an idempotent read and retries on transient failures.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/ssl/get-list/
+func (ss *SSLService) GetListWithContext(ctx context.Context, args *SSLGetListArgs) (*SSLGetListCommandResponse, error) {
+	params := map[string]string{"Command": "namecheap.ssl.getList"}
+	if err := args.apply(params); err != nil {
+		return nil, err
+	}
+
+	var response SSLGetListResponse
+	_, err := ss.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}
+
+// apply validates the filters and writes them into params. A nil receiver leaves
+// params untouched (all defaults).
+func (a *SSLGetListArgs) apply(params map[string]string) error {
+	if a == nil {
+		return nil
+	}
+	if a.ListType != nil {
+		if !oneOf(*a.ListType, sslAllowedListTypes) {
+			return &InvalidArgumentsError{Fields: []string{"ListType"}, Reason: fmt.Sprintf("invalid ListType value: %s", *a.ListType)}
+		}
+		params["ListType"] = *a.ListType
+	}
+	if a.SortBy != nil {
+		if !oneOf(*a.SortBy, sslAllowedSortBy) {
+			return &InvalidArgumentsError{Fields: []string{"SortBy"}, Reason: fmt.Sprintf("invalid SortBy value: %s", *a.SortBy)}
+		}
+		params["SortBy"] = *a.SortBy
+	}
+	if a.Page != nil {
+		if *a.Page < 1 {
+			return &InvalidArgumentsError{Fields: []string{"Page"}, Reason: "Page must be a positive integer"}
+		}
+		params["Page"] = strconv.Itoa(*a.Page)
+	}
+	if a.PageSize != nil {
+		if *a.PageSize < 10 || *a.PageSize > 100 {
+			return &InvalidArgumentsError{Fields: []string{"PageSize"}, Reason: "PageSize must be between 10 and 100"}
+		}
+		params["PageSize"] = strconv.Itoa(*a.PageSize)
+	}
+	if a.SearchTerm != nil {
+		params["SearchTerm"] = *a.SearchTerm
+	}
+	return nil
+}
+
+// oneOf reports whether value is present in allowed.
+func oneOf(value string, allowed []string) bool {
+	for _, v := range allowed {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}

--- a/namecheap/ssl_get_list_test.go
+++ b/namecheap/ssl_get_list_test.go
@@ -1,0 +1,127 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const sslGetListOKResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.ssl.getList">
+		<SSLListResult>
+			<SSL CertificateID="123456" HostName="example.com" SSLType="PositiveSSL" PurchaseDate="09/22/2020" ExpireDate="09/22/2021" Status="Active" />
+			<SSL CertificateID="123457" HostName="foo.example" SSLType="EV SSL" PurchaseDate="01/01/2021" ExpireDate="01/01/2022" Status="Purchased" />
+		</SSLListResult>
+		<Paging>
+			<TotalItems>2</TotalItems>
+			<CurrentPage>1</CurrentPage>
+			<PageSize>20</PageSize>
+		</Paging>
+	</CommandResponse>
+</ApiResponse>`
+
+func TestSSLService_GetList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse_and_filters", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = w.Write([]byte(sslGetListOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.SSL.GetListWithContext(context.Background(), &SSLGetListArgs{
+			ListType:   String("Active"),
+			SearchTerm: String("example"),
+			Page:       Int(2),
+			PageSize:   Int(50),
+			SortBy:     String("EXPIREDATETIME"),
+		})
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.ssl.getList", sentBody.Get("Command"))
+		assert.Equal(t, "Active", sentBody.Get("ListType"))
+		assert.Equal(t, "example", sentBody.Get("SearchTerm"))
+		assert.Equal(t, "2", sentBody.Get("Page"))
+		assert.Equal(t, "50", sentBody.Get("PageSize"))
+		assert.Equal(t, "EXPIREDATETIME", sentBody.Get("SortBy"))
+
+		certs := *resp.SSLCertificates
+		assert.Len(t, certs, 2)
+		assert.Equal(t, 123456, *certs[0].CertificateID)
+		assert.Equal(t, "example.com", *certs[0].HostName)
+		assert.Equal(t, "PositiveSSL", *certs[0].SSLType)
+		assert.Equal(t, "Active", *certs[0].Status)
+		assert.Equal(t, 2, *resp.Paging.TotalItems)
+	})
+
+	t.Run("nil_args_ok", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = w.Write([]byte(sslGetListOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.SSL.GetListWithContext(context.Background(), nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "namecheap.ssl.getList", sentBody.Get("Command"))
+		assert.Empty(t, sentBody.Get("ListType"))
+	})
+
+	t.Run("invalid_filters_no_http", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "http://127.0.0.1:0"
+
+		for _, args := range []*SSLGetListArgs{
+			{ListType: String("Bogus")},
+			{SortBy: String("Bogus")},
+			{Page: Int(0)},
+			{PageSize: Int(5)},
+			{PageSize: Int(500)},
+		} {
+			_, err := client.SSL.GetListWithContext(context.Background(), args)
+			var argErr *InvalidArgumentsError
+			assert.True(t, errors.As(err, &argErr))
+		}
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(apiErrorXML(2011170, "Promotion code invalid")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.SSL.GetListWithContext(context.Background(), nil)
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2011170, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/ssl_parse_csr.go
+++ b/namecheap/ssl_parse_csr.go
@@ -1,0 +1,74 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+)
+
+// SSLParseCSRResponse is the raw envelope for namecheap.ssl.parseCSR.
+type SSLParseCSRResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *SSLParseCSRCommandResponse `xml:"CommandResponse"`
+}
+
+// SSLParseCSRCommandResponse wraps the parseCSR result.
+type SSLParseCSRCommandResponse struct {
+	SSLParseCSRResult *SSLParseCSRResult `xml:"SSLParseCSRResult"`
+}
+
+// SSLParseCSRResult holds the fields decoded from a CSR. They follow the parseCSR
+// response table in docs/namecheap-api-v2.md (lines 861-868).
+//
+// Documented gap. The doc names each field's meaning ("Common name", "Domain
+// name", ...) but not the exact XML element names of the response; the tags below
+// use the conventional CSR distinguished-name element names nested under
+// <CSRDetails>. If a live response uses different element names, only the mapping
+// here needs adjusting — the field set matches the doc.
+type SSLParseCSRResult struct {
+	// CommonName is the hostname the SSL is applied to.
+	CommonName *string `xml:"CSRDetails>CommonName"`
+	// DomainName is the domain the SSL is applied to.
+	DomainName *string `xml:"CSRDetails>DomainName"`
+	// Country is the country of the applicant.
+	Country *string `xml:"CSRDetails>Country"`
+	// OrganisationUnit is the organisation unit of the applicant.
+	OrganisationUnit *string `xml:"CSRDetails>OrganisationUnit"`
+	// Organisation is the organisation of the applicant.
+	Organisation *string `xml:"CSRDetails>Organisation"`
+	// State is the state / province information.
+	State *string `xml:"CSRDetails>State"`
+	// Locality is the locality information.
+	Locality *string `xml:"CSRDetails>Locality"`
+	// Email is the email address of the applicant.
+	Email *string `xml:"CSRDetails>Email"`
+}
+
+// ParseCSRWithContext parses a Certificate Signing Request and returns its
+// decoded fields. It only transports the CSR string; no key material is read or
+// stored. It is an idempotent read and retries on transient failures.
+//
+// certificateType is optional (doc line 855); pass "" to omit it.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/ssl/parse-csr/
+func (ss *SSLService) ParseCSRWithContext(ctx context.Context, csr, certificateType string) (*SSLParseCSRCommandResponse, error) {
+	if csr == "" {
+		return nil, &InvalidArgumentsError{Fields: []string{"csr"}}
+	}
+
+	params := map[string]string{
+		"Command": "namecheap.ssl.parseCSR",
+		"csr":     csr,
+	}
+	setIfNotEmpty(params, "CertificateType", certificateType)
+
+	var response SSLParseCSRResponse
+	_, err := ss.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/ssl_parse_csr_test.go
+++ b/namecheap/ssl_parse_csr_test.go
@@ -1,0 +1,94 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const sslParseCSROKResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.ssl.parseCSR">
+		<SSLParseCSRResult>
+			<CSRDetails>
+				<CommonName>example.com</CommonName>
+				<DomainName>example.com</DomainName>
+				<Country>US</Country>
+				<OrganisationUnit>IT</OrganisationUnit>
+				<Organisation>Example Inc</Organisation>
+				<State>CA</State>
+				<Locality>San Francisco</Locality>
+				<Email>[email protected]</Email>
+			</CSRDetails>
+		</SSLParseCSRResult>
+	</CommandResponse>
+</ApiResponse>`
+
+func TestSSLService_ParseCSR(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = w.Write([]byte(sslParseCSROKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.SSL.ParseCSRWithContext(context.Background(), "-----BEGIN CERTIFICATE REQUEST-----\nMIIC...\n-----END CERTIFICATE REQUEST-----", "PositiveSSL")
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.ssl.parseCSR", sentBody.Get("Command"))
+		assert.Contains(t, sentBody.Get("csr"), "BEGIN CERTIFICATE REQUEST")
+		assert.Equal(t, "PositiveSSL", sentBody.Get("CertificateType"))
+
+		result := resp.SSLParseCSRResult
+		assert.Equal(t, "example.com", *result.CommonName)
+		assert.Equal(t, "US", *result.Country)
+		assert.Equal(t, "Example Inc", *result.Organisation)
+		assert.Equal(t, "[email protected]", *result.Email)
+	})
+
+	t.Run("missing_csr_no_http", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "http://127.0.0.1:0"
+
+		_, err := client.SSL.ParseCSRWithContext(context.Background(), "", "")
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "csr")
+		}
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(apiErrorXML(2030166, "Domain invalid")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.SSL.ParseCSRWithContext(context.Background(), "csr-data", "")
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2030166, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/ssl_purchase_more_sans.go
+++ b/namecheap/ssl_purchase_more_sans.go
@@ -1,0 +1,103 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// SSLPurchaseMoreSansResponse is the raw envelope for
+// namecheap.ssl.purchasemoresans.
+type SSLPurchaseMoreSansResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *SSLPurchaseMoreSansCommandResponse `xml:"CommandResponse"`
+}
+
+// SSLPurchaseMoreSansCommandResponse wraps the purchasemoresans result.
+type SSLPurchaseMoreSansCommandResponse struct {
+	SSLPurchaseMoreSansResult *SSLPurchaseMoreSansResult `xml:"SSLPurchaseMoreSansResult"`
+}
+
+// SSLPurchaseMoreSansResult is the outcome of purchasing additional SANs. Fields
+// follow the purchasemoresans response table in docs/namecheap-api-v2.md
+// (lines 1044-1050).
+type SSLPurchaseMoreSansResult struct {
+	// IsSuccess reports whether more SANs were purchased.
+	IsSuccess *bool `xml:"IsSuccess,attr"`
+	// OrderID is the unique integer identifying the order.
+	OrderID *int `xml:"OrderID,attr"`
+	// TransactionID is the unique integer identifying the transaction.
+	TransactionID *int `xml:"TransactionID,attr"`
+	// ChargedAmount is the amount charged, kept as an exact decimal string (see Amount).
+	ChargedAmount *Amount `xml:"ChargedAmount,attr"`
+	// CertificateID is the unique integer identifying the SSL certificate.
+	CertificateID *int `xml:"CertificateID,attr"`
+	// SSLType is the type of SSL certificate.
+	SSLType *string `xml:"SSLType,attr"`
+	// SANSCount is the number of add-on domains after the purchase.
+	SANSCount *int `xml:"SANSCount,attr"`
+}
+
+// SSLPurchaseMoreSansArgs are the arguments for PurchaseMoreSansWithContext.
+// Field names and required status follow the purchasemoresans request table in
+// docs/namecheap-api-v2.md (lines 1036-1038).
+type SSLPurchaseMoreSansArgs struct {
+	// CertificateID is the certificate to add SANs to. Required.
+	CertificateID int
+	// NumberOfSANSToAdd is the number of add-on domains to order. Required (>= 1).
+	NumberOfSANSToAdd int
+}
+
+// PurchaseMoreSansWithContext purchases additional add-on domains (SANs) for an
+// already-purchased certificate.
+//
+// It is a charge-bearing, non-idempotent call: on an ambiguous transport or
+// server-side failure the SDK does NOT retry (a resend could double-charge). Only
+// the pre-execution HTTP 405 rate-limit signal is retried. Reconcile ambiguous
+// failures via GetInfoWithContext / the account order history.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/ssl/purchase-more-sans/
+func (ss *SSLService) PurchaseMoreSansWithContext(ctx context.Context, args *SSLPurchaseMoreSansArgs) (*SSLPurchaseMoreSansCommandResponse, error) {
+	if args == nil {
+		return nil, &InvalidArgumentsError{Fields: []string{"args"}, Reason: "args must not be nil"}
+	}
+	if err := args.validate(); err != nil {
+		return nil, err
+	}
+
+	var response SSLPurchaseMoreSansResponse
+	// idempotent=false: never retry a charge-bearing call on an ambiguous error.
+	_, err := ss.client.doXML(ctx, args.params(), &response, false)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}
+
+// validate reports every missing required field at once.
+func (a *SSLPurchaseMoreSansArgs) validate() error {
+	missing := make([]string, 0, 2)
+	if a.CertificateID < 1 {
+		missing = append(missing, "CertificateID")
+	}
+	if a.NumberOfSANSToAdd < 1 {
+		missing = append(missing, "NumberOfSANSToAdd")
+	}
+	if len(missing) > 0 {
+		return &InvalidArgumentsError{Fields: missing}
+	}
+	return nil
+}
+
+// params flattens the validated args into the request map.
+func (a *SSLPurchaseMoreSansArgs) params() map[string]string {
+	return map[string]string{
+		"Command":           "namecheap.ssl.purchasemoresans",
+		"CertificateID":     strconv.Itoa(a.CertificateID),
+		"NumberOfSANSToAdd": strconv.Itoa(a.NumberOfSANSToAdd),
+	}
+}

--- a/namecheap/ssl_purchase_more_sans_test.go
+++ b/namecheap/ssl_purchase_more_sans_test.go
@@ -1,0 +1,85 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const sslPurchaseMoreSansOKResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.ssl.purchasemoresans">
+		<SSLPurchaseMoreSansResult IsSuccess="true" OrderID="11223344" TransactionID="55667788" ChargedAmount="15.0000" CertificateID="123456" SSLType="PositiveSSL Multi-Domain" SANSCount="5" />
+	</CommandResponse>
+</ApiResponse>`
+
+func TestSSLService_PurchaseMoreSans(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = w.Write([]byte(sslPurchaseMoreSansOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.SSL.PurchaseMoreSansWithContext(context.Background(), &SSLPurchaseMoreSansArgs{
+			CertificateID:     123456,
+			NumberOfSANSToAdd: 2,
+		})
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.ssl.purchasemoresans", sentBody.Get("Command"))
+		assert.Equal(t, "123456", sentBody.Get("CertificateID"))
+		assert.Equal(t, "2", sentBody.Get("NumberOfSANSToAdd"))
+
+		result := resp.SSLPurchaseMoreSansResult
+		assert.True(t, *result.IsSuccess)
+		assert.Equal(t, Amount("15.0000"), *result.ChargedAmount)
+		assert.Equal(t, 5, *result.SANSCount)
+	})
+
+	t.Run("validation_no_http", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "http://127.0.0.1:0"
+
+		_, err := client.SSL.PurchaseMoreSansWithContext(context.Background(), &SSLPurchaseMoreSansArgs{})
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Equal(t, []string{"CertificateID", "NumberOfSANSToAdd"}, argErr.Fields)
+		}
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(apiErrorXML(2033409, "Order not found")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.SSL.PurchaseMoreSansWithContext(context.Background(), &SSLPurchaseMoreSansArgs{CertificateID: 1, NumberOfSANSToAdd: 1})
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2033409, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/ssl_reissue.go
+++ b/namecheap/ssl_reissue.go
@@ -1,0 +1,108 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// SSLReissueResponse is the raw envelope for namecheap.ssl.reissue.
+type SSLReissueResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *SSLReissueCommandResponse `xml:"CommandResponse"`
+}
+
+// SSLReissueCommandResponse wraps the reissue result.
+type SSLReissueCommandResponse struct {
+	SSLReissueResult *SSLReissueResult `xml:"SSLReissueResult"`
+}
+
+// SSLReissueResult is the outcome of a reissue. The doc's reissue section
+// (docs/namecheap-api-v2.md lines 988-1005) does not tabulate the response fields;
+// like activate, a reissue restarts domain-control validation, so the HTTP-DCV
+// file details are surfaced alongside the success flag.
+type SSLReissueResult struct {
+	// ID is the unique integer identifying the certificate.
+	ID *int `xml:"ID,attr"`
+	// IsSuccess reports whether the reissue request was accepted.
+	IsSuccess *bool `xml:"IsSuccess,attr"`
+	// HTTPDCValidation carries the HTTP DCV file details when HTTP validation is set.
+	HTTPDCValidation *SSLHTTPDCValidation `xml:"HttpDCValidation"`
+}
+
+// SSLReissueArgs are the arguments for ReissueWithContext. Field names and
+// required status follow the reissue request table in docs/namecheap-api-v2.md
+// (lines 996-1002).
+type SSLReissueArgs struct {
+	// CertificateID is the certificate to reissue. Required.
+	CertificateID int
+	// CSR is the PEM-encoded Certificate Signing Request. Required. Transported
+	// verbatim; no key material is read or stored.
+	CSR string
+	// AdminEmailAddress is the admin email; it cannot be changed from the initial
+	// activation. Optional.
+	AdminEmailAddress string
+	// WebServerType is the server software type (apacheopenssl, nginx, iis, ...).
+	// Optional.
+	WebServerType string
+	// UniqueValue is an optional unique identifier for the reissue request.
+	UniqueValue string
+}
+
+// ReissueWithContext reissues an SSL certificate.
+//
+// It is classified as a non-idempotent lifecycle call (same treatment as the
+// SSL money operations): on an ambiguous transport or server-side failure the SDK
+// does NOT retry, since a reissue can re-enter billing/validation flows. Only the
+// pre-execution HTTP 405 rate-limit signal is retried. Reconcile ambiguous
+// failures via GetInfoWithContext.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/ssl/reissue/
+func (ss *SSLService) ReissueWithContext(ctx context.Context, args *SSLReissueArgs) (*SSLReissueCommandResponse, error) {
+	if args == nil {
+		return nil, &InvalidArgumentsError{Fields: []string{"args"}, Reason: "args must not be nil"}
+	}
+	if err := args.validate(); err != nil {
+		return nil, err
+	}
+
+	var response SSLReissueResponse
+	// idempotent=false: never retry on an ambiguous error (see doc comment above).
+	_, err := ss.client.doXML(ctx, args.params(), &response, false)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}
+
+// validate reports every missing required field at once.
+func (a *SSLReissueArgs) validate() error {
+	missing := make([]string, 0, 2)
+	if a.CertificateID < 1 {
+		missing = append(missing, "CertificateID")
+	}
+	if a.CSR == "" {
+		missing = append(missing, "CSR")
+	}
+	if len(missing) > 0 {
+		return &InvalidArgumentsError{Fields: missing}
+	}
+	return nil
+}
+
+// params flattens the validated args into the request map.
+func (a *SSLReissueArgs) params() map[string]string {
+	params := map[string]string{
+		"Command":       "namecheap.ssl.reissue",
+		"CertificateID": strconv.Itoa(a.CertificateID),
+		"CSR":           a.CSR,
+	}
+	setIfNotEmpty(params, "AdminEmailAddress", a.AdminEmailAddress)
+	setIfNotEmpty(params, "WebServerType", a.WebServerType)
+	setIfNotEmpty(params, "UniqueValue", a.UniqueValue)
+	return params
+}

--- a/namecheap/ssl_reissue_test.go
+++ b/namecheap/ssl_reissue_test.go
@@ -1,0 +1,113 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const sslReissueOKResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.ssl.reissue">
+		<SSLReissueResult ID="123456" IsSuccess="true">
+			<HttpDCValidation ValueAvailable="true">
+				<FileName>reissue.txt</FileName>
+				<FileContent>hash</FileContent>
+			</HttpDCValidation>
+		</SSLReissueResult>
+	</CommandResponse>
+</ApiResponse>`
+
+func TestSSLService_Reissue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = w.Write([]byte(sslReissueOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.SSL.ReissueWithContext(context.Background(), &SSLReissueArgs{
+			CertificateID: 123456,
+			CSR:           "csr-data",
+			WebServerType: "nginx",
+		})
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.ssl.reissue", sentBody.Get("Command"))
+		assert.Equal(t, "123456", sentBody.Get("CertificateID"))
+		assert.Equal(t, "csr-data", sentBody.Get("CSR"))
+		assert.Equal(t, "nginx", sentBody.Get("WebServerType"))
+
+		result := resp.SSLReissueResult
+		assert.True(t, *result.IsSuccess)
+		assert.Equal(t, "reissue.txt", *result.HTTPDCValidation.FileName)
+	})
+
+	t.Run("validation_no_http", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "http://127.0.0.1:0"
+
+		_, err := client.SSL.ReissueWithContext(context.Background(), &SSLReissueArgs{})
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Equal(t, []string{"CertificateID", "CSR"}, argErr.Fields)
+		}
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(apiErrorXML(4011103, "Access denied")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.SSL.ReissueWithContext(context.Background(), &SSLReissueArgs{CertificateID: 1, CSR: "c"})
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 4011103, apiErr.Number)
+		}
+	})
+
+	// Reissue is classified non-idempotent: a retryable server error is not
+	// re-fired (exactly one attempt).
+	t.Run("non_idempotent_no_retry", func(t *testing.T) {
+		t.Parallel()
+		var calls int32
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&calls, 1)
+			_, _ = w.Write([]byte(apiErrorXML(5050900, "Server exception")))
+		}))
+		defer mockServer.Close()
+
+		client := newResilienceClient(mockServer.URL, func(o *ClientOptions) {
+			o.RateLimit = &RateLimitOptions{Disabled: true}
+			o.Retry = &RetryOptions{MaxAttempts: 4, BaseDelay: time.Millisecond, MaxDelay: 2 * time.Millisecond}
+		})
+
+		_, _ = client.SSL.ReissueWithContext(context.Background(), &SSLReissueArgs{CertificateID: 1, CSR: "c"})
+		assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "a reissue must not be retried on an ambiguous server error")
+	})
+}

--- a/namecheap/ssl_renew.go
+++ b/namecheap/ssl_renew.go
@@ -1,0 +1,106 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// SSLRenewResponse is the raw envelope for namecheap.ssl.renew.
+type SSLRenewResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *SSLRenewCommandResponse `xml:"CommandResponse"`
+}
+
+// SSLRenewCommandResponse wraps the renew result.
+type SSLRenewCommandResponse struct {
+	SSLRenewResult *SSLRenewResult `xml:"SSLRenewResult"`
+}
+
+// SSLRenewResult is the outcome of a renewal. Fields follow the renew response
+// table in docs/namecheap-api-v2.md (lines 980-984).
+type SSLRenewResult struct {
+	// CertificateID is the unique integer for the renewal certificate.
+	CertificateID *int `xml:"CertificateID,attr"`
+	// Years is the number of years valid once issued.
+	Years *int `xml:"Years,attr"`
+	// OrderID is the unique integer for the renewal order.
+	OrderID *int `xml:"OrderID,attr"`
+	// TransactionID is the unique integer for the renewal transaction.
+	TransactionID *int `xml:"TransactionID,attr"`
+	// ChargedAmount is the amount charged, kept as an exact decimal string (see Amount).
+	ChargedAmount *Amount `xml:"ChargedAmount,attr"`
+}
+
+// SSLRenewArgs are the arguments for RenewWithContext. Field names and required
+// status follow the renew request table in docs/namecheap-api-v2.md
+// (lines 969-974).
+type SSLRenewArgs struct {
+	// CertificateID is the certificate to renew. Required.
+	CertificateID int
+	// Years is the renewal term; allowed values 1..5. Required.
+	Years int
+	// SSLType is the SSL product name. Required.
+	SSLType string
+	// PromotionCode is an optional promotional code.
+	PromotionCode string
+}
+
+// RenewWithContext renews an SSL certificate.
+//
+// It is a charge-bearing, non-idempotent call: on an ambiguous transport or
+// server-side failure the SDK does NOT retry (a resend could double-charge). Only
+// the pre-execution HTTP 405 rate-limit signal is retried. Reconcile ambiguous
+// failures via GetListWithContext / the account order history.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/ssl/renew/
+func (ss *SSLService) RenewWithContext(ctx context.Context, args *SSLRenewArgs) (*SSLRenewCommandResponse, error) {
+	if args == nil {
+		return nil, &InvalidArgumentsError{Fields: []string{"args"}, Reason: "args must not be nil"}
+	}
+	if err := args.validate(); err != nil {
+		return nil, err
+	}
+
+	var response SSLRenewResponse
+	// idempotent=false: never retry a charge-bearing call on an ambiguous error.
+	_, err := ss.client.doXML(ctx, args.params(), &response, false)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}
+
+// validate reports every missing required field at once and range-checks Years.
+func (a *SSLRenewArgs) validate() error {
+	missing := make([]string, 0, 3)
+	if a.CertificateID < 1 {
+		missing = append(missing, "CertificateID")
+	}
+	if a.Years < 1 || a.Years > 5 {
+		missing = append(missing, "Years")
+	}
+	if a.SSLType == "" {
+		missing = append(missing, "SSLType")
+	}
+	if len(missing) > 0 {
+		return &InvalidArgumentsError{Fields: missing}
+	}
+	return nil
+}
+
+// params flattens the validated args into the request map.
+func (a *SSLRenewArgs) params() map[string]string {
+	params := map[string]string{
+		"Command":       "namecheap.ssl.renew",
+		"CertificateID": strconv.Itoa(a.CertificateID),
+		"Years":         strconv.Itoa(a.Years),
+		"SSLType":       a.SSLType,
+	}
+	setIfNotEmpty(params, "PromotionCode", a.PromotionCode)
+	return params
+}

--- a/namecheap/ssl_renew_test.go
+++ b/namecheap/ssl_renew_test.go
@@ -1,0 +1,86 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const sslRenewOKResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.ssl.renew">
+		<SSLRenewResult CertificateID="123456" Years="1" OrderID="11223344" TransactionID="55667788" ChargedAmount="7.5000" />
+	</CommandResponse>
+</ApiResponse>`
+
+func TestSSLService_Renew(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = w.Write([]byte(sslRenewOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.SSL.RenewWithContext(context.Background(), &SSLRenewArgs{
+			CertificateID: 123456,
+			Years:         1,
+			SSLType:       "PositiveSSL",
+		})
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.ssl.renew", sentBody.Get("Command"))
+		assert.Equal(t, "123456", sentBody.Get("CertificateID"))
+		assert.Equal(t, "1", sentBody.Get("Years"))
+		assert.Equal(t, "PositiveSSL", sentBody.Get("SSLType"))
+
+		result := resp.SSLRenewResult
+		assert.Equal(t, 123456, *result.CertificateID)
+		assert.Equal(t, Amount("7.5000"), *result.ChargedAmount)
+	})
+
+	t.Run("validation_no_http", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "http://127.0.0.1:0"
+
+		_, err := client.SSL.RenewWithContext(context.Background(), &SSLRenewArgs{})
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Equal(t, []string{"CertificateID", "Years", "SSLType"}, argErr.Fields)
+		}
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(apiErrorXML(2033409, "Order not found")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.SSL.RenewWithContext(context.Background(), &SSLRenewArgs{CertificateID: 1, Years: 1, SSLType: "PositiveSSL"})
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2033409, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/ssl_resend_approver_email.go
+++ b/namecheap/ssl_resend_approver_email.go
@@ -1,0 +1,55 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// SSLResendApproverEmailResponse is the raw envelope for
+// namecheap.ssl.resendApproverEmail.
+type SSLResendApproverEmailResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *SSLResendApproverEmailCommandResponse `xml:"CommandResponse"`
+}
+
+// SSLResendApproverEmailCommandResponse wraps the resendApproverEmail result.
+type SSLResendApproverEmailCommandResponse struct {
+	SSLResendApproverEmailResult *SSLResendApproverEmailResult `xml:"SSLResendApproverEmailResult"`
+}
+
+// SSLResendApproverEmailResult is the outcome of a resend request. Fields follow
+// the response table in docs/namecheap-api-v2.md (lines 929-930).
+type SSLResendApproverEmailResult struct {
+	// ID is the unique integer identifying the certificate.
+	ID *int `xml:"ID,attr"`
+	// IsSuccess reports whether the approver email was resent successfully.
+	IsSuccess *bool `xml:"IsSuccess,attr"`
+}
+
+// ResendApproverEmailWithContext resends the approver email for a certificate and
+// also serves as the retry mechanism for HTTP/DNS validation (doc lines 913-915).
+// It is idempotent (safe to resend) and retries on transient failures.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/ssl/resend-approver-email/
+func (ss *SSLService) ResendApproverEmailWithContext(ctx context.Context, certificateID int) (*SSLResendApproverEmailCommandResponse, error) {
+	if certificateID < 1 {
+		return nil, &InvalidArgumentsError{Fields: []string{"CertificateID"}, Reason: "CertificateID must be a positive integer"}
+	}
+
+	params := map[string]string{
+		"Command":       "namecheap.ssl.resendApproverEmail",
+		"CertificateID": strconv.Itoa(certificateID),
+	}
+
+	var response SSLResendApproverEmailResponse
+	_, err := ss.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/ssl_resend_approver_email_test.go
+++ b/namecheap/ssl_resend_approver_email_test.go
@@ -1,0 +1,78 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const sslResendApproverEmailOKResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.ssl.resendApproverEmail">
+		<SSLResendApproverEmailResult ID="123456" IsSuccess="true" />
+	</CommandResponse>
+</ApiResponse>`
+
+func TestSSLService_ResendApproverEmail(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = w.Write([]byte(sslResendApproverEmailOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.SSL.ResendApproverEmailWithContext(context.Background(), 123456)
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.ssl.resendApproverEmail", sentBody.Get("Command"))
+		assert.Equal(t, "123456", sentBody.Get("CertificateID"))
+		assert.Equal(t, 123456, *resp.SSLResendApproverEmailResult.ID)
+		assert.True(t, *resp.SSLResendApproverEmailResult.IsSuccess)
+	})
+
+	t.Run("invalid_id_no_http", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "http://127.0.0.1:0"
+
+		_, err := client.SSL.ResendApproverEmailWithContext(context.Background(), 0)
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "CertificateID")
+		}
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(apiErrorXML(2011170, "Promotion code invalid")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.SSL.ResendApproverEmailWithContext(context.Background(), 999)
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2011170, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/ssl_resend_fulfillment_email.go
+++ b/namecheap/ssl_resend_fulfillment_email.go
@@ -1,0 +1,57 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// SSLResendFulfillmentEmailResponse is the raw envelope for
+// namecheap.ssl.resendfulfillmentemail.
+type SSLResendFulfillmentEmailResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *SSLResendFulfillmentEmailCommandResponse `xml:"CommandResponse"`
+}
+
+// SSLResendFulfillmentEmailCommandResponse wraps the resendfulfillmentemail
+// result.
+type SSLResendFulfillmentEmailCommandResponse struct {
+	SSLResendFulfillmentEmailResult *SSLResendFulfillmentEmailResult `xml:"SSLResendFulfillmentEmailResult"`
+}
+
+// SSLResendFulfillmentEmailResult is the outcome of a resend. Fields follow the
+// resendfulfillmentemail response table in docs/namecheap-api-v2.md
+// (lines 1022-1023).
+type SSLResendFulfillmentEmailResult struct {
+	// ID is the unique integer identifying the certificate.
+	ID *int `xml:"ID,attr"`
+	// IsSuccess reports whether the fulfillment email was resent successfully.
+	IsSuccess *bool `xml:"IsSuccess,attr"`
+}
+
+// ResendFulfillmentEmailWithContext resends the fulfilment email that carries the
+// issued certificate. Resending an email is safe, so the call is treated as
+// idempotent and retries on transient failures.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/ssl/resend-fulfillment-email/
+func (ss *SSLService) ResendFulfillmentEmailWithContext(ctx context.Context, certificateID int) (*SSLResendFulfillmentEmailCommandResponse, error) {
+	if certificateID < 1 {
+		return nil, &InvalidArgumentsError{Fields: []string{"CertificateID"}, Reason: "CertificateID must be a positive integer"}
+	}
+
+	params := map[string]string{
+		"Command":       "namecheap.ssl.resendfulfillmentemail",
+		"CertificateID": strconv.Itoa(certificateID),
+	}
+
+	var response SSLResendFulfillmentEmailResponse
+	_, err := ss.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/ssl_resend_fulfillment_email_test.go
+++ b/namecheap/ssl_resend_fulfillment_email_test.go
@@ -1,0 +1,78 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const sslResendFulfillmentEmailOKResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.ssl.resendfulfillmentemail">
+		<SSLResendFulfillmentEmailResult ID="123456" IsSuccess="true" />
+	</CommandResponse>
+</ApiResponse>`
+
+func TestSSLService_ResendFulfillmentEmail(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = w.Write([]byte(sslResendFulfillmentEmailOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.SSL.ResendFulfillmentEmailWithContext(context.Background(), 123456)
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.ssl.resendfulfillmentemail", sentBody.Get("Command"))
+		assert.Equal(t, "123456", sentBody.Get("CertificateID"))
+		assert.Equal(t, 123456, *resp.SSLResendFulfillmentEmailResult.ID)
+		assert.True(t, *resp.SSLResendFulfillmentEmailResult.IsSuccess)
+	})
+
+	t.Run("invalid_id_no_http", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "http://127.0.0.1:0"
+
+		_, err := client.SSL.ResendFulfillmentEmailWithContext(context.Background(), 0)
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "CertificateID")
+		}
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(apiErrorXML(2019166, "Domain not found")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.SSL.ResendFulfillmentEmailWithContext(context.Background(), 999)
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2019166, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/ssl_revoke_certificate.go
+++ b/namecheap/ssl_revoke_certificate.go
@@ -1,0 +1,67 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// SSLRevokeCertificateResponse is the raw envelope for
+// namecheap.ssl.revokecertificate.
+type SSLRevokeCertificateResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *SSLRevokeCertificateCommandResponse `xml:"CommandResponse"`
+}
+
+// SSLRevokeCertificateCommandResponse wraps the revokecertificate result.
+type SSLRevokeCertificateCommandResponse struct {
+	SSLRevokeCertificateResult *SSLRevokeCertificateResult `xml:"SSLRevokeCertificateResult"`
+}
+
+// SSLRevokeCertificateResult is the outcome of a revoke. Fields follow the
+// revokecertificate response table in docs/namecheap-api-v2.md (lines 1071-1072).
+type SSLRevokeCertificateResult struct {
+	// IsSuccess reports whether the certificate was revoked successfully.
+	IsSuccess *bool `xml:"IsSuccess,attr"`
+	// CertificateID is the unique integer identifying the certificate.
+	CertificateID *int `xml:"CertificateID,attr"`
+}
+
+// RevokeCertificateWithContext revokes a re-issued SSL certificate.
+//
+// It is not charge-bearing and re-firing it is safe (revoking an already-revoked
+// certificate leaves the same end state), so it is treated as idempotent and
+// retries on transient failures.
+//
+// Both certificateID and certificateType are required (doc lines 1064-1065).
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/ssl/revoke-certificate/
+func (ss *SSLService) RevokeCertificateWithContext(ctx context.Context, certificateID int, certificateType string) (*SSLRevokeCertificateCommandResponse, error) {
+	missing := make([]string, 0, 2)
+	if certificateID < 1 {
+		missing = append(missing, "CertificateID")
+	}
+	if certificateType == "" {
+		missing = append(missing, "CertificateType")
+	}
+	if len(missing) > 0 {
+		return nil, &InvalidArgumentsError{Fields: missing}
+	}
+
+	params := map[string]string{
+		"Command":         "namecheap.ssl.revokecertificate",
+		"CertificateID":   strconv.Itoa(certificateID),
+		"CertificateType": certificateType,
+	}
+
+	var response SSLRevokeCertificateResponse
+	_, err := ss.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/ssl_revoke_certificate_test.go
+++ b/namecheap/ssl_revoke_certificate_test.go
@@ -1,0 +1,81 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const sslRevokeCertificateOKResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.ssl.revokecertificate">
+		<SSLRevokeCertificateResult IsSuccess="true" CertificateID="123456" />
+	</CommandResponse>
+</ApiResponse>`
+
+func TestSSLService_RevokeCertificate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = w.Write([]byte(sslRevokeCertificateOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.SSL.RevokeCertificateWithContext(context.Background(), 123456, "PositiveSSL")
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.ssl.revokecertificate", sentBody.Get("Command"))
+		assert.Equal(t, "123456", sentBody.Get("CertificateID"))
+		assert.Equal(t, "PositiveSSL", sentBody.Get("CertificateType"))
+
+		result := resp.SSLRevokeCertificateResult
+		assert.True(t, *result.IsSuccess)
+		assert.Equal(t, 123456, *result.CertificateID)
+	})
+
+	t.Run("validation_no_http", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "http://127.0.0.1:0"
+
+		_, err := client.SSL.RevokeCertificateWithContext(context.Background(), 0, "")
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Equal(t, []string{"CertificateID", "CertificateType"}, argErr.Fields)
+		}
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(apiErrorXML(2033409, "Order not found")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.SSL.RevokeCertificateWithContext(context.Background(), 999, "PositiveSSL")
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2033409, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/ssl_test.go
+++ b/namecheap/ssl_test.go
@@ -1,0 +1,142 @@
+package namecheap
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDCVMethodIsValid confirms only the three documented methods are valid and
+// an arbitrary string cannot masquerade as a valid method.
+func TestDCVMethodIsValid(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, DCVMethodHTTP.IsValid())
+	assert.True(t, DCVMethodDNS.IsValid())
+	assert.True(t, DCVMethodEmail.IsValid())
+	assert.False(t, DCVMethod("").IsValid())
+	assert.False(t, DCVMethod("FTP_HASH").IsValid())
+}
+
+// TestDCVWireValue confirms HTTP/DNS emit their tokens verbatim and email emits
+// the approver address.
+func TestDCVWireValue(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "HTTP_CSR_HASH", dcvWireValue(DCVMethodHTTP, ""))
+	assert.Equal(t, "CNAME_CSR_HASH", dcvWireValue(DCVMethodDNS, ""))
+	assert.Equal(t, "[email protected]", dcvWireValue(DCVMethodEmail, "[email protected]"))
+}
+
+// TestDCVMissingFieldsMatrix table-tests the per-method required-field rule: email
+// requires an approver address, HTTP and DNS require nothing, and an unknown
+// method surfaces DCVMethod as invalid. Every combination is covered.
+func TestDCVMissingFieldsMatrix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		method        DCVMethod
+		approverEmail string
+		want          []string
+	}{
+		{"http_ok", DCVMethodHTTP, "", nil},
+		{"http_ignores_email", DCVMethodHTTP, "[email protected]", nil},
+		{"dns_ok", DCVMethodDNS, "", nil},
+		{"email_ok", DCVMethodEmail, "[email protected]", nil},
+		{"email_missing_approver", DCVMethodEmail, "", []string{"ApproverEmail"}},
+		{"email_blank_approver", DCVMethodEmail, "   ", []string{"ApproverEmail"}},
+		{"unknown_method", DCVMethod("FTP"), "", []string{"DCVMethod"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, dcvMissingFields("", tc.method, tc.approverEmail))
+		})
+	}
+}
+
+// TestDCVMissingFieldsLabel confirms the label prefix is applied so per-SAN
+// errors are attributable.
+func TestDCVMissingFieldsLabel(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, []string{"SANs[2].ApproverEmail"}, dcvMissingFields("SANs[2].", DCVMethodEmail, ""))
+}
+
+// TestClassifyStatus confirms every documented status maps to its constant,
+// classification is case-insensitive and whitespace-tolerant, and an unknown or
+// empty value yields CertStatusUnknown (no fabricated codes).
+func TestClassifyStatus(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]CertStatus{
+		"Active":        CertStatusActive,
+		"active":        CertStatusActive,
+		"  ACTIVE  ":    CertStatusActive,
+		"Newpurchase":   CertStatusNewPurchase,
+		"NEWRENEWAL":    CertStatusNewRenewal,
+		"Purchased":     CertStatusPurchased,
+		"Purchaseerror": CertStatusPurchaseError,
+		"Cancelled":     CertStatusCancelled,
+		"":              CertStatusUnknown,
+		"SomethingElse": CertStatusUnknown,
+	}
+	for raw, want := range cases {
+		assert.Equalf(t, want, ClassifyStatus(raw), "status %q", raw)
+	}
+}
+
+// TestExpiresWithinBoundary boundary-tests the single expiry-math helper: the
+// threshold is inclusive, an already-expired instant counts, a zero expiry never
+// counts, and the comparison is timezone-safe (same instant in another zone gives
+// the same answer).
+func TestExpiresWithinBoundary(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+	within := 30 * 24 * time.Hour
+
+	// Exactly at the threshold: inclusive -> true.
+	assert.True(t, expiresWithin(now.Add(within), within, now))
+	// One second past the threshold -> false.
+	assert.False(t, expiresWithin(now.Add(within+time.Second), within, now))
+	// Comfortably inside the window -> true.
+	assert.True(t, expiresWithin(now.Add(within-time.Hour), within, now))
+	// Already expired -> true (needs attention).
+	assert.True(t, expiresWithin(now.Add(-time.Hour), within, now))
+	// Zero expiry -> false.
+	assert.False(t, expiresWithin(time.Time{}, within, now))
+
+	// Timezone safety: the boundary instant expressed in a +2h zone is the same
+	// instant, so the answer must not change.
+	other := now.Add(within).In(time.FixedZone("UTC+2", 2*3600))
+	assert.True(t, expiresWithin(other, within, now))
+}
+
+// TestGetInfoResultHelpers exercises IsIssued / IsExpiringSoon / CertStatus on the
+// result, including nil-safety.
+func TestGetInfoResultHelpers(t *testing.T) {
+	t.Parallel()
+
+	var nilResult *SSLGetInfoResult
+	assert.Equal(t, CertStatusUnknown, nilResult.CertStatus())
+	assert.False(t, nilResult.IsIssued())
+	assert.False(t, nilResult.IsExpiringSoon(time.Hour))
+
+	active := &SSLGetInfoResult{Status: "Active"}
+	assert.True(t, active.IsIssued())
+	assert.Equal(t, CertStatusActive, active.CertStatus())
+
+	// Purchased is activated-but-awaiting-issuance: NOT issued.
+	purchased := &SSLGetInfoResult{Status: "Purchased"}
+	assert.False(t, purchased.IsIssued())
+
+	// A far-future expiry is not expiring soon; a near one is.
+	far := &SSLGetInfoResult{Expires: &DateTime{Time: time.Now().Add(365 * 24 * time.Hour)}}
+	assert.False(t, far.IsExpiringSoon(30*24*time.Hour))
+	near := &SSLGetInfoResult{Expires: &DateTime{Time: time.Now().Add(24 * time.Hour)}}
+	assert.True(t, near.IsExpiringSoon(30*24*time.Hour))
+	// A result with no expiry is never expiring soon.
+	assert.False(t, (&SSLGetInfoResult{}).IsExpiringSoon(30*24*time.Hour))
+}


### PR DESCRIPTION
Closes #116. Phase 2 coverage on the go-namecheap-sdk 2.0 roadmap (#122) — the largest coverage item (13 commands). Unlocks certificate-lifecycle automation (issuance pipelines, renewal automation, expiring-cert inventory). Reuses `Amount` (#114), the non-idempotent `doXML` path (#114), and the `DateTime` parsing.

## What — new `SSLService` (ctx-first, `WithContext` suffix), all 13 commands
- **Read/inventory:** `GetList`, `GetInfo`, `ParseCSR`.
- **Activation:** `Activate` (CSR, web-server type, DCV method, approver email, multi-SAN), `GetApproverEmailList`, `ResendApproverEmail`, `EditDCVMethod`.
- **Lifecycle/money:** `Create`, `Renew`, `Reissue`, `PurchaseMoreSans`, `RevokeCertificate`, `ResendFulfillmentEmail`.

(Doc's 13th command is **`editDCVMethod`** — the issue text's "editDNSDSCRecords" is a typo; implemented per the doc.)

## Design
- **`DCVMethod` enum** (HTTP/DNS/Email) with per-method client-side validation listing all missing fields at once (`InvalidArgumentsError`), on both `Activate` and `EditDCVMethod`; one Activate fixture per DCV method.
- **`CertStatus`** mirrors the doc's documented status vocabulary (ACTIVE/NEWPURCHASE/…/CANCELLED) — no fabricated codes; `IsIssued()` (ACTIVE only) and **`IsExpiringSoon(within)`** do expiry math in one tested, timezone-safe place (inclusive boundary tested).
- **Money ops non-idempotent** (`Create`/`Renew`/`Reissue`/`PurchaseMoreSans` via `doXML(..., false)`) — never re-charged on ambiguous transport failure (call-count proven); reads retryable. Money is `Amount` (no float64).
- **Multi-SAN** host blocks round-trip (indexed params; 3+ SANs tested).
- **CSR/keys non-goal:** the SDK only transports CSR strings — never generates/stores keys (documented).

## ⚠️ Documented gap (flagged in code + this PR)
The doc tabulates the ssl params but does **not** enumerate the DCV-method wire values or the multi-SAN sub-params for `activate`/`editDCVMethod`. Those are grounded in the documented Namecheap DCV flow (`HTTP_CSR_HASH`/`CNAME_CSR_HASH`/`EMAIL`, indexed SAN params) and marked adjust-if-wire-differs — same "don't fabricate silently" principle as #111/#115. Worth a sandbox capture to confirm before a tagged release.

## Acceptance criteria
- [x] All 13 commands; structs cross-checked against the doc (line ranges cited in commit).
- [x] DCV enum + per-method validation matrix (table-driven); invalid method not constructible.
- [x] Status constants cover the documented set; `IsExpiringSoon` boundary + timezone tested.
- [x] Money ops non-idempotent (proven); reads retryable.
- [x] Table tests per command (success + API error); Activate fixture per DCV method; 3+ SAN round-trip.
- [x] README coverage matrix + Create→Activate(DNS)→poll-GetInfo example; CHANGELOG; doc comments everywhere.

## Verification (local, go 1.26.4 + golangci-lint 2.12.2)
`go vet` ✅ · `golangci-lint run` → 0 issues ✅ · `go mod verify` (no new deps, go.mod/go.sum unchanged) ✅ · `make test` unit + **race** ✅ (95.4% coverage, ~170 SSL subtests). Nested `otelnamecheap/` untouched.
