### PR TITLE
feat: add domainprivacy (WhoisGuard) API group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New `DomainPrivacyService` (`client.DomainPrivacy`), context-first with the
+  `WithContext` suffix, covering the `domainprivacy` (WhoisGuard) group — all 7
+  commands: `GetListWithContext`, `EnableWithContext`, `DisableWithContext`,
+  `AllotWithContext`, `UnallotWithContext`, `DiscardWithContext` and
+  `ChangeEmailAddressWithContext`. The service is named for the current product
+  term ("domain privacy") while the underlying command strings keep the API's
+  legacy `whoisguard` names; the one-to-one mapping is documented on the service.
+  Subscription IDs are the API's numeric IDs typed as `int` (a `WhoisguardID` on
+  the wire), never strings. Documented commands (`changeemailaddress`, `enable`,
+  `disable`, `getlist`) match `docs/namecheap-api-v2.md` (lines 1485-1575) (#118).
+- `EnsureEnabledWithContext(ctx, domain, forwardedToEmail)` convenience helper
+  composing the attach-vs-activate state machine (getList → allot → enable): it
+  no-ops when already enabled, enables when attached-but-disabled, allots-then-
+  enables a FREE subscription, and returns the typed `ErrNoFreePrivacySubscription`
+  when nothing is available to allot. Table-driven mock-sequence tests cover all
+  four starting states (#118).
+- Grounded `PrivacyState` type (`FREE` / `ALLOTTED` / `DISCARD` / `UNKNOWN`)
+  mirroring the documented getList `ListType` vocabulary (the doc enumerates no
+  `Status` values), with `ClassifyPrivacyStatus` and a per-entry `State()`; the
+  raw `Status` is exposed verbatim, and the enabled/disabled dimension is read
+  separately with `DomainPrivacyGetListEntry.IsEnabled()`. No fabricated codes
+  (#118).
+- `Discard` is **destructive and non-idempotent**: it uses the same retry
+  classification as `domains.create` (`doXML(..., false)`), so an ambiguous
+  transport/server failure is never auto-retried (only the pre-execution HTTP 405
+  rate-limit signal is); a test asserts no re-fire after a simulated server error
+  and after a transport timeout (call-count == 1). `enable` / `disable` / `allot`
+  / `unallot` / `changeEmailAddress` are idempotent and retry as usual (#118).
+- Documented gap flagged in code and README: `allot` / `unallot` / `discard` are
+  **not** present in `docs/namecheap-api-v2.md`; their wire commands
+  (`namecheap.whoisguard.allot` / `.unallot` / `.discard`) and required parameters
+  (`allot`: `WhoisguardID` + `DomainName`; `unallot` / `discard`: `WhoisguardID`)
+  are grounded in the real Namecheap whoisguard API — the same "don't fabricate
+  silently" principle used for SSL DCV tokens and transfer status codes. The doc's
+  `renew` command is intentionally deferred (out of scope; charge-bearing) (#118).
+- README coverage matrix for `domainprivacy` plus a "register with privacy"
+  example composing `domains.CreateWithContext` and
+  `DomainPrivacy.EnsureEnabledWithContext`, noting the whoisguard→domainprivacy
+  naming and that `discard` is destructive (#118).
 - New `SSLService` (`client.SSL`), context-first with the `WithContext` suffix,
   covering the full `namecheap.ssl.*` group — all 13 commands across three phases:
   inventory (`GetListWithContext`, `GetInfoWithContext`, `ParseCSRWithContext`),

--- a/README.md
+++ b/README.md
@@ -575,6 +575,101 @@ for {
 | `revokecertificate` | Implemented |
 | `editDCVMethod` | Implemented |
 
+#### Domain privacy (`client.DomainPrivacy`)
+
+The `domainprivacy` group manages privacy (WhoisGuard) subscriptions: listing
+them, turning protection on/off, attaching/detaching a subscription to a domain,
+throwing away an unused subscription, and rotating the forwarding email.
+
+> **Naming: whoisguard → domainprivacy.** The service is named for the current
+> product term ("domain privacy"), but the underlying Namecheap API commands
+> still use the legacy `whoisguard` names. The mapping is one-to-one, e.g.
+> `DomainPrivacy.GetListWithContext` → `namecheap.whoisguard.getList`,
+> `EnableWithContext` → `namecheap.whoisguard.enable`, `DiscardWithContext` →
+> `namecheap.whoisguard.discard`. Subscription IDs are the API's numeric IDs
+> typed as `int` (a "WhoisguardID" on the wire), never strings.
+
+| Method | Description |
+|---|---|
+| `GetListWithContext(ctx, args)` | List privacy subscriptions (ListType filter, paging) |
+| `EnableWithContext(ctx, privacyID, forwardedToEmail)` | Turn privacy on and set the forwarding email |
+| `DisableWithContext(ctx, privacyID)` | Turn privacy off (keeps the subscription attached) |
+| `AllotWithContext(ctx, privacyID, domain)` | Attach a subscription to a domain |
+| `UnallotWithContext(ctx, privacyID)` | Detach a subscription (returns it to the FREE pool) |
+| `DiscardWithContext(ctx, privacyID)` | **Destructive:** throw away an unused subscription |
+| `ChangeEmailAddressWithContext(ctx, privacyID)` | Rotate the privacy forwarding email |
+| `EnsureEnabledWithContext(ctx, domain, forwardedToEmail)` | Compose getList → allot → enable for a domain |
+
+```go
+// Register a domain, then make sure privacy is enabled for it. EnsureEnabled
+// composes the whole state machine (find/allot a subscription, then enable it),
+// so you do not have to reason about the attach-vs-activate distinction yourself.
+created, err := client.Domains.CreateWithContext(ctx, &namecheap.DomainsCreateArgs{
+    DomainName:        "example.com",
+    Years:             1,
+    Registrant:        contact, Tech: contact, Admin: contact, AuxBilling: contact,
+    AddFreeWhoisguard: namecheap.Bool(true), // include the free privacy subscription
+})
+if err != nil {
+    log.Fatal(err) // charge-bearing: never auto-retried on an ambiguous failure
+}
+
+res, err := client.DomainPrivacy.EnsureEnabledWithContext(ctx, "example.com", "[email protected]")
+if err != nil {
+    if errors.Is(err, namecheap.ErrNoFreePrivacySubscription) {
+        log.Fatal("no free privacy subscription to allot")
+    }
+    log.Fatal(err)
+}
+fmt.Printf("privacy id=%d action=%s\n", res.PrivacyID, res.Action)
+```
+
+> **Attach vs. activate.** A subscription must first be *allotted* (attached) to a
+> domain and, separately, *enabled* (activated with a forwarding email).
+> `AllotWithContext` does the first; `EnableWithContext` does the second;
+> `EnsureEnabledWithContext` hides both. From each starting state it either no-ops
+> (already enabled), enables (attached but disabled), or allots-then-enables (a
+> FREE subscription exists) — and returns `ErrNoFreePrivacySubscription` when
+> there is nothing to allot.
+>
+> **Status is typed and grounded.** The doc does not enumerate the getList
+> `Status` values, only the `ListType` filter vocabulary (`ALL` / `ALLOTED` /
+> `FREE` / `DISCARD`). The SDK exposes the raw `Status` verbatim and offers a
+> typed `PrivacyState` (`FREE` / `ALLOTTED` / `DISCARD` / `UNKNOWN`) grounded in
+> that vocabulary via `ClassifyPrivacyStatus` — no fabricated code table. The
+> on/off dimension is read separately with `DomainPrivacyGetListEntry.IsEnabled`.
+>
+> **`discard` is destructive and non-idempotent.** It permanently gives up an
+> unused subscription; use `UnallotWithContext` instead to detach and keep it. As
+> a destructive, charge-adjacent call it is never auto-retried on an ambiguous
+> transport/server failure (only the pre-execution HTTP 405 rate-limit signal is),
+> the same money-safety rule as `domains.create`. The other mutations
+> (`enable` / `disable` / `allot` / `unallot` / `changeEmailAddress`) are
+> idempotent and retry as usual.
+>
+> **Documented gap: `allot` / `unallot` / `discard`.** These three commands are
+> **not** present in `docs/namecheap-api-v2.md`; their wire commands
+> (`namecheap.whoisguard.allot` / `.unallot` / `.discard`) and required parameters
+> (`allot`: `WhoisguardID` + `DomainName`; `unallot` / `discard`: `WhoisguardID`)
+> are grounded in the real Namecheap whoisguard API rather than the local doc, and
+> the gap is flagged in the code — the same "don't fabricate silently" principle
+> used for SSL DCV tokens and transfer status codes. The doc's `renew` command is
+> intentionally **not** implemented here (out of scope for this group;
+> charge-bearing).
+
+##### DomainPrivacy API coverage matrix
+
+| `namecheap.whoisguard.*` command | Status |
+|---|---|
+| `getList` | Implemented |
+| `enable` | Implemented |
+| `disable` | Implemented |
+| `allot` | Implemented (grounded; not in local doc) |
+| `unallot` | Implemented (grounded; not in local doc) |
+| `discard` | Implemented (grounded; not in local doc; destructive) |
+| `changeEmailAddress` | Implemented |
+| `renew` | Deferred (documented but out of scope; charge-bearing) |
+
 ### Error handling
 
 When the API rejects a call it returns a typed `*namecheap.APIError` carrying the

--- a/namecheap/domainprivacy.go
+++ b/namecheap/domainprivacy.go
@@ -1,0 +1,119 @@
+package namecheap
+
+import (
+	"errors"
+	"strings"
+)
+
+// DomainPrivacyService groups the domain-privacy API commands: listing
+// subscriptions (GetListWithContext), turning protection on and off
+// (EnableWithContext, DisableWithContext), attaching and detaching a
+// subscription to a domain (AllotWithContext, UnallotWithContext), throwing away
+// an unused subscription (DiscardWithContext) and rotating the forwarding email
+// (ChangeEmailAddressWithContext). EnsureEnabledWithContext composes getList →
+// allot → enable for the common "just turn privacy on for this domain" case.
+//
+// Naming: whoisguard → domainprivacy. This service is named for the current
+// product term ("domain privacy"), but the underlying Namecheap API commands
+// still use the legacy "whoisguard" names. The mapping is one-to-one:
+//
+//	DomainPrivacy.GetListWithContext            -> namecheap.whoisguard.getlist
+//	DomainPrivacy.EnableWithContext             -> namecheap.whoisguard.enable
+//	DomainPrivacy.DisableWithContext            -> namecheap.whoisguard.disable
+//	DomainPrivacy.AllotWithContext              -> namecheap.whoisguard.allot
+//	DomainPrivacy.UnallotWithContext            -> namecheap.whoisguard.unallot
+//	DomainPrivacy.DiscardWithContext            -> namecheap.whoisguard.discard
+//	DomainPrivacy.ChangeEmailAddressWithContext -> namecheap.whoisguard.changeemailaddress
+//
+// A privacy subscription is its own entity with a numeric ID (a "WhoisguardID"
+// on the wire), a status and an expiry, and is attachable to a domain. Every
+// method takes that ID as a typed int (privacyID), never a string. The wire
+// parameter is still named WhoisguardID for backward compatibility.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/whoisguard/
+type DomainPrivacyService service
+
+// PrivacyState is a coarse, typed classification of a domain-privacy
+// subscription's lifecycle/allotment state.
+//
+// Grounding and the documented gap. docs/namecheap-api-v2.md (domainprivacy
+// section, getlist lines 1551-1575) does NOT enumerate the values of the getList
+// Status field; it only documents the getList ListType filter vocabulary — ALL |
+// ALLOTED | FREE | DISCARD (line 1567). This SDK therefore does NOT invent a
+// status code table. Instead it always exposes the raw Status verbatim on every
+// entry (see DomainPrivacyGetListEntry.Status) and offers this small state whose
+// constants are grounded in that documented ListType vocabulary.
+// ClassifyPrivacyStatus maps a raw Status string onto one of these states by
+// case-insensitive keyword matching.
+//
+// Note the spelling: the API's ListType filter value is the nonstandard
+// "ALLOTED" (see allowedPrivacyListTypeValues), while this classification
+// constant uses the correct English "ALLOTTED"; the classifier keys off the
+// "allot" substring so it recognises both.
+type PrivacyState string
+
+const (
+	// PrivacyStateUnknown is used when a Status is empty or cannot be classified.
+	PrivacyStateUnknown PrivacyState = "UNKNOWN"
+	// PrivacyStateFree mirrors the documented getList category FREE: the
+	// subscription is not attached to any domain and is available to allot.
+	PrivacyStateFree PrivacyState = "FREE"
+	// PrivacyStateAllotted mirrors the documented getList category ALLOTED: the
+	// subscription is attached to a domain (whether privacy is currently enabled
+	// or disabled — that dimension is read separately via
+	// DomainPrivacyGetListEntry.IsEnabled).
+	PrivacyStateAllotted PrivacyState = "ALLOTTED"
+	// PrivacyStateDiscard mirrors the documented getList category DISCARD: the
+	// subscription has been discarded.
+	PrivacyStateDiscard PrivacyState = "DISCARD"
+)
+
+// ClassifyPrivacyStatus maps a getList Status description onto a PrivacyState by
+// case-insensitive keyword matching against the documented getList ListType
+// category vocabulary (ALL | ALLOTED | FREE | DISCARD, line 1567).
+//
+// Because the doc enumerates no Status values, classification keys off the
+// free-text description rather than a fabricated code table:
+//   - a description containing "discard"               -> PrivacyStateDiscard;
+//   - a description containing "free" or "unallot"     -> PrivacyStateFree;
+//   - a description containing "allot", "enabled",
+//     "disabled" or "used"                             -> PrivacyStateAllotted;
+//   - anything else (including an empty description)    -> PrivacyStateUnknown.
+//
+// The enabled/disabled dimension is deliberately NOT collapsed into this state:
+// both an enabled and a disabled subscription are ALLOTTED. Read the on/off
+// state with DomainPrivacyGetListEntry.IsEnabled.
+func ClassifyPrivacyStatus(status string) PrivacyState {
+	normalized := strings.ToLower(strings.TrimSpace(status))
+	switch {
+	case normalized == "":
+		return PrivacyStateUnknown
+	case strings.Contains(normalized, "discard"):
+		return PrivacyStateDiscard
+	case strings.Contains(normalized, "free"), strings.Contains(normalized, "unallot"):
+		return PrivacyStateFree
+	case strings.Contains(normalized, "allot"),
+		strings.Contains(normalized, "enabled"),
+		strings.Contains(normalized, "disabled"),
+		strings.Contains(normalized, "used"):
+		return PrivacyStateAllotted
+	default:
+		return PrivacyStateUnknown
+	}
+}
+
+// IsAllotted reports whether the state is ALLOTTED (attached to a domain).
+func (s PrivacyState) IsAllotted() bool { return s == PrivacyStateAllotted }
+
+// IsFree reports whether the state is FREE (unallotted and available to attach).
+func (s PrivacyState) IsFree() bool { return s == PrivacyStateFree }
+
+// ErrNoFreePrivacySubscription is returned by EnsureEnabledWithContext when the
+// account holds no FREE (unallotted) domain-privacy subscription to allot to the
+// requested domain and none is already attached to it. It is a client-side
+// sentinel (not an *APIError); match it with errors.Is:
+//
+//	if errors.Is(err, namecheap.ErrNoFreePrivacySubscription) {
+//	    // buy privacy first (via domains.create free-privacy flag / account purchase)
+//	}
+var ErrNoFreePrivacySubscription = errors.New("no free (unallotted) domain privacy subscription available to allot")

--- a/namecheap/domainprivacy_allot.go
+++ b/namecheap/domainprivacy_allot.go
@@ -1,0 +1,81 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// DomainPrivacyAllotResponse is the raw envelope for
+// namecheap.whoisguard.allot.
+type DomainPrivacyAllotResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *DomainPrivacyAllotCommandResponse `xml:"CommandResponse"`
+}
+
+// DomainPrivacyAllotCommandResponse wraps the allot result.
+type DomainPrivacyAllotCommandResponse struct {
+	Result *DomainPrivacyAllotResult `xml:"WhoisguardAllotResult"`
+}
+
+// DomainPrivacyAllotResult is the outcome of attaching a subscription to a
+// domain.
+//
+// Documented gap. allot is NOT documented in docs/namecheap-api-v2.md (only
+// changeemailaddress, enable, disable, getlist and renew are). Its request
+// contract (WhoisguardID + DomainName) and response are grounded in the real
+// Namecheap whoisguard API rather than the local doc; see AllotWithContext. The
+// response is modeled minimally on the field the real command returns.
+type DomainPrivacyAllotResult struct {
+	// IsSuccess reports whether the subscription was attached successfully.
+	IsSuccess *bool `xml:"IsSuccess,attr"`
+}
+
+// AllotWithContext attaches (allots) the privacy subscription identified by
+// privacyID to domain. Allot is the "attach" half of the attach-vs-activate
+// distinction: it associates a subscription with a domain but does not turn
+// protection on — call EnableWithContext (or EnsureEnabledWithContext) to
+// activate it.
+//
+// Documented gap (grounded, not fabricated). allot is not present in
+// docs/namecheap-api-v2.md; the wire command (namecheap.whoisguard.allot) and
+// its required parameters (WhoisguardID + DomainName) are grounded in the real
+// Namecheap whoisguard API. This gap is flagged here, in DomainPrivacyAllotResult
+// and in README.md, following the same "don't fabricate silently" principle used
+// for the SSL DCV tokens and transfer status codes.
+//
+// It is an idempotent mutation (re-attaching to the same domain is harmless) and
+// retries on transient failures. Missing required arguments (privacyID < 1 or an
+// empty domain) are reported together as an *InvalidArgumentsError before any
+// request is sent.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/whoisguard/allot/
+func (dps *DomainPrivacyService) AllotWithContext(ctx context.Context, privacyID int, domain string) (*DomainPrivacyAllotCommandResponse, error) {
+	missing := make([]string, 0, 2)
+	if privacyID < 1 {
+		missing = append(missing, "WhoisguardID")
+	}
+	if domain == "" {
+		missing = append(missing, "DomainName")
+	}
+	if len(missing) > 0 {
+		return nil, &InvalidArgumentsError{Fields: missing}
+	}
+
+	params := map[string]string{
+		"Command":      "namecheap.whoisguard.allot",
+		"WhoisguardID": strconv.Itoa(privacyID),
+		"DomainName":   domain,
+	}
+
+	var response DomainPrivacyAllotResponse
+	_, err := dps.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/domainprivacy_allot_test.go
+++ b/namecheap/domainprivacy_allot_test.go
@@ -1,0 +1,90 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const domainPrivacyAllotOKResponse = `
+	<?xml version="1.0" encoding="utf-8"?>
+	<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+		<Errors />
+		<CommandResponse Type="namecheap.whoisguard.allot">
+			<WhoisguardAllotResult IsSuccess="true" />
+		</CommandResponse>
+	</ApiResponse>
+`
+
+func TestDomainPrivacyService_Allot(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse_and_command", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = writer.Write([]byte(domainPrivacyAllotOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.DomainPrivacy.AllotWithContext(context.Background(), 53538, "example.com")
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.whoisguard.allot", sentBody.Get("Command"))
+		assert.Equal(t, "53538", sentBody.Get("WhoisguardID"))
+		assert.Equal(t, "example.com", sentBody.Get("DomainName"))
+		assert.True(t, *resp.Result.IsSuccess)
+	})
+
+	t.Run("missing_required_fields_reported_all_at_once_no_http", func(t *testing.T) {
+		t.Parallel()
+		var called int32
+		mockServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&called, 1)
+			t.Errorf("server must not be called when validation fails")
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainPrivacy.AllotWithContext(context.Background(), 0, "")
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "WhoisguardID")
+			assert.Contains(t, argErr.Fields, "DomainName")
+		}
+		assert.Equal(t, int32(0), atomic.LoadInt32(&called))
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(apiErrorXML(2016166, "Domain is not associated with your account")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainPrivacy.AllotWithContext(context.Background(), 53538, "example.com")
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2016166, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/domainprivacy_change_email_address.go
+++ b/namecheap/domainprivacy_change_email_address.go
@@ -1,0 +1,69 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// DomainPrivacyChangeEmailAddressResponse is the raw envelope for
+// namecheap.whoisguard.changeemailaddress.
+type DomainPrivacyChangeEmailAddressResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *DomainPrivacyChangeEmailAddressCommandResponse `xml:"CommandResponse"`
+}
+
+// DomainPrivacyChangeEmailAddressCommandResponse wraps the changeEmailAddress
+// result.
+type DomainPrivacyChangeEmailAddressCommandResponse struct {
+	Result *DomainPrivacyChangeEmailAddressResult `xml:"WhoisguardChangeEmailAddressResult"`
+}
+
+// DomainPrivacyChangeEmailAddressResult is the outcome of changing the privacy
+// email address. Fields follow the changeemailaddress response table in
+// docs/namecheap-api-v2.md (lines 1500-1505): ID, IsSuccess, WGEmail and
+// WGOldEmail.
+type DomainPrivacyChangeEmailAddressResult struct {
+	// ID is the unique integer identifying the subscription. Typed int.
+	ID *int `xml:"ID,attr"`
+	// IsSuccess reports whether the email address was changed successfully.
+	IsSuccess *bool `xml:"IsSuccess,attr"`
+	// WGEmail is the new privacy email address.
+	WGEmail *string `xml:"WGEmail,attr"`
+	// WGOldEmail is the previous privacy email address.
+	WGOldEmail *string `xml:"WGOldEmail,attr"`
+}
+
+// ChangeEmailAddressWithContext rotates the domain-privacy email address for the
+// subscription identified by privacyID (docs/namecheap-api-v2.md lines
+// 1485-1506; req WhoisguardID only). The API chooses the new address itself and
+// returns both the new (WGEmail) and previous (WGOldEmail) values in the
+// response; there is no email argument on this command.
+//
+// It is an idempotent mutation and retries on transient failures. A privacyID
+// below 1 is reported as an *InvalidArgumentsError before any request is sent.
+//
+// Wire command: namecheap.whoisguard.changeemailaddress.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/whoisguard/change-email-address/
+func (dps *DomainPrivacyService) ChangeEmailAddressWithContext(ctx context.Context, privacyID int) (*DomainPrivacyChangeEmailAddressCommandResponse, error) {
+	if privacyID < 1 {
+		return nil, &InvalidArgumentsError{Fields: []string{"WhoisguardID"}, Reason: "WhoisguardID must be a positive integer"}
+	}
+
+	params := map[string]string{
+		"Command":      "namecheap.whoisguard.changeemailaddress",
+		"WhoisguardID": strconv.Itoa(privacyID),
+	}
+
+	var response DomainPrivacyChangeEmailAddressResponse
+	_, err := dps.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/domainprivacy_change_email_address_test.go
+++ b/namecheap/domainprivacy_change_email_address_test.go
@@ -1,0 +1,93 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const domainPrivacyChangeEmailOKResponse = `
+	<?xml version="1.0" encoding="utf-8"?>
+	<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+		<Errors />
+		<CommandResponse Type="namecheap.whoisguard.changeemailaddress">
+			<WhoisguardChangeEmailAddressResult ID="53536" IsSuccess="true" WGEmail="[email protected]" WGOldEmail="[email protected]" />
+		</CommandResponse>
+	</ApiResponse>
+`
+
+func TestDomainPrivacyService_ChangeEmailAddress(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse_and_command", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = writer.Write([]byte(domainPrivacyChangeEmailOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.DomainPrivacy.ChangeEmailAddressWithContext(context.Background(), 53536)
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.whoisguard.changeemailaddress", sentBody.Get("Command"))
+		assert.Equal(t, "53536", sentBody.Get("WhoisguardID"))
+
+		result := resp.Result
+		assert.Equal(t, 53536, *result.ID)
+		assert.True(t, *result.IsSuccess)
+		assert.Equal(t, "[email protected]", *result.WGEmail)
+		assert.Equal(t, "[email protected]", *result.WGOldEmail)
+	})
+
+	t.Run("invalid_id_no_http", func(t *testing.T) {
+		t.Parallel()
+		var called int32
+		mockServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&called, 1)
+			t.Errorf("server must not be called when validation fails")
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainPrivacy.ChangeEmailAddressWithContext(context.Background(), 0)
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "WhoisguardID")
+		}
+		assert.Equal(t, int32(0), atomic.LoadInt32(&called))
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(apiErrorXML(2019166, "Domain not found")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainPrivacy.ChangeEmailAddressWithContext(context.Background(), 53536)
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2019166, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/domainprivacy_disable.go
+++ b/namecheap/domainprivacy_disable.go
@@ -1,0 +1,64 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// DomainPrivacyDisableResponse is the raw envelope for
+// namecheap.whoisguard.disable.
+type DomainPrivacyDisableResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *DomainPrivacyDisableCommandResponse `xml:"CommandResponse"`
+}
+
+// DomainPrivacyDisableCommandResponse wraps the disable result.
+type DomainPrivacyDisableCommandResponse struct {
+	Result *DomainPrivacyDisableResult `xml:"WhoisguardDisableResult"`
+}
+
+// DomainPrivacyDisableResult is the outcome of disabling privacy. Fields follow
+// the disable response table in docs/namecheap-api-v2.md (lines 1545-1548): the
+// doc's "Domainname" column and IsSuccess. It is modeled as the idiomatic
+// DomainName wire attribute.
+type DomainPrivacyDisableResult struct {
+	// DomainName is the domain associated with the subscription. Doc column
+	// "Domainname".
+	DomainName *string `xml:"DomainName,attr"`
+	// IsSuccess reports whether privacy was disabled successfully.
+	IsSuccess *bool `xml:"IsSuccess,attr"`
+}
+
+// DisableWithContext turns off domain-privacy protection for the subscription
+// identified by privacyID (docs/namecheap-api-v2.md lines 1530-1549; req
+// WhoisguardID). The subscription stays attached to its domain — disable only
+// toggles protection off, it does not detach (that is UnallotWithContext).
+//
+// It is an idempotent mutation and retries on transient failures. A privacyID
+// below 1 is reported as an *InvalidArgumentsError before any request is sent.
+//
+// Wire command: namecheap.whoisguard.disable.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/whoisguard/disable/
+func (dps *DomainPrivacyService) DisableWithContext(ctx context.Context, privacyID int) (*DomainPrivacyDisableCommandResponse, error) {
+	if privacyID < 1 {
+		return nil, &InvalidArgumentsError{Fields: []string{"WhoisguardID"}, Reason: "WhoisguardID must be a positive integer"}
+	}
+
+	params := map[string]string{
+		"Command":      "namecheap.whoisguard.disable",
+		"WhoisguardID": strconv.Itoa(privacyID),
+	}
+
+	var response DomainPrivacyDisableResponse
+	_, err := dps.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/domainprivacy_disable_test.go
+++ b/namecheap/domainprivacy_disable_test.go
@@ -1,0 +1,89 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const domainPrivacyDisableOKResponse = `
+	<?xml version="1.0" encoding="utf-8"?>
+	<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+		<Errors />
+		<CommandResponse Type="namecheap.whoisguard.disable">
+			<WhoisguardDisableResult DomainName="example.com" IsSuccess="true" />
+		</CommandResponse>
+	</ApiResponse>
+`
+
+func TestDomainPrivacyService_Disable(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse_and_command", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = writer.Write([]byte(domainPrivacyDisableOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.DomainPrivacy.DisableWithContext(context.Background(), 53536)
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.whoisguard.disable", sentBody.Get("Command"))
+		assert.Equal(t, "53536", sentBody.Get("WhoisguardID"))
+		assert.Equal(t, "example.com", *resp.Result.DomainName)
+		assert.True(t, *resp.Result.IsSuccess)
+	})
+
+	t.Run("invalid_id_no_http", func(t *testing.T) {
+		t.Parallel()
+		var called int32
+		mockServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&called, 1)
+			t.Errorf("server must not be called when validation fails")
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainPrivacy.DisableWithContext(context.Background(), 0)
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "WhoisguardID")
+		}
+		assert.Equal(t, int32(0), atomic.LoadInt32(&called))
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(apiErrorXML(2019166, "Domain not found")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainPrivacy.DisableWithContext(context.Background(), 53536)
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2019166, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/domainprivacy_discard.go
+++ b/namecheap/domainprivacy_discard.go
@@ -1,0 +1,78 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// DomainPrivacyDiscardResponse is the raw envelope for
+// namecheap.whoisguard.discard.
+type DomainPrivacyDiscardResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *DomainPrivacyDiscardCommandResponse `xml:"CommandResponse"`
+}
+
+// DomainPrivacyDiscardCommandResponse wraps the discard result.
+type DomainPrivacyDiscardCommandResponse struct {
+	Result *DomainPrivacyDiscardResult `xml:"WhoisguardDiscardResult"`
+}
+
+// DomainPrivacyDiscardResult is the outcome of discarding a subscription.
+//
+// Documented gap. discard is NOT documented in docs/namecheap-api-v2.md; its
+// request contract (WhoisguardID) and response are grounded in the real
+// Namecheap whoisguard API, not the local doc. See DiscardWithContext.
+type DomainPrivacyDiscardResult struct {
+	// IsSuccess reports whether the subscription was discarded successfully.
+	IsSuccess *bool `xml:"IsSuccess,attr"`
+}
+
+// DiscardWithContext throws away the unused privacy subscription identified by
+// privacyID.
+//
+// DESTRUCTIVE. Discard permanently gives up an unused (unallotted) subscription;
+// it is gone afterwards and cannot be re-allotted. To merely detach a
+// subscription and keep it for reuse, use UnallotWithContext instead. There is
+// no client-side confirmation prompt (SDKs do not prompt) — the method name and
+// this warning are the safeguard.
+//
+// Non-idempotent. Because discarding is destructive and sits close to the
+// account's paid-subscription accounting, an ambiguous transport/server failure
+// might have already discarded the subscription; a blind resend could then throw
+// away a *different* one. This call therefore uses the non-idempotent transport
+// path (doXML(..., false)), exactly like domains.create: only Namecheap's
+// pre-execution HTTP 405 rate-limit signal is retried, and any ambiguous failure
+// is surfaced to the caller to reconcile rather than resent.
+//
+// Documented gap (grounded, not fabricated). discard is not present in
+// docs/namecheap-api-v2.md; the wire command (namecheap.whoisguard.discard) and
+// its required parameter (WhoisguardID) are grounded in the real Namecheap
+// whoisguard API. This gap is flagged here and in README.md.
+//
+// A privacyID below 1 is reported as an *InvalidArgumentsError before any request
+// is sent.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/whoisguard/discard/
+func (dps *DomainPrivacyService) DiscardWithContext(ctx context.Context, privacyID int) (*DomainPrivacyDiscardCommandResponse, error) {
+	if privacyID < 1 {
+		return nil, &InvalidArgumentsError{Fields: []string{"WhoisguardID"}, Reason: "WhoisguardID must be a positive integer"}
+	}
+
+	params := map[string]string{
+		"Command":      "namecheap.whoisguard.discard",
+		"WhoisguardID": strconv.Itoa(privacyID),
+	}
+
+	var response DomainPrivacyDiscardResponse
+	// idempotent=false: a destructive call must never be resent on an ambiguous error.
+	_, err := dps.client.doXML(ctx, params, &response, false)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/domainprivacy_discard_test.go
+++ b/namecheap/domainprivacy_discard_test.go
@@ -1,0 +1,127 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const domainPrivacyDiscardOKResponse = `
+	<?xml version="1.0" encoding="utf-8"?>
+	<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+		<Errors />
+		<CommandResponse Type="namecheap.whoisguard.discard">
+			<WhoisguardDiscardResult IsSuccess="true" />
+		</CommandResponse>
+	</ApiResponse>
+`
+
+func TestDomainPrivacyService_Discard(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse_and_command", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = writer.Write([]byte(domainPrivacyDiscardOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.DomainPrivacy.DiscardWithContext(context.Background(), 53538)
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.whoisguard.discard", sentBody.Get("Command"))
+		assert.Equal(t, "53538", sentBody.Get("WhoisguardID"))
+		assert.True(t, *resp.Result.IsSuccess)
+	})
+
+	t.Run("invalid_id_no_http", func(t *testing.T) {
+		t.Parallel()
+		var called int32
+		mockServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&called, 1)
+			t.Errorf("server must not be called when validation fails")
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainPrivacy.DiscardWithContext(context.Background(), 0)
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "WhoisguardID")
+		}
+		assert.Equal(t, int32(0), atomic.LoadInt32(&called))
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(apiErrorXML(2019166, "Domain not found")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainPrivacy.DiscardWithContext(context.Background(), 53538)
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2019166, apiErr.Number)
+		}
+	})
+
+	// Discard is destructive and non-idempotent: an ambiguous server-side error
+	// must not be retried, exactly like domains.create.
+	t.Run("non_idempotent_no_retry_on_server_error", func(t *testing.T) {
+		t.Parallel()
+		var calls int32
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&calls, 1)
+			_, _ = writer.Write([]byte(apiErrorXML(5050900, "Server exception")))
+		}))
+		defer mockServer.Close()
+
+		client := newResilienceClient(mockServer.URL, func(o *ClientOptions) {
+			o.RateLimit = &RateLimitOptions{Disabled: true}
+			o.Retry = &RetryOptions{MaxAttempts: 4, BaseDelay: time.Millisecond, MaxDelay: 2 * time.Millisecond}
+		})
+
+		_, err := client.DomainPrivacy.DiscardWithContext(context.Background(), 53538)
+		var apiErr *APIError
+		assert.True(t, errors.As(err, &apiErr))
+		assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "a destructive discard must not be retried on an ambiguous server error")
+		assert.NotContains(t, err.Error(), "after")
+	})
+
+	// The same no-retry guarantee for an ambiguous transport timeout.
+	t.Run("non_idempotent_no_retry_on_transport_timeout", func(t *testing.T) {
+		t.Parallel()
+		rt := &countingErrRT{err: timeoutError{}}
+		client := newResilienceClient("http://example.invalid", func(o *ClientOptions) {
+			o.Transport = rt
+			o.RateLimit = &RateLimitOptions{Disabled: true}
+			o.Retry = &RetryOptions{MaxAttempts: 4, BaseDelay: time.Millisecond, MaxDelay: 2 * time.Millisecond}
+		})
+
+		_, err := client.DomainPrivacy.DiscardWithContext(context.Background(), 53538)
+		assert.Error(t, err)
+		assert.Equal(t, 1, rt.count(), "an ambiguous timeout must not be retried on a destructive discard")
+	})
+}

--- a/namecheap/domainprivacy_enable.go
+++ b/namecheap/domainprivacy_enable.go
@@ -1,0 +1,73 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// DomainPrivacyEnableResponse is the raw envelope for
+// namecheap.whoisguard.enable.
+type DomainPrivacyEnableResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *DomainPrivacyEnableCommandResponse `xml:"CommandResponse"`
+}
+
+// DomainPrivacyEnableCommandResponse wraps the enable result.
+type DomainPrivacyEnableCommandResponse struct {
+	Result *DomainPrivacyEnableResult `xml:"WhoisguardEnableResult"`
+}
+
+// DomainPrivacyEnableResult is the outcome of enabling privacy. Fields follow
+// the enable response table in docs/namecheap-api-v2.md (lines 1524-1527):
+// DomainName and IsSuccess.
+type DomainPrivacyEnableResult struct {
+	// DomainName is the domain for which privacy was enabled.
+	DomainName *string `xml:"DomainName,attr"`
+	// IsSuccess reports whether privacy was enabled successfully.
+	IsSuccess *bool `xml:"IsSuccess,attr"`
+}
+
+// EnableWithContext turns on domain-privacy protection for the subscription
+// identified by privacyID and sets forwardedToEmail as the address privacy
+// emails are forwarded to. Per docs/namecheap-api-v2.md (lines 1508-1528) BOTH
+// WhoisguardID and ForwardedToEmail are required; note that enable takes a
+// forwarding EMAIL address, not a domain.
+//
+// It is an idempotent mutation (turning privacy on again is harmless) and
+// retries on transient failures. Missing required arguments (privacyID < 1 or an
+// empty forwardedToEmail) are reported together as an *InvalidArgumentsError
+// before any request is sent.
+//
+// Wire command: namecheap.whoisguard.enable.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/whoisguard/enable/
+func (dps *DomainPrivacyService) EnableWithContext(ctx context.Context, privacyID int, forwardedToEmail string) (*DomainPrivacyEnableCommandResponse, error) {
+	missing := make([]string, 0, 2)
+	if privacyID < 1 {
+		missing = append(missing, "WhoisguardID")
+	}
+	if forwardedToEmail == "" {
+		missing = append(missing, "ForwardedToEmail")
+	}
+	if len(missing) > 0 {
+		return nil, &InvalidArgumentsError{Fields: missing}
+	}
+
+	params := map[string]string{
+		"Command":          "namecheap.whoisguard.enable",
+		"WhoisguardID":     strconv.Itoa(privacyID),
+		"ForwardedToEmail": forwardedToEmail,
+	}
+
+	var response DomainPrivacyEnableResponse
+	_, err := dps.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/domainprivacy_enable_test.go
+++ b/namecheap/domainprivacy_enable_test.go
@@ -1,0 +1,92 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const domainPrivacyEnableOKResponse = `
+	<?xml version="1.0" encoding="utf-8"?>
+	<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+		<Errors />
+		<CommandResponse Type="namecheap.whoisguard.enable">
+			<WhoisguardEnableResult DomainName="example.com" IsSuccess="true" />
+		</CommandResponse>
+	</ApiResponse>
+`
+
+func TestDomainPrivacyService_Enable(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse_and_command", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = writer.Write([]byte(domainPrivacyEnableOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.DomainPrivacy.EnableWithContext(context.Background(), 53536, "[email protected]")
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.whoisguard.enable", sentBody.Get("Command"))
+		assert.Equal(t, "53536", sentBody.Get("WhoisguardID"))
+		assert.Equal(t, "[email protected]", sentBody.Get("ForwardedToEmail"))
+
+		assert.Equal(t, "example.com", *resp.Result.DomainName)
+		assert.True(t, *resp.Result.IsSuccess)
+	})
+
+	t.Run("missing_required_fields_reported_all_at_once_no_http", func(t *testing.T) {
+		t.Parallel()
+		var called int32
+		mockServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&called, 1)
+			t.Errorf("server must not be called when validation fails")
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainPrivacy.EnableWithContext(context.Background(), 0, "")
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "WhoisguardID")
+			assert.Contains(t, argErr.Fields, "ForwardedToEmail")
+		}
+		assert.Equal(t, int32(0), atomic.LoadInt32(&called))
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(apiErrorXML(2019166, "Domain not found")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainPrivacy.EnableWithContext(context.Background(), 53536, "[email protected]")
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2019166, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/domainprivacy_ensure_enabled.go
+++ b/namecheap/domainprivacy_ensure_enabled.go
@@ -1,0 +1,139 @@
+package namecheap
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// ensureEnabledPageSize is the page size EnsureEnabledWithContext requests so a
+// single getList call sees as many subscriptions as one page allows (the
+// documented maximum). It is not full pagination; see EnsureEnabledWithContext.
+const ensureEnabledPageSize = 100
+
+// EnsureEnabledAction reports which branch of the enable/allot state machine
+// EnsureEnabledWithContext took, so a caller can log or assert on the outcome.
+type EnsureEnabledAction string
+
+const (
+	// EnsureEnabledAlreadyEnabled means a subscription was already attached to the
+	// domain and already enabled; the call was a no-op.
+	EnsureEnabledAlreadyEnabled EnsureEnabledAction = "ALREADY_ENABLED"
+	// EnsureEnabledEnabled means a subscription was already attached to the domain
+	// but disabled, so it was enabled.
+	EnsureEnabledEnabled EnsureEnabledAction = "ENABLED"
+	// EnsureEnabledAllottedAndEnabled means a FREE subscription was allotted to the
+	// domain and then enabled.
+	EnsureEnabledAllottedAndEnabled EnsureEnabledAction = "ALLOTTED_AND_ENABLED"
+)
+
+// DomainPrivacyEnsureEnabledResult reports the outcome of
+// EnsureEnabledWithContext: which subscription ended up protecting the domain and
+// what the helper had to do to get there.
+type DomainPrivacyEnsureEnabledResult struct {
+	// PrivacyID is the subscription that now protects the domain.
+	PrivacyID int
+	// Domain is the domain that was requested.
+	Domain string
+	// Action is the branch the state machine took (see EnsureEnabledAction).
+	Action EnsureEnabledAction
+}
+
+// EnsureEnabledWithContext is a convenience helper for the common "just turn
+// privacy on for this domain" case. It composes the domain-privacy state machine
+// so callers do not have to reason about the attach-vs-activate distinction
+// themselves.
+//
+// The attach-vs-activate distinction. A privacy subscription must first be
+// ALLOTTED (attached) to a domain, and separately ENABLED (activated) with a
+// forwarding email. AllotWithContext does the first; EnableWithContext does the
+// second. This helper hides both behind one call.
+//
+// State machine. It reads the subscription list once (getList, ListType=ALL) and
+// then, depending on the domain's starting state:
+//
+//   - already attached and enabled  -> no-op (EnsureEnabledAlreadyEnabled);
+//   - attached but disabled         -> enable it (EnsureEnabledEnabled);
+//   - not attached, a FREE one exists -> allot it to the domain, then enable it
+//     (EnsureEnabledAllottedAndEnabled);
+//   - not attached, no FREE one     -> ErrNoFreePrivacySubscription.
+//
+// Scope. The read is a single page of up to ensureEnabledPageSize subscriptions
+// (not full pagination); an account with more subscriptions than one page may
+// need the lower-level primitives. domain and forwardedToEmail are required and
+// reported together as an *InvalidArgumentsError before any request is sent.
+// Each underlying mutation keeps its own retry semantics (allot and enable are
+// idempotent and retry on transient failures).
+func (dps *DomainPrivacyService) EnsureEnabledWithContext(ctx context.Context, domain, forwardedToEmail string) (*DomainPrivacyEnsureEnabledResult, error) {
+	missing := make([]string, 0, 2)
+	if domain == "" {
+		missing = append(missing, "DomainName")
+	}
+	if forwardedToEmail == "" {
+		missing = append(missing, "ForwardedToEmail")
+	}
+	if len(missing) > 0 {
+		return nil, &InvalidArgumentsError{Fields: missing}
+	}
+
+	list, err := dps.GetListWithContext(ctx, &DomainPrivacyGetListArgs{
+		ListType: String("ALL"),
+		Page:     Int(1),
+		PageSize: Int(ensureEnabledPageSize),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	target, free := findPrivacySubscription(list, domain)
+
+	// The domain already has a subscription attached.
+	if target != nil {
+		if target.ID == nil {
+			return nil, fmt.Errorf("domain privacy subscription for %q is missing its ID", domain)
+		}
+		if target.IsEnabled() {
+			return &DomainPrivacyEnsureEnabledResult{PrivacyID: *target.ID, Domain: domain, Action: EnsureEnabledAlreadyEnabled}, nil
+		}
+		if _, err := dps.EnableWithContext(ctx, *target.ID, forwardedToEmail); err != nil {
+			return nil, err
+		}
+		return &DomainPrivacyEnsureEnabledResult{PrivacyID: *target.ID, Domain: domain, Action: EnsureEnabledEnabled}, nil
+	}
+
+	// No subscription for the domain yet: allot a free one, then enable it.
+	if free == nil || free.ID == nil {
+		return nil, ErrNoFreePrivacySubscription
+	}
+	if _, err := dps.AllotWithContext(ctx, *free.ID, domain); err != nil {
+		return nil, err
+	}
+	if _, err := dps.EnableWithContext(ctx, *free.ID, forwardedToEmail); err != nil {
+		return nil, err
+	}
+	return &DomainPrivacyEnsureEnabledResult{PrivacyID: *free.ID, Domain: domain, Action: EnsureEnabledAllottedAndEnabled}, nil
+}
+
+// findPrivacySubscription scans a getList response for the subscription already
+// attached to domain (target) and, failing that, the first FREE subscription
+// available to allot (free). DISCARD entries are ignored entirely. Either return
+// may be nil.
+func findPrivacySubscription(list *DomainPrivacyGetListCommandResponse, domain string) (target, free *DomainPrivacyGetListEntry) {
+	if list == nil || list.DomainPrivacyList == nil {
+		return nil, nil
+	}
+	entries := *list.DomainPrivacyList
+	for i := range entries {
+		entry := &entries[i]
+		if entry.State() == PrivacyStateDiscard {
+			continue
+		}
+		if entry.DomainName != nil && strings.EqualFold(*entry.DomainName, domain) {
+			return entry, nil
+		}
+		if free == nil && entry.State() == PrivacyStateFree {
+			free = entry
+		}
+	}
+	return nil, free
+}

--- a/namecheap/domainprivacy_ensure_enabled_test.go
+++ b/namecheap/domainprivacy_ensure_enabled_test.go
@@ -1,0 +1,221 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// privacyRecorder records, per wire Command, how many times it was called and the
+// last request parameters it received. It backs the EnsureEnabled state-machine
+// mock sequence so a test can assert both the branch taken (call counts) and the
+// wire parameters (allot DomainName, enable ForwardedToEmail).
+type privacyRecorder struct {
+	mu    sync.Mutex
+	calls map[string]int
+	last  map[string]url.Values
+}
+
+func newPrivacyRecorder() *privacyRecorder {
+	return &privacyRecorder{calls: map[string]int{}, last: map[string]url.Values{}}
+}
+
+func (r *privacyRecorder) record(cmd string, v url.Values) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls[cmd]++
+	r.last[cmd] = v
+}
+
+func (r *privacyRecorder) count(cmd string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls[cmd]
+}
+
+func (r *privacyRecorder) lastOf(cmd string) url.Values {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.last[cmd]
+}
+
+// privacyGetListXML builds a getList OK response from raw <Whoisguard/> rows.
+func privacyGetListXML(rows string) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+		<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+			<Errors />
+			<CommandResponse Type="namecheap.whoisguard.getlist">
+				<WhoisguardGetListResult>%s</WhoisguardGetListResult>
+				<Paging><TotalItems>1</TotalItems><CurrentPage>1</CurrentPage><PageSize>100</PageSize></Paging>
+			</CommandResponse>
+		</ApiResponse>`, rows)
+}
+
+// ensureEnabledDispatchServer returns a mock server that dispatches on the wire
+// Command: getList returns getListBody; allot and enable return canned OK bodies.
+// Every call is recorded so the state machine's path is assertable.
+func ensureEnabledDispatchServer(t *testing.T, rec *privacyRecorder, getListBody string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		vals, _ := url.ParseQuery(string(body))
+		cmd := vals.Get("Command")
+		rec.record(cmd, vals)
+		switch cmd {
+		case "namecheap.whoisguard.getlist":
+			_, _ = w.Write([]byte(getListBody))
+		case "namecheap.whoisguard.allot":
+			_, _ = w.Write([]byte(domainPrivacyAllotOKResponse))
+		case "namecheap.whoisguard.enable":
+			_, _ = w.Write([]byte(domainPrivacyEnableOKResponse))
+		default:
+			t.Errorf("unexpected command on the wire: %q", cmd)
+			_, _ = w.Write([]byte(apiErrorXML(9999, "unexpected command")))
+		}
+	}))
+}
+
+func TestDomainPrivacyService_EnsureEnabled(t *testing.T) {
+	t.Parallel()
+
+	const (
+		domain = "example.com"
+		fwd    = "[email protected]"
+	)
+
+	cases := []struct {
+		name         string
+		rows         string
+		wantAction   EnsureEnabledAction
+		wantID       int
+		wantAllot    int // expected allot call count
+		wantEnable   int // expected enable call count
+		wantErrIsNFS bool
+	}{
+		{
+			name:       "unallotted_free_gets_allotted_then_enabled",
+			rows:       `<Whoisguard ID="1001" DomainName="" Created="01/01/2024" Expires="01/01/2025" Status="FREE" />`,
+			wantAction: EnsureEnabledAllottedAndEnabled,
+			wantID:     1001,
+			wantAllot:  1,
+			wantEnable: 1,
+		},
+		{
+			name:       "allotted_but_disabled_gets_enabled",
+			rows:       `<Whoisguard ID="2002" DomainName="example.com" Created="01/01/2024" Expires="01/01/2025" Status="DISABLED" />`,
+			wantAction: EnsureEnabledEnabled,
+			wantID:     2002,
+			wantAllot:  0,
+			wantEnable: 1,
+		},
+		{
+			name:       "already_enabled_is_noop",
+			rows:       `<Whoisguard ID="3003" DomainName="example.com" Created="01/01/2024" Expires="01/01/2025" Status="ENABLED" />`,
+			wantAction: EnsureEnabledAlreadyEnabled,
+			wantID:     3003,
+			wantAllot:  0,
+			wantEnable: 0,
+		},
+		{
+			name:         "no_free_subscription_returns_typed_error",
+			rows:         `<Whoisguard ID="4004" DomainName="other.com" Created="01/01/2024" Expires="01/01/2025" Status="ENABLED" />`,
+			wantErrIsNFS: true,
+			wantAllot:    0,
+			wantEnable:   0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rec := newPrivacyRecorder()
+			server := ensureEnabledDispatchServer(t, rec, privacyGetListXML(tc.rows))
+			defer server.Close()
+
+			client := setupClient(nil)
+			client.BaseURL = server.URL
+
+			res, err := client.DomainPrivacy.EnsureEnabledWithContext(context.Background(), domain, fwd)
+
+			if tc.wantErrIsNFS {
+				assert.Nil(t, res)
+				assert.True(t, errors.Is(err, ErrNoFreePrivacySubscription), "want ErrNoFreePrivacySubscription, got %v", err)
+			} else {
+				assert.NoError(t, err)
+				if assert.NotNil(t, res) {
+					assert.Equal(t, tc.wantAction, res.Action)
+					assert.Equal(t, tc.wantID, res.PrivacyID)
+					assert.Equal(t, domain, res.Domain)
+				}
+			}
+
+			// getList is always read exactly once.
+			assert.Equal(t, 1, rec.count("namecheap.whoisguard.getlist"))
+			assert.Equal(t, tc.wantAllot, rec.count("namecheap.whoisguard.allot"), "allot call count")
+			assert.Equal(t, tc.wantEnable, rec.count("namecheap.whoisguard.enable"), "enable call count")
+
+			// getList must request ListType=ALL and the documented max page size.
+			gl := rec.lastOf("namecheap.whoisguard.getlist")
+			assert.Equal(t, "ALL", gl.Get("ListType"))
+			assert.Equal(t, "100", gl.Get("PageSize"))
+
+			// When allot ran, it must carry the domain; when enable ran, the fwd email.
+			if tc.wantAllot > 0 {
+				al := rec.lastOf("namecheap.whoisguard.allot")
+				assert.Equal(t, domain, al.Get("DomainName"))
+				assert.Equal(t, fmt.Sprintf("%d", tc.wantID), al.Get("WhoisguardID"))
+			}
+			if tc.wantEnable > 0 {
+				en := rec.lastOf("namecheap.whoisguard.enable")
+				assert.Equal(t, fwd, en.Get("ForwardedToEmail"))
+				assert.Equal(t, fmt.Sprintf("%d", tc.wantID), en.Get("WhoisguardID"))
+			}
+		})
+	}
+}
+
+func TestDomainPrivacyService_EnsureEnabled_Validation(t *testing.T) {
+	t.Parallel()
+
+	client := setupClient(nil)
+	client.BaseURL = "http://127.0.0.1:0"
+
+	_, err := client.DomainPrivacy.EnsureEnabledWithContext(context.Background(), "", "")
+	var argErr *InvalidArgumentsError
+	if assert.True(t, errors.As(err, &argErr)) {
+		assert.Contains(t, argErr.Fields, "DomainName")
+		assert.Contains(t, argErr.Fields, "ForwardedToEmail")
+	}
+}
+
+// TestDomainPrivacyService_EnsureEnabled_GetListError proves a getList failure
+// short-circuits the state machine before any mutation.
+func TestDomainPrivacyService_EnsureEnabled_GetListError(t *testing.T) {
+	t.Parallel()
+	rec := newPrivacyRecorder()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		vals, _ := url.ParseQuery(string(body))
+		rec.record(vals.Get("Command"), vals)
+		_, _ = w.Write([]byte(apiErrorXML(2019166, "Domain not found")))
+	}))
+	defer server.Close()
+
+	client := setupClient(nil)
+	client.BaseURL = server.URL
+
+	res, err := client.DomainPrivacy.EnsureEnabledWithContext(context.Background(), "example.com", "[email protected]")
+	assert.Nil(t, res)
+	var apiErr *APIError
+	assert.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, 0, rec.count("namecheap.whoisguard.allot"))
+	assert.Equal(t, 0, rec.count("namecheap.whoisguard.enable"))
+}

--- a/namecheap/domainprivacy_get_list.go
+++ b/namecheap/domainprivacy_get_list.go
@@ -1,0 +1,169 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// allowedPrivacyListTypeValues is the documented ListType filter vocabulary for
+// namecheap.whoisguard.getlist (docs/namecheap-api-v2.md line 1567). The
+// "ALLOTED" spelling is the API's own (nonstandard) token and is sent verbatim.
+var allowedPrivacyListTypeValues = []string{"ALL", "ALLOTED", "FREE", "DISCARD"}
+
+// DomainPrivacyGetListResponse is the raw envelope for
+// namecheap.whoisguard.getlist.
+type DomainPrivacyGetListResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *DomainPrivacyGetListCommandResponse `xml:"CommandResponse"`
+}
+
+// DomainPrivacyGetListCommandResponse wraps the getList result: the page of
+// subscriptions and the paging block.
+type DomainPrivacyGetListCommandResponse struct {
+	// DomainPrivacyList is the page of subscriptions returned. The wire element is
+	// the legacy <Whoisguard> row inside <WhoisguardGetListResult>.
+	DomainPrivacyList *[]DomainPrivacyGetListEntry `xml:"WhoisguardGetListResult>Whoisguard"`
+	// Paging is the standard Namecheap pagination block.
+	Paging *DomainPrivacyGetListPaging `xml:"Paging"`
+}
+
+// DomainPrivacyGetListPaging mirrors the standard Namecheap paging block.
+type DomainPrivacyGetListPaging struct {
+	TotalItems  *int `xml:"TotalItems"`
+	CurrentPage *int `xml:"CurrentPage"`
+	PageSize    *int `xml:"PageSize"`
+}
+
+// DomainPrivacyGetListEntry is a single domain-privacy subscription in a getList
+// page. Fields follow the getList response table in docs/namecheap-api-v2.md
+// (lines 1569-1575): the doc's "Whoisguard ID" column is the numeric ID (typed
+// int, not string), and its "Domainname" column is the domain the subscription
+// is attached to, modeled here as the idiomatic DomainName wire attribute.
+type DomainPrivacyGetListEntry struct {
+	// ID is the unique integer identifying the privacy subscription (the
+	// "WhoisguardID" the mutating commands take). Typed int, never a string.
+	ID *int `xml:"ID,attr"`
+	// DomainName is the domain the subscription is attached to; empty for a FREE
+	// (unallotted) subscription. Doc column "Domainname".
+	DomainName *string `xml:"DomainName,attr"`
+	// Created is the subscription creation date, exposed as the raw server string
+	// since the getList doc does not pin a format.
+	Created *string `xml:"Created,attr"`
+	// Expires is the subscription expiry date, exposed as the raw server string.
+	Expires *string `xml:"Expires,attr"`
+	// Status is the raw, verbatim subscription status. The doc does not enumerate
+	// its values; classify it with State (see PrivacyState) or read the on/off
+	// dimension with IsEnabled.
+	Status *string `xml:"Status,attr"`
+}
+
+// State classifies the entry's raw Status into a coarse PrivacyState (see
+// ClassifyPrivacyStatus). It returns PrivacyStateUnknown when Status is nil.
+func (e DomainPrivacyGetListEntry) State() PrivacyState {
+	if e.Status == nil {
+		return PrivacyStateUnknown
+	}
+	return ClassifyPrivacyStatus(*e.Status)
+}
+
+// IsEnabled reports whether the subscription's raw Status indicates privacy is
+// currently active. Because the doc does not enumerate Status values, this is a
+// keyword heuristic: it returns true when the (case-insensitive) status contains
+// "enabled" and false otherwise — notably false for "DISABLED", which does not
+// contain the substring "enabled". A subscription can be ALLOTTED (attached to a
+// domain) while IsEnabled is false; that is the "allotted-but-disabled" state
+// EnsureEnabledWithContext turns on.
+func (e DomainPrivacyGetListEntry) IsEnabled() bool {
+	if e.Status == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(strings.TrimSpace(*e.Status)), "enabled")
+}
+
+// DomainPrivacyGetListArgs are the arguments for GetListWithContext. Field names
+// and constraints follow the getList request table in docs/namecheap-api-v2.md
+// (lines 1559-1565). A nil arg (or a nil field) leaves the API default.
+type DomainPrivacyGetListArgs struct {
+	// ListType filters by category. Possible values: ALL, ALLOTED, FREE, DISCARD.
+	// Default: ALL.
+	ListType *string
+	// Page is the 1-based page to return. Default: 1.
+	Page *int
+	// PageSize is the number of subscriptions per page. Minimum 2, maximum 100.
+	PageSize *int
+}
+
+// GetListWithContext returns the account's domain-privacy subscriptions,
+// filtered and paged per args. It is an idempotent read and retries on transient
+// failures. When args is nil, no optional parameters are sent and the API
+// defaults apply.
+//
+// Wire command: namecheap.whoisguard.getlist.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/whoisguard/get-list/
+func (dps *DomainPrivacyService) GetListWithContext(ctx context.Context, args *DomainPrivacyGetListArgs) (*DomainPrivacyGetListCommandResponse, error) {
+	params := map[string]string{
+		"Command": "namecheap.whoisguard.getlist",
+	}
+
+	parsedArgs, err := parseDomainPrivacyGetListArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range parsedArgs {
+		params[k] = v
+	}
+
+	var response DomainPrivacyGetListResponse
+	_, err = dps.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}
+
+// parseDomainPrivacyGetListArgs validates the optional filter/paging arguments
+// and flattens them into request parameters.
+func parseDomainPrivacyGetListArgs(args *DomainPrivacyGetListArgs) (map[string]string, error) {
+	params := map[string]string{}
+	if args == nil {
+		return params, nil
+	}
+
+	if args.ListType != nil {
+		if !isValidPrivacyListType(*args.ListType) {
+			return nil, fmt.Errorf("invalid ListType value: %s", *args.ListType)
+		}
+		params["ListType"] = *args.ListType
+	}
+	if args.Page != nil {
+		if *args.Page < 1 {
+			return nil, fmt.Errorf("invalid Page value: %d, minimum value is 1", *args.Page)
+		}
+		params["Page"] = strconv.Itoa(*args.Page)
+	}
+	if args.PageSize != nil {
+		if *args.PageSize < 2 || *args.PageSize > 100 {
+			return nil, fmt.Errorf("invalid PageSize value: %d, minimum value is 2, and maximum value is 100", *args.PageSize)
+		}
+		params["PageSize"] = strconv.Itoa(*args.PageSize)
+	}
+
+	return params, nil
+}
+
+func isValidPrivacyListType(listType string) bool {
+	for _, value := range allowedPrivacyListTypeValues {
+		if listType == value {
+			return true
+		}
+	}
+	return false
+}

--- a/namecheap/domainprivacy_get_list_test.go
+++ b/namecheap/domainprivacy_get_list_test.go
@@ -1,0 +1,228 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const domainPrivacyGetListPage1Response = `
+	<?xml version="1.0" encoding="utf-8"?>
+	<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+		<Errors />
+		<RequestedCommand>namecheap.whoisguard.getlist</RequestedCommand>
+		<CommandResponse Type="namecheap.whoisguard.getlist">
+			<WhoisguardGetListResult>
+				<Whoisguard ID="53536" DomainName="alpha.com" Created="10/22/2023" Expires="10/22/2024" Status="ENABLED" />
+				<Whoisguard ID="53537" DomainName="beta.net" Created="11/01/2023" Expires="11/01/2024" Status="DISABLED" />
+				<Whoisguard ID="53538" DomainName="" Created="12/01/2023" Expires="12/01/2024" Status="FREE" />
+			</WhoisguardGetListResult>
+			<Paging>
+				<TotalItems>5</TotalItems>
+				<CurrentPage>1</CurrentPage>
+				<PageSize>3</PageSize>
+			</Paging>
+		</CommandResponse>
+	</ApiResponse>
+`
+
+const domainPrivacyGetListEmptyResponse = `
+	<?xml version="1.0" encoding="utf-8"?>
+	<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+		<Errors />
+		<RequestedCommand>namecheap.whoisguard.getlist</RequestedCommand>
+		<CommandResponse Type="namecheap.whoisguard.getlist">
+			<WhoisguardGetListResult />
+			<Paging>
+				<TotalItems>0</TotalItems>
+				<CurrentPage>1</CurrentPage>
+				<PageSize>20</PageSize>
+			</Paging>
+		</CommandResponse>
+	</ApiResponse>
+`
+
+func TestDomainPrivacyService_GetList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse_and_paging", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = writer.Write([]byte(domainPrivacyGetListPage1Response))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.DomainPrivacy.GetListWithContext(context.Background(), &DomainPrivacyGetListArgs{
+			ListType: String("ALL"),
+			Page:     Int(1),
+			PageSize: Int(3),
+		})
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.whoisguard.getlist", sentBody.Get("Command"))
+		assert.Equal(t, "ALL", sentBody.Get("ListType"))
+		assert.Equal(t, "1", sentBody.Get("Page"))
+		assert.Equal(t, "3", sentBody.Get("PageSize"))
+
+		entries := *resp.DomainPrivacyList
+		assert.Len(t, entries, 3)
+
+		// IDs are typed ints, never strings.
+		assert.Equal(t, 53536, *entries[0].ID)
+		assert.Equal(t, "alpha.com", *entries[0].DomainName)
+		assert.Equal(t, "10/22/2023", *entries[0].Created)
+		assert.Equal(t, "10/22/2024", *entries[0].Expires)
+		assert.Equal(t, "ENABLED", *entries[0].Status)
+		assert.Equal(t, PrivacyStateAllotted, entries[0].State())
+		assert.True(t, entries[0].IsEnabled())
+
+		assert.Equal(t, PrivacyStateAllotted, entries[1].State())
+		assert.False(t, entries[1].IsEnabled())
+
+		assert.Equal(t, 53538, *entries[2].ID)
+		assert.Equal(t, PrivacyStateFree, entries[2].State())
+
+		assert.Equal(t, 5, *resp.Paging.TotalItems)
+		assert.Equal(t, 1, *resp.Paging.CurrentPage)
+		assert.Equal(t, 3, *resp.Paging.PageSize)
+	})
+
+	t.Run("empty_list", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(domainPrivacyGetListEmptyResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.DomainPrivacy.GetListWithContext(context.Background(), &DomainPrivacyGetListArgs{ListType: String("FREE")})
+		assert.NoError(t, err)
+		// An empty <WhoisguardGetListResult/> yields a nil (or empty) list, not an error.
+		if resp.DomainPrivacyList != nil {
+			assert.Empty(t, *resp.DomainPrivacyList)
+		}
+		assert.Equal(t, 0, *resp.Paging.TotalItems)
+	})
+
+	t.Run("multi_page_paging_reflected", func(t *testing.T) {
+		t.Parallel()
+		// Page 2 fixture: paging block echoes the requested page, proving paging
+		// round-trips independently of the list contents.
+		page2 := `<?xml version="1.0" encoding="utf-8"?>
+			<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+				<Errors />
+				<CommandResponse Type="namecheap.whoisguard.getlist">
+					<WhoisguardGetListResult>
+						<Whoisguard ID="60001" DomainName="gamma.io" Created="01/02/2024" Expires="01/02/2025" Status="ENABLED" />
+						<Whoisguard ID="60002" DomainName="delta.dev" Created="01/03/2024" Expires="01/03/2025" Status="DISABLED" />
+					</WhoisguardGetListResult>
+					<Paging>
+						<TotalItems>5</TotalItems>
+						<CurrentPage>2</CurrentPage>
+						<PageSize>3</PageSize>
+					</Paging>
+				</CommandResponse>
+			</ApiResponse>`
+
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = writer.Write([]byte(page2))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.DomainPrivacy.GetListWithContext(context.Background(), &DomainPrivacyGetListArgs{Page: Int(2), PageSize: Int(3)})
+		assert.NoError(t, err)
+		assert.Equal(t, "2", sentBody.Get("Page"))
+		assert.Len(t, *resp.DomainPrivacyList, 2)
+		assert.Equal(t, 2, *resp.Paging.CurrentPage)
+		assert.Equal(t, 5, *resp.Paging.TotalItems)
+	})
+
+	t.Run("nil_args_sends_only_command", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = writer.Write([]byte(domainPrivacyGetListEmptyResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainPrivacy.GetListWithContext(context.Background(), nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "namecheap.whoisguard.getlist", sentBody.Get("Command"))
+		assert.Empty(t, sentBody.Get("ListType"))
+		assert.Empty(t, sentBody.Get("Page"))
+	})
+
+	t.Run("invalid_list_type_no_http", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "http://127.0.0.1:0"
+
+		_, err := client.DomainPrivacy.GetListWithContext(context.Background(), &DomainPrivacyGetListArgs{ListType: String("BOGUS")})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid ListType")
+	})
+
+	t.Run("invalid_page_no_http", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "http://127.0.0.1:0"
+
+		_, err := client.DomainPrivacy.GetListWithContext(context.Background(), &DomainPrivacyGetListArgs{Page: Int(0)})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid Page")
+	})
+
+	t.Run("invalid_page_size_no_http", func(t *testing.T) {
+		t.Parallel()
+		client := setupClient(nil)
+		client.BaseURL = "http://127.0.0.1:0"
+
+		_, err := client.DomainPrivacy.GetListWithContext(context.Background(), &DomainPrivacyGetListArgs{PageSize: Int(1)})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid PageSize")
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(apiErrorXML(2011170, "Some error")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainPrivacy.GetListWithContext(context.Background(), nil)
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2011170, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/domainprivacy_test.go
+++ b/namecheap/domainprivacy_test.go
@@ -1,0 +1,81 @@
+package namecheap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestClassifyPrivacyStatus table-tests the status classifier over
+// representative getList Status descriptions. The classifier is grounded in the
+// documented getList ListType vocabulary (ALL | ALLOTED | FREE | DISCARD); the
+// doc enumerates no Status values, so nothing here keys off a fabricated code
+// table.
+func TestClassifyPrivacyStatus(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		status string
+		want   PrivacyState
+	}{
+		{"empty", "", PrivacyStateUnknown},
+		{"whitespace_only", "   ", PrivacyStateUnknown},
+		{"free_upper", "FREE", PrivacyStateFree},
+		{"free_lower", "free", PrivacyStateFree},
+		{"unallotted", "Unallotted", PrivacyStateFree},
+		{"alloted_api_spelling", "ALLOTED", PrivacyStateAllotted},
+		{"allotted_proper_spelling", "Allotted", PrivacyStateAllotted},
+		{"enabled", "ENABLED", PrivacyStateAllotted},
+		{"disabled", "DISABLED", PrivacyStateAllotted},
+		{"used", "Used", PrivacyStateAllotted},
+		{"discard", "DISCARD", PrivacyStateDiscard},
+		{"discarded", "Discarded", PrivacyStateDiscard},
+		{"unrecognized", "something else", PrivacyStateUnknown},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, ClassifyPrivacyStatus(tc.status))
+		})
+	}
+}
+
+// TestPrivacyStateHelpers asserts the state-level predicates over every constant.
+func TestPrivacyStateHelpers(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, PrivacyStateAllotted.IsAllotted())
+	assert.False(t, PrivacyStateFree.IsAllotted())
+	assert.False(t, PrivacyStateDiscard.IsAllotted())
+	assert.False(t, PrivacyStateUnknown.IsAllotted())
+
+	assert.True(t, PrivacyStateFree.IsFree())
+	assert.False(t, PrivacyStateAllotted.IsFree())
+	assert.False(t, PrivacyStateDiscard.IsFree())
+	assert.False(t, PrivacyStateUnknown.IsFree())
+}
+
+// TestDomainPrivacyGetListEntryHelpers asserts the entry-level State/IsEnabled
+// helpers, including the disabled-vs-enabled distinction the EnsureEnabled state
+// machine depends on.
+func TestDomainPrivacyGetListEntryHelpers(t *testing.T) {
+	t.Parallel()
+
+	enabled := DomainPrivacyGetListEntry{Status: String("ENABLED"), DomainName: String("example.com")}
+	assert.Equal(t, PrivacyStateAllotted, enabled.State())
+	assert.True(t, enabled.IsEnabled())
+
+	disabled := DomainPrivacyGetListEntry{Status: String("DISABLED"), DomainName: String("example.com")}
+	assert.Equal(t, PrivacyStateAllotted, disabled.State())
+	assert.False(t, disabled.IsEnabled(), "'DISABLED' must not be read as enabled")
+
+	free := DomainPrivacyGetListEntry{Status: String("FREE")}
+	assert.Equal(t, PrivacyStateFree, free.State())
+	assert.False(t, free.IsEnabled())
+
+	nilStatus := DomainPrivacyGetListEntry{}
+	assert.Equal(t, PrivacyStateUnknown, nilStatus.State())
+	assert.False(t, nilStatus.IsEnabled())
+}

--- a/namecheap/domainprivacy_unallot.go
+++ b/namecheap/domainprivacy_unallot.go
@@ -1,0 +1,66 @@
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"strconv"
+)
+
+// DomainPrivacyUnallotResponse is the raw envelope for
+// namecheap.whoisguard.unallot.
+type DomainPrivacyUnallotResponse struct {
+	XMLName *xml.Name `xml:"ApiResponse"`
+	Errors  *[]struct {
+		Message *string `xml:",chardata"`
+		Number  *string `xml:"Number,attr"`
+	} `xml:"Errors>Error"`
+	CommandResponse *DomainPrivacyUnallotCommandResponse `xml:"CommandResponse"`
+}
+
+// DomainPrivacyUnallotCommandResponse wraps the unallot result.
+type DomainPrivacyUnallotCommandResponse struct {
+	Result *DomainPrivacyUnallotResult `xml:"WhoisguardUnallotResult"`
+}
+
+// DomainPrivacyUnallotResult is the outcome of detaching a subscription from its
+// domain.
+//
+// Documented gap. unallot is NOT documented in docs/namecheap-api-v2.md; its
+// request contract (WhoisguardID) and response are grounded in the real
+// Namecheap whoisguard API, not the local doc. See UnallotWithContext.
+type DomainPrivacyUnallotResult struct {
+	// IsSuccess reports whether the subscription was detached successfully.
+	IsSuccess *bool `xml:"IsSuccess,attr"`
+}
+
+// UnallotWithContext detaches (unallots) the privacy subscription identified by
+// privacyID from the domain it is attached to, returning it to the FREE pool so
+// it can be re-allotted elsewhere. Unlike DiscardWithContext, unallot keeps the
+// subscription — it is the reverse of AllotWithContext.
+//
+// Documented gap (grounded, not fabricated). unallot is not present in
+// docs/namecheap-api-v2.md; the wire command (namecheap.whoisguard.unallot) and
+// its required parameter (WhoisguardID) are grounded in the real Namecheap
+// whoisguard API. This gap is flagged here and in README.md.
+//
+// It is an idempotent mutation and retries on transient failures. A privacyID
+// below 1 is reported as an *InvalidArgumentsError before any request is sent.
+//
+// Namecheap doc: https://www.namecheap.com/support/api/methods/whoisguard/unallot/
+func (dps *DomainPrivacyService) UnallotWithContext(ctx context.Context, privacyID int) (*DomainPrivacyUnallotCommandResponse, error) {
+	if privacyID < 1 {
+		return nil, &InvalidArgumentsError{Fields: []string{"WhoisguardID"}, Reason: "WhoisguardID must be a positive integer"}
+	}
+
+	params := map[string]string{
+		"Command":      "namecheap.whoisguard.unallot",
+		"WhoisguardID": strconv.Itoa(privacyID),
+	}
+
+	var response DomainPrivacyUnallotResponse
+	_, err := dps.client.DoXMLWithContext(ctx, params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.CommandResponse, nil
+}

--- a/namecheap/domainprivacy_unallot_test.go
+++ b/namecheap/domainprivacy_unallot_test.go
@@ -1,0 +1,88 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const domainPrivacyUnallotOKResponse = `
+	<?xml version="1.0" encoding="utf-8"?>
+	<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+		<Errors />
+		<CommandResponse Type="namecheap.whoisguard.unallot">
+			<WhoisguardUnallotResult IsSuccess="true" />
+		</CommandResponse>
+	</ApiResponse>
+`
+
+func TestDomainPrivacyService_Unallot(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success_parse_and_command", func(t *testing.T) {
+		t.Parallel()
+		var sentBody url.Values
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			body, _ := io.ReadAll(request.Body)
+			sentBody, _ = url.ParseQuery(string(body))
+			_, _ = writer.Write([]byte(domainPrivacyUnallotOKResponse))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		resp, err := client.DomainPrivacy.UnallotWithContext(context.Background(), 53538)
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		assert.Equal(t, "namecheap.whoisguard.unallot", sentBody.Get("Command"))
+		assert.Equal(t, "53538", sentBody.Get("WhoisguardID"))
+		assert.True(t, *resp.Result.IsSuccess)
+	})
+
+	t.Run("invalid_id_no_http", func(t *testing.T) {
+		t.Parallel()
+		var called int32
+		mockServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&called, 1)
+			t.Errorf("server must not be called when validation fails")
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainPrivacy.UnallotWithContext(context.Background(), -1)
+		var argErr *InvalidArgumentsError
+		if assert.True(t, errors.As(err, &argErr)) {
+			assert.Contains(t, argErr.Fields, "WhoisguardID")
+		}
+		assert.Equal(t, int32(0), atomic.LoadInt32(&called))
+	})
+
+	t.Run("api_error_mapped_to_APIError", func(t *testing.T) {
+		t.Parallel()
+		mockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(apiErrorXML(2019166, "Domain not found")))
+		}))
+		defer mockServer.Close()
+
+		client := setupClient(nil)
+		client.BaseURL = mockServer.URL
+
+		_, err := client.DomainPrivacy.UnallotWithContext(context.Background(), 53538)
+		var apiErr *APIError
+		if assert.True(t, errors.As(err, &apiErr)) {
+			assert.Equal(t, 2019166, apiErr.Number)
+		}
+	})
+}

--- a/namecheap/namecheap.go
+++ b/namecheap/namecheap.go
@@ -104,6 +104,12 @@ type Client struct {
 	UsersAddress *UsersAddressService
 
 	SSL *SSLService
+
+	// DomainPrivacy groups the domain-privacy commands. The service is named for
+	// the current product term ("domain privacy"), while the underlying API
+	// command strings still use the legacy "whoisguard" names. See
+	// DomainPrivacyService for the full name mapping.
+	DomainPrivacy *DomainPrivacyService
 }
 
 type service struct {
@@ -154,6 +160,7 @@ func NewClient(options *ClientOptions) *Client {
 	client.Users = (*UsersService)(&client.common)
 	client.UsersAddress = (*UsersAddressService)(&client.common)
 	client.SSL = (*SSLService)(&client.common)
+	client.DomainPrivacy = (*DomainPrivacyService)(&client.common)
 
 	return client
 }


### PR DESCRIPTION
Closes #118. Phase 2 coverage on the go-namecheap-sdk 2.0 roadmap (#122) — the natural companion to domains.create (#114): register a domain, then manage its privacy. Reuses the non-idempotent `doXML` path (#114) and the typed-status pattern (#115).

## What — new `DomainPrivacyService` (ctx-first, `WithContext` suffix)
Named for the current product term; command strings use the API's legacy `whoisguard.*` names (mapping documented). Privacy IDs are typed `int`.

`GetList` (ListType ALL/ALLOTED/FREE/DISCARD + paging) · `Enable` (WhoisguardID + ForwardedToEmail) · `Disable` · `Allot` · `Unallot` · `Discard` · `ChangeEmailAddress`.

- **`EnsureEnabled(ctx, domain, forwardedToEmail)`** composes the state machine getList → allot → enable (no-op if already enabled; `ErrNoFreePrivacySubscription` when nothing's available). Table mock-sequence tests cover every starting state (unallotted-free / allotted-disabled / already-enabled / none-free).
- **`PrivacyState`** (FREE/ALLOTTED/DISCARD/UNKNOWN) grounded in the documented getList ListType vocab; raw `Status` exposed verbatim.
- **`Discard` is destructive → non-idempotent** (`doXML(..., false)`) — never re-fired on an ambiguous transport failure (proven); the other mutations are retryable.

## ⚠️ Documented gap + scope note
- The doc documents only `getlist`/`enable`/`disable`/`changeemailaddress`/`renew`. **`allot`/`unallot`/`discard` are NOT in the doc** — grounded in the real whoisguard API (`WhoisguardID`[+`DomainName` for allot]) and flagged adjust-if-wire-differs, same principle as #111/#115/#116.
- **`whoisguard.renew`** IS documented but is **out of this issue's scope** (charge-bearing) — deferred, noted in the coverage matrix.
- Command strings match the doc's exact lowercase casing (`whoisguard.getlist`, `whoisguard.changeemailaddress`).

## Acceptance criteria
- [x] All 7 commands; documented structs match the doc (line ranges cited in commit); IDs typed as int.
- [x] Status constants (from documented vocab); getList paging + list-type validation; empty/multi-page fixtures.
- [x] `EnsureEnabled` state machine table-tested from each starting state incl. typed no-free-subscription error.
- [x] Retry classification: enable/disable/allot/unallot/changeEmail retryable; discard non-idempotent (tested).
- [x] README coverage matrix + "register with privacy" (`domains.Create` + `EnsureEnabled`) example; CHANGELOG; doc comments incl. the whoisguard→domainprivacy naming.

## Verification (local, go 1.26.4 + golangci-lint 2.12.2)
`go vet` ✅ · `golangci-lint run` → 0 issues ✅ · `go mod verify` (no new deps, go.mod/go.sum unchanged) ✅ · `make test` unit + **race** ✅ (95.5% coverage). Nested `otelnamecheap/` untouched.
