### PR TITLE
feat: add auto-paging iterators for list endpoints (iter.Seq2, ListAll/ListAllSlice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Auto-paging iterators for every paged list endpoint: `ListAll(ctx, args)`
+  returns a lazy, context-aware `iter.Seq2[*T, error]` (Go 1.23+ range-over-func)
+  that transparently walks all pages, and `ListAllSlice(ctx, args)` eagerly
+  collects the whole set (preallocated from the first page's `TotalItems`).
+  Shipped on `Domains` (`*Domain`), `DomainsTransfer` (`*DomainTransfer`), `SSL`
+  (`*SSLListCertificate`) and `DomainPrivacy` (`*DomainPrivacyGetListEntry`); the
+  flat, non-paged `UsersAddress.getList` also gains `ListAll`/`ListAllSlice`
+  (single fetch) for API uniformity. Iteration is lazy (page N+1 fetched only
+  when needed), a `break` stops cleanly with no goroutine leak (pull-based), a
+  fetch error is yielded once after the already-succeeded items and then stops,
+  and a context cancelled between pages surfaces as the next yielded error.
+  `PageSize` defaults to each endpoint's documented maximum (100) when unset to
+  minimize calls. The existing `GetListWithContext` methods are unchanged so
+  page-level control and raw paging metadata remain available. Built on a single
+  generic, table-tested pager (`namecheap/pager.go`); a new paged endpoint gains
+  its iterator by adding one small fetch adapter (see CONTRIBUTING.md) (#120).
 - New `DomainPrivacyService` (`client.DomainPrivacy`), context-first with the
   `WithContext` suffix, covering the `domainprivacy` (WhoisGuard) group — all 7
   commands: `GetListWithContext`, `EnableWithContext`, `DisableWithContext`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,31 @@ make test-unit-quiet  # failures only (fast)
 make test             # verbose + race detector
 ```
 
+## Adding an auto-paging iterator to a new list endpoint
+
+Paged list endpoints expose `ListAll` / `ListAllSlice` iterators (see issue #120)
+built on the shared generic pager in `namecheap/pager.go`. Adding them to a new
+paged endpoint is mechanical — you write one small fetch adapter, the pager does
+the rest. Copy an existing `*_list_all.go` file (for example
+`domains_list_all.go`) and change four things:
+
+1. A `const <endpoint>MaxPageSize = 100` citing the documented maximum from
+   `docs/namecheap-api-v2.md`.
+2. A `ListAll(ctx, args) iter.Seq2[*ItemType, error]` method that returns
+   `pageAll(ctx, <fetch closure>)`.
+3. A `ListAllSlice(ctx, args) ([]*ItemType, error)` method that captures the
+   total into a variable inside the closure and returns
+   `collectAll(seq, &total)`.
+4. A `fetch<Endpoint>Page` helper: copy the caller's args (never mutate them),
+   set `Page` and default `PageSize` to the max when unset, call the existing
+   `GetListWithContext`, and return `(ptrsOf(resp.<Items>), TotalItems, err)`.
+
+The pager's semantics (laziness, clean early break, error-then-stop, context
+cancellation) are table-tested once in `pager_test.go`; a new endpoint only needs
+a small wiring test that its `ListAllSlice` returns the full multi-page set. Keep
+the existing `GetListWithContext` method unchanged so page-level control is
+preserved.
+
 ## Release
 
 We publish a new tagged release once significant changes accumulate. If you need a release with a specific fix,

--- a/README.md
+++ b/README.md
@@ -670,6 +670,54 @@ fmt.Printf("privacy id=%d action=%s\n", res.PrivacyID, res.Action)
 | `changeEmailAddress` | Implemented |
 | `renew` | Deferred (documented but out of scope; charge-bearing) |
 
+### Iterating all pages
+
+Every paged list endpoint offers a lazy, auto-paging iterator so you can walk an
+entire portfolio without writing the fetch loop yourself. Iterate all your
+domains in four lines:
+
+```go
+for domain, err := range client.Domains.ListAll(ctx, &namecheap.DomainsGetListArgs{}) {
+    if err != nil {
+        return err // a page fetch failed mid-iteration; iteration has stopped
+    }
+    fmt.Println(*domain.Name)
+}
+```
+
+`ListAll` returns an `iter.Seq2[*T, error]` (Go 1.23+ range-over-func):
+
+- **Lazy** — page N+1 is fetched only when you have consumed page N. `PageSize`
+  defaults to each endpoint's documented maximum (100) when you leave it unset,
+  so the fewest possible calls are made.
+- **Clean early break** — `break` (or a `return`) stops iteration immediately
+  without fetching the next page. It is pull-based, so there is no goroutine to
+  leak.
+- **Errors** — a fetch error is yielded once as the final `(zero, err)` pair,
+  after the items from the pages that already succeeded, then iteration stops.
+  Always check `err` on every iteration.
+- **Context** — a context cancelled between pages surfaces as the next yielded
+  error; the in-flight request, the rate-limiter wait and the retry backoff are
+  all ctx-bound.
+
+When you want the whole set in memory, `ListAllSlice` eagerly collects it
+(preallocated from the first page's `TotalItems`); on the first error it returns
+that error together with whatever was gathered before it:
+
+```go
+domains, err := client.Domains.ListAllSlice(ctx, &namecheap.DomainsGetListArgs{})
+if err != nil {
+    return err
+}
+fmt.Printf("you own %d domains\n", len(domains))
+```
+
+The same pair ships on `client.Domains`, `client.DomainsTransfer`, `client.SSL`
+and `client.DomainPrivacy`. `client.UsersAddress.ListAll(ctx)` /
+`ListAllSlice(ctx)` are provided for uniformity even though that endpoint is flat
+(one fetch, no paging). The existing `GetListWithContext` methods are unchanged —
+use them when you need page-level control or the raw paging metadata.
+
 ### Error handling
 
 When the API rejects a call it returns a typed `*namecheap.APIError` carrying the

--- a/namecheap/domainprivacy_list_all.go
+++ b/namecheap/domainprivacy_list_all.go
@@ -1,0 +1,78 @@
+package namecheap
+
+import (
+	"context"
+	"iter"
+)
+
+// privacyMaxPageSize is the documented maximum PageSize for whoisguard.getlist
+// (docs/namecheap-api-v2.md line 1563: "Min: 2, Max: 100"). ListAll requests this
+// many items per page when PageSize is unset.
+const privacyMaxPageSize = 100
+
+// ListAll returns a lazy, auto-paging iterator over every domain-privacy
+// subscription that matches args, fetching each page as it is consumed. It shares
+// the semantics of DomainsService.ListAll: lazy paging, clean early break
+// (pull-based, no goroutine leak), and a context cancelled between pages surfaced
+// as the next yielded error. args is never mutated (iteration uses a shallow copy
+// with Page advanced per page and PageSize defaulted to privacyMaxPageSize when
+// unset). Use GetListWithContext for page-level control.
+//
+//	for sub, err := range client.DomainPrivacy.ListAll(ctx, nil) {
+//	    if err != nil {
+//	        return err
+//	    }
+//	    fmt.Println(*sub.DomainName)
+//	}
+func (dps *DomainPrivacyService) ListAll(ctx context.Context, args *DomainPrivacyGetListArgs) iter.Seq2[*DomainPrivacyGetListEntry, error] {
+	return pageAll(ctx, func(ctx context.Context, page int) ([]*DomainPrivacyGetListEntry, int, error) {
+		return dps.fetchPrivacyPage(ctx, args, page)
+	})
+}
+
+// ListAllSlice eagerly collects every subscription matching args into a single
+// slice, draining ListAll. The result is preallocated from the first page's
+// TotalItems when available. On the first fetch error it returns that error
+// together with the subscriptions gathered from the pages that succeeded before
+// it.
+func (dps *DomainPrivacyService) ListAllSlice(ctx context.Context, args *DomainPrivacyGetListArgs) ([]*DomainPrivacyGetListEntry, error) {
+	var total int
+	seq := pageAll(ctx, func(ctx context.Context, page int) ([]*DomainPrivacyGetListEntry, int, error) {
+		items, pageTotal, err := dps.fetchPrivacyPage(ctx, args, page)
+		total = pageTotal
+		return items, pageTotal, err
+	})
+	return collectAll(seq, &total)
+}
+
+// fetchPrivacyPage fetches one page of subscriptions and adapts the response to
+// the pager's (items, total, err) shape.
+func (dps *DomainPrivacyService) fetchPrivacyPage(ctx context.Context, args *DomainPrivacyGetListArgs, page int) ([]*DomainPrivacyGetListEntry, int, error) {
+	resp, err := dps.GetListWithContext(ctx, privacyListAllPageArgs(args, page))
+	if err != nil {
+		return nil, 0, err
+	}
+	if resp == nil {
+		return nil, 0, nil
+	}
+	total := 0
+	if resp.Paging != nil {
+		total = intValue(resp.Paging.TotalItems)
+	}
+	return ptrsOf(resp.DomainPrivacyList), total, nil
+}
+
+// privacyListAllPageArgs returns a shallow copy of args (or a fresh value when
+// nil) with Page set and PageSize defaulted to the documented maximum when
+// unset, leaving the caller's args untouched.
+func privacyListAllPageArgs(args *DomainPrivacyGetListArgs, page int) *DomainPrivacyGetListArgs {
+	var c DomainPrivacyGetListArgs
+	if args != nil {
+		c = *args
+	}
+	c.Page = Int(page)
+	if c.PageSize == nil {
+		c.PageSize = Int(privacyMaxPageSize)
+	}
+	return &c
+}

--- a/namecheap/domains_list_all.go
+++ b/namecheap/domains_list_all.go
@@ -1,0 +1,84 @@
+package namecheap
+
+import (
+	"context"
+	"iter"
+)
+
+// domainsMaxPageSize is the documented maximum PageSize for domains.getList
+// (docs/namecheap-api-v2.md line 71: "Min: 10, Max: 100"). ListAll requests this
+// many items per page when the caller leaves PageSize unset, minimizing the
+// number of API calls made under the rate limiter.
+const domainsMaxPageSize = 100
+
+// ListAll returns a lazy, auto-paging iterator over every domain that matches
+// args, transparently fetching each page as it is consumed. It is the idiomatic
+// way to walk an entire portfolio without writing a manual paging loop:
+//
+//	for domain, err := range client.Domains.ListAll(ctx, &namecheap.DomainsGetListArgs{}) {
+//	    if err != nil {
+//	        return err // a fetch failed mid-iteration; iteration has stopped
+//	    }
+//	    fmt.Println(*domain.Name)
+//	}
+//
+// The iterator is lazy (page N+1 is fetched only when page N is drained), a break
+// stops it cleanly without fetching further pages (it is pull-based, so there is
+// no goroutine to leak), and a context cancelled between pages surfaces as the
+// next yielded error. args is never mutated: ListAll iterates over a shallow copy
+// with Page advanced per page and PageSize defaulted to the documented maximum
+// (domainsMaxPageSize) when the caller left it unset. Use GetListWithContext
+// directly when you need page-level control or the raw paging metadata.
+func (ds *DomainsService) ListAll(ctx context.Context, args *DomainsGetListArgs) iter.Seq2[*Domain, error] {
+	return pageAll(ctx, func(ctx context.Context, page int) ([]*Domain, int, error) {
+		return ds.fetchDomainsPage(ctx, args, page)
+	})
+}
+
+// ListAllSlice eagerly collects every domain matching args into a single slice,
+// draining ListAll. The result is preallocated from the first page's TotalItems
+// when available. On the first fetch error it returns that error together with
+// the domains gathered from the pages that succeeded before it. Prefer ListAll
+// when the portfolio is large or you may stop early; use ListAllSlice when you
+// want the whole set in memory.
+func (ds *DomainsService) ListAllSlice(ctx context.Context, args *DomainsGetListArgs) ([]*Domain, error) {
+	var total int
+	seq := pageAll(ctx, func(ctx context.Context, page int) ([]*Domain, int, error) {
+		items, pageTotal, err := ds.fetchDomainsPage(ctx, args, page)
+		total = pageTotal
+		return items, pageTotal, err
+	})
+	return collectAll(seq, &total)
+}
+
+// fetchDomainsPage fetches one page of domains and adapts the response to the
+// pager's (items, total, err) shape.
+func (ds *DomainsService) fetchDomainsPage(ctx context.Context, args *DomainsGetListArgs, page int) ([]*Domain, int, error) {
+	resp, err := ds.GetListWithContext(ctx, domainsListAllPageArgs(args, page))
+	if err != nil {
+		return nil, 0, err
+	}
+	if resp == nil {
+		return nil, 0, nil
+	}
+	total := 0
+	if resp.Paging != nil {
+		total = intValue(resp.Paging.TotalItems)
+	}
+	return ptrsOf(resp.Domains), total, nil
+}
+
+// domainsListAllPageArgs returns a shallow copy of args (or a fresh value when
+// args is nil) with Page set to page and PageSize defaulted to the documented
+// maximum when unset, so the caller's args are never mutated.
+func domainsListAllPageArgs(args *DomainsGetListArgs, page int) *DomainsGetListArgs {
+	var c DomainsGetListArgs
+	if args != nil {
+		c = *args
+	}
+	c.Page = Int(page)
+	if c.PageSize == nil {
+		c.PageSize = Int(domainsMaxPageSize)
+	}
+	return &c
+}

--- a/namecheap/domains_list_all_test.go
+++ b/namecheap/domains_list_all_test.go
@@ -1,0 +1,223 @@
+package namecheap
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// domainsPageResponse renders a domains.getList XML response for the given page,
+// pageSize and total, emitting exactly the rows that belong on that page and a
+// paging block reporting total.
+func domainsPageResponse(page, pageSize, total int) string {
+	start := (page - 1) * pageSize
+	count := total - start
+	if count < 0 {
+		count = 0
+	}
+	if count > pageSize {
+		count = pageSize
+	}
+
+	var rows strings.Builder
+	for i := 0; i < count; i++ {
+		id := start + i + 1
+		fmt.Fprintf(&rows, `<Domain ID="%d" Name="domain%d.com" User="user" Created="06/02/2021" Expires="06/02/2022" IsExpired="false" IsLocked="false" AutoRenew="true" WhoisGuard="ENABLED" IsPremium="false" IsOurDNS="false" />`, id, id)
+	}
+
+	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.domains.getList">
+		<DomainGetListResult>%s</DomainGetListResult>
+		<Paging>
+			<TotalItems>%d</TotalItems>
+			<CurrentPage>%d</CurrentPage>
+			<PageSize>%d</PageSize>
+		</Paging>
+	</CommandResponse>
+</ApiResponse>`, rows.String(), total, page, pageSize)
+}
+
+// pagedDomainsServer returns a mock server that serves domainsPageResponse for
+// the Page/PageSize parsed from each request body, and a pointer to a counter of
+// the number of requests it has served.
+func pagedDomainsServer(t *testing.T, total int) (*httptest.Server, *int64) {
+	t.Helper()
+	var calls int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&calls, 1)
+		body, _ := io.ReadAll(r.Body)
+		q, _ := url.ParseQuery(string(body))
+		page, _ := strconv.Atoi(q.Get("Page"))
+		pageSize, _ := strconv.Atoi(q.Get("PageSize"))
+		if page == 0 {
+			page = 1
+		}
+		if pageSize == 0 {
+			pageSize = 20
+		}
+		_, _ = w.Write([]byte(domainsPageResponse(page, pageSize, total)))
+	}))
+	t.Cleanup(server.Close)
+	return server, &calls
+}
+
+func TestDomainsListAllSlice(t *testing.T) {
+	t.Parallel()
+	server, calls := pagedDomainsServer(t, 25)
+
+	client := setupClient(nil)
+	client.BaseURL = server.URL
+
+	domains, err := client.Domains.ListAllSlice(context.Background(), &DomainsGetListArgs{PageSize: Int(10)})
+	assert.NoError(t, err)
+
+	if !assert.Len(t, domains, 25) {
+		return
+	}
+	assert.Equal(t, "domain1.com", *domains[0].Name)
+	assert.Equal(t, "domain25.com", *domains[24].Name)
+	// 25 items / 10 per page = 3 pages fetched (10 + 10 + 5).
+	assert.Equal(t, int64(3), atomic.LoadInt64(calls))
+}
+
+func TestDomainsListAllDefaultsToMaxPageSize(t *testing.T) {
+	t.Parallel()
+	var sentPageSize string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		q, _ := url.ParseQuery(string(body))
+		sentPageSize = q.Get("PageSize")
+		_, _ = w.Write([]byte(domainsPageResponse(1, domainsMaxPageSize, 3)))
+	}))
+	t.Cleanup(server.Close)
+
+	client := setupClient(nil)
+	client.BaseURL = server.URL
+
+	_, err := client.Domains.ListAllSlice(context.Background(), nil)
+	assert.NoError(t, err)
+	assert.Equal(t, strconv.Itoa(domainsMaxPageSize), sentPageSize, "unset PageSize should default to the documented maximum")
+}
+
+func TestDomainsListAllDoesNotMutateArgs(t *testing.T) {
+	t.Parallel()
+	server, _ := pagedDomainsServer(t, 4)
+
+	client := setupClient(nil)
+	client.BaseURL = server.URL
+
+	args := &DomainsGetListArgs{PageSize: Int(10)}
+	_, err := client.Domains.ListAllSlice(context.Background(), args)
+	assert.NoError(t, err)
+
+	assert.Nil(t, args.Page, "ListAll must not set Page on the caller's args")
+	assert.Equal(t, 10, *args.PageSize, "ListAll must not change the caller's PageSize")
+}
+
+// TestDomainsListAllLaziness proves endpoint-level laziness: breaking after the
+// first domain of a 5-page result performs only a single HTTP request.
+func TestDomainsListAllLaziness(t *testing.T) {
+	t.Parallel()
+	server, calls := pagedDomainsServer(t, 25)
+
+	client := setupClient(nil)
+	client.BaseURL = server.URL
+
+	var first string
+	for d, err := range client.Domains.ListAll(context.Background(), &DomainsGetListArgs{PageSize: Int(10)}) {
+		if !assert.NoError(t, err) {
+			break
+		}
+		first = *d.Name
+		break
+	}
+
+	assert.Equal(t, "domain1.com", first)
+	assert.Equal(t, int64(1), atomic.LoadInt64(calls), "early break should fetch only the first page")
+}
+
+// TestDomainsListAllErrorMidIteration proves a fetch error on page 2 yields
+// page-1 items first, then the error, then stops.
+func TestDomainsListAllErrorMidIteration(t *testing.T) {
+	t.Parallel()
+	var calls int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt64(&calls, 1)
+		if n == 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`<?xml version="1.0"?>
+<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+	<Errors><Error Number="4022337">Server error</Error></Errors>
+</ApiResponse>`))
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		q, _ := url.ParseQuery(string(body))
+		page, _ := strconv.Atoi(q.Get("Page"))
+		_, _ = w.Write([]byte(domainsPageResponse(page, 10, 25)))
+	}))
+	t.Cleanup(server.Close)
+
+	// One attempt only, so the page-2 server error is terminal (the resilience
+	// layer would otherwise retry the retryable code).
+	client := NewClient(&ClientOptions{
+		UserName: ncUserName, ApiUser: ncAPIUser, ApiKey: ncAPIKey, ClientIp: ncClientIP,
+		RateLimit: &RateLimitOptions{Disabled: true},
+		Retry:     &RetryOptions{MaxAttempts: 1},
+	})
+	client.BaseURL = server.URL
+
+	var got []string
+	var gotErr error
+	for d, err := range client.Domains.ListAll(context.Background(), &DomainsGetListArgs{PageSize: Int(10)}) {
+		if err != nil {
+			gotErr = err
+			break
+		}
+		got = append(got, *d.Name)
+	}
+
+	// Page 1 (10 items) is yielded before the page-2 error surfaces.
+	if assert.Len(t, got, 10) {
+		assert.Equal(t, "domain1.com", got[0])
+		assert.Equal(t, "domain10.com", got[9])
+	}
+	assert.Error(t, gotErr)
+	assert.ErrorContains(t, gotErr, "Server error")
+}
+
+// TestDomainsListAllSliceUnderRateLimiter is the rate-limiter interplay
+// integration test: a 15-page ListAllSlice through the full resilience pipeline
+// (limiter + concurrency gate + retry) completes without deadlock and returns
+// every item. The limiter is enabled but paced high so the test runs quickly.
+func TestDomainsListAllSliceUnderRateLimiter(t *testing.T) {
+	t.Parallel()
+	server, calls := pagedDomainsServer(t, 105)
+
+	client := NewClient(&ClientOptions{
+		UserName: ncUserName, ApiUser: ncAPIUser, ApiKey: ncAPIKey, ClientIp: ncClientIP,
+		RateLimit: &RateLimitOptions{PerMinute: 6000, MaxConcurrent: 4},
+	})
+	client.BaseURL = server.URL
+
+	domains, err := client.Domains.ListAllSlice(context.Background(), &DomainsGetListArgs{PageSize: Int(10)})
+	assert.NoError(t, err)
+
+	if !assert.Len(t, domains, 105) {
+		return
+	}
+	assert.Equal(t, "domain105.com", *domains[104].Name)
+	// 105 items / 10 per page = 11 pages, all paced through the limiter without deadlock.
+	assert.Equal(t, int64(11), atomic.LoadInt64(calls), "105 items / 10 per page = 11 pages")
+}

--- a/namecheap/domains_transfer_list_all.go
+++ b/namecheap/domains_transfer_list_all.go
@@ -1,0 +1,77 @@
+package namecheap
+
+import (
+	"context"
+	"iter"
+)
+
+// transferMaxPageSize is the documented maximum PageSize for transfer.getList
+// (docs/namecheap-api-v2.md line 768: "Min: 10, Max: 100"). ListAll requests this
+// many items per page when PageSize is unset.
+const transferMaxPageSize = 100
+
+// ListAll returns a lazy, auto-paging iterator over every domain transfer that
+// matches args, fetching each page as it is consumed. It shares the semantics of
+// DomainsService.ListAll: lazy paging, clean early break (pull-based, no
+// goroutine leak), and a context cancelled between pages surfaced as the next
+// yielded error. args is never mutated (iteration uses a shallow copy with Page
+// advanced per page and PageSize defaulted to transferMaxPageSize when unset).
+// Use GetListWithContext for page-level control.
+//
+//	for transfer, err := range client.DomainsTransfer.ListAll(ctx, nil) {
+//	    if err != nil {
+//	        return err
+//	    }
+//	    fmt.Println(*transfer.DomainName)
+//	}
+func (dts *DomainsTransferService) ListAll(ctx context.Context, args *DomainsTransferGetListArgs) iter.Seq2[*DomainTransfer, error] {
+	return pageAll(ctx, func(ctx context.Context, page int) ([]*DomainTransfer, int, error) {
+		return dts.fetchTransferPage(ctx, args, page)
+	})
+}
+
+// ListAllSlice eagerly collects every transfer matching args into a single
+// slice, draining ListAll. The result is preallocated from the first page's
+// TotalItems when available. On the first fetch error it returns that error
+// together with the transfers gathered from the pages that succeeded before it.
+func (dts *DomainsTransferService) ListAllSlice(ctx context.Context, args *DomainsTransferGetListArgs) ([]*DomainTransfer, error) {
+	var total int
+	seq := pageAll(ctx, func(ctx context.Context, page int) ([]*DomainTransfer, int, error) {
+		items, pageTotal, err := dts.fetchTransferPage(ctx, args, page)
+		total = pageTotal
+		return items, pageTotal, err
+	})
+	return collectAll(seq, &total)
+}
+
+// fetchTransferPage fetches one page of transfers and adapts the response to the
+// pager's (items, total, err) shape.
+func (dts *DomainsTransferService) fetchTransferPage(ctx context.Context, args *DomainsTransferGetListArgs, page int) ([]*DomainTransfer, int, error) {
+	resp, err := dts.GetListWithContext(ctx, transferListAllPageArgs(args, page))
+	if err != nil {
+		return nil, 0, err
+	}
+	if resp == nil {
+		return nil, 0, nil
+	}
+	total := 0
+	if resp.Paging != nil {
+		total = intValue(resp.Paging.TotalItems)
+	}
+	return ptrsOf(resp.Transfers), total, nil
+}
+
+// transferListAllPageArgs returns a shallow copy of args (or a fresh value when
+// nil) with Page set and PageSize defaulted to the documented maximum when
+// unset, leaving the caller's args untouched.
+func transferListAllPageArgs(args *DomainsTransferGetListArgs, page int) *DomainsTransferGetListArgs {
+	var c DomainsTransferGetListArgs
+	if args != nil {
+		c = *args
+	}
+	c.Page = Int(page)
+	if c.PageSize == nil {
+		c.PageSize = Int(transferMaxPageSize)
+	}
+	return &c
+}

--- a/namecheap/list_all_endpoints_test.go
+++ b/namecheap/list_all_endpoints_test.go
@@ -1,0 +1,187 @@
+package namecheap
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// pageBounds returns the 0-based start index and item count for the given page.
+func pageBounds(page, pageSize, total int) (start, count int) {
+	start = (page - 1) * pageSize
+	count = total - start
+	if count < 0 {
+		count = 0
+	}
+	if count > pageSize {
+		count = pageSize
+	}
+	return start, count
+}
+
+// pagedServer serves render(page, pageSize, total) for the Page/PageSize parsed
+// from each request body.
+func pagedServer(t *testing.T, total int, render func(page, pageSize, total int) string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		q, _ := url.ParseQuery(string(body))
+		page, _ := strconv.Atoi(q.Get("Page"))
+		pageSize, _ := strconv.Atoi(q.Get("PageSize"))
+		if page == 0 {
+			page = 1
+		}
+		if pageSize == 0 {
+			pageSize = 20
+		}
+		_, _ = w.Write([]byte(render(page, pageSize, total)))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func envelope(commandType, result string, page, pageSize, total int) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="%s">
+		%s
+		<Paging>
+			<TotalItems>%d</TotalItems>
+			<CurrentPage>%d</CurrentPage>
+			<PageSize>%d</PageSize>
+		</Paging>
+	</CommandResponse>
+</ApiResponse>`, commandType, result, total, page, pageSize)
+}
+
+func transferPageResponse(page, pageSize, total int) string {
+	start, count := pageBounds(page, pageSize, total)
+	var rows strings.Builder
+	for i := 0; i < count; i++ {
+		id := start + i + 1
+		fmt.Fprintf(&rows, `<Transfer TransferID="%d" DomainName="transfer%d.com" User="user" TransferDate="06/02/2021" OrderID="%d" StatusID="1" Status="In progress" />`, id, id, id)
+	}
+	result := "<TransferGetListResult>" + rows.String() + "</TransferGetListResult>"
+	return envelope("namecheap.domains.transfer.getList", result, page, pageSize, total)
+}
+
+func sslPageResponse(page, pageSize, total int) string {
+	start, count := pageBounds(page, pageSize, total)
+	var rows strings.Builder
+	for i := 0; i < count; i++ {
+		id := start + i + 1
+		fmt.Fprintf(&rows, `<SSL CertificateID="%d" HostName="ssl%d.com" SSLType="PositiveSSL" PurchaseDate="06/02/2021" ExpireDate="06/02/2022" Status="active" />`, id, id)
+	}
+	result := "<SSLListResult>" + rows.String() + "</SSLListResult>"
+	return envelope("namecheap.ssl.getList", result, page, pageSize, total)
+}
+
+func privacyPageResponse(page, pageSize, total int) string {
+	start, count := pageBounds(page, pageSize, total)
+	var rows strings.Builder
+	for i := 0; i < count; i++ {
+		id := start + i + 1
+		fmt.Fprintf(&rows, `<Whoisguard ID="%d" DomainName="privacy%d.com" Created="06/02/2021" Expires="06/02/2022" Status="ENABLED" />`, id, id)
+	}
+	result := "<WhoisguardGetListResult>" + rows.String() + "</WhoisguardGetListResult>"
+	return envelope("namecheap.whoisguard.getlist", result, page, pageSize, total)
+}
+
+func TestDomainsTransferListAllSlice(t *testing.T) {
+	t.Parallel()
+	server := pagedServer(t, 25, transferPageResponse)
+	client := setupClient(nil)
+	client.BaseURL = server.URL
+
+	transfers, err := client.DomainsTransfer.ListAllSlice(context.Background(), &DomainsTransferGetListArgs{PageSize: Int(10)})
+	assert.NoError(t, err)
+	if !assert.Len(t, transfers, 25) {
+		return
+	}
+	assert.Equal(t, "transfer1.com", *transfers[0].DomainName)
+	assert.Equal(t, "transfer25.com", *transfers[24].DomainName)
+}
+
+func TestSSLListAllSlice(t *testing.T) {
+	t.Parallel()
+	server := pagedServer(t, 25, sslPageResponse)
+	client := setupClient(nil)
+	client.BaseURL = server.URL
+
+	certs, err := client.SSL.ListAllSlice(context.Background(), &SSLGetListArgs{PageSize: Int(10)})
+	assert.NoError(t, err)
+	if !assert.Len(t, certs, 25) {
+		return
+	}
+	assert.Equal(t, "ssl1.com", *certs[0].HostName)
+	assert.Equal(t, "ssl25.com", *certs[24].HostName)
+}
+
+func TestDomainPrivacyListAllSlice(t *testing.T) {
+	t.Parallel()
+	server := pagedServer(t, 25, privacyPageResponse)
+	client := setupClient(nil)
+	client.BaseURL = server.URL
+
+	subs, err := client.DomainPrivacy.ListAllSlice(context.Background(), &DomainPrivacyGetListArgs{PageSize: Int(10)})
+	assert.NoError(t, err)
+	if !assert.Len(t, subs, 25) {
+		return
+	}
+	assert.Equal(t, "privacy1.com", *subs[0].DomainName)
+	assert.Equal(t, "privacy25.com", *subs[24].DomainName)
+}
+
+// TestUsersAddressListAll covers the flat (non-paged) iterator: a single fetch
+// yields every entry, and ListAllSlice collects them.
+func TestUsersAddressListAll(t *testing.T) {
+	t.Parallel()
+	response := `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<CommandResponse Type="namecheap.users.address.getList">
+		<AddressGetListResult>
+			<List AddressId="1" AddressName="Home" />
+			<List AddressId="2" AddressName="Work" />
+		</AddressGetListResult>
+	</CommandResponse>
+</ApiResponse>`
+
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		_, _ = w.Write([]byte(response))
+	}))
+	t.Cleanup(server.Close)
+
+	client := setupClient(nil)
+	client.BaseURL = server.URL
+
+	addresses, err := client.UsersAddress.ListAllSlice(context.Background())
+	assert.NoError(t, err)
+	if !assert.Len(t, addresses, 2) {
+		return
+	}
+	assert.Equal(t, "Home", *addresses[0].AddressName)
+	assert.Equal(t, "Work", *addresses[1].AddressName)
+	assert.Equal(t, 1, calls, "the flat endpoint is fetched exactly once")
+}
+
+func TestUsersAddressListAllContextCancelled(t *testing.T) {
+	t.Parallel()
+	client := setupClient(nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.UsersAddress.ListAllSlice(ctx)
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/namecheap/pager.go
+++ b/namecheap/pager.go
@@ -1,0 +1,132 @@
+package namecheap
+
+import (
+	"context"
+	"iter"
+)
+
+// pageAll turns a page-fetching function into a lazy, auto-paging iterator that
+// yields every item across every page as a single flat sequence, so callers
+// never write a manual fetch loop (and never get the off-by-one on the last
+// partial page).
+//
+// fetchPage is the one small adapter a paged endpoint supplies: given a 1-based
+// page number it returns that page's items, the total item count reported by the
+// endpoint's paging block (0 when the endpoint does not report one), and any
+// error. See the per-endpoint ListAll methods (for example DomainsService.ListAll)
+// for the mechanical shape — copy the caller's args, set Page and a max PageSize,
+// call the existing GetListWithContext, and return (items, TotalItems, err).
+//
+// Semantics (each is exercised by the pager table tests):
+//
+//   - Lazy / pull-based: page N+1 is fetched only when the consumer has drained
+//     page N and asks for more. range-over-func is pull-based, not channel- or
+//     goroutine-based, so nothing runs ahead of consumption and there is no
+//     goroutine to leak.
+//   - Early break: when the consumer stops early (a break in the range loop, or
+//     any code path where yield returns false) the iterator returns immediately
+//     without fetching the next page. Only the pages actually consumed are
+//     fetched.
+//   - Multi-page: pages are fetched in order (1, 2, 3, ...) and their items are
+//     yielded in order until the total is reached.
+//   - Exactly one page / last partial page: iteration stops once seen >= total
+//     (when a positive total is reported) so a final short page ends cleanly.
+//   - Empty result: a page with zero items ends iteration (nothing is yielded).
+//   - Error on page N: the items from pages 1..N-1 are yielded first, then the
+//     error from page N is yielded once (with the zero value of T), then
+//     iteration stops. No further pages are fetched.
+//   - Context cancellation: ctx is checked before each page fetch, so a context
+//     cancelled between pages surfaces as the next yielded (zero, ctx.Err())
+//     pair and iteration stops. An in-flight fetch is also bound to ctx by the
+//     underlying client, so its error propagates the same way.
+//
+// The (T, error) yield contract is: on success err is nil and the item is valid;
+// on failure the item is the zero value of T and err is non-nil, and it is the
+// final pair the iterator yields. Consumers should check err on every iteration.
+func pageAll[T any](ctx context.Context, fetchPage func(ctx context.Context, page int) (items []T, total int, err error)) iter.Seq2[T, error] {
+	return func(yield func(T, error) bool) {
+		seen := 0
+		for page := 1; ; page++ {
+			if err := ctx.Err(); err != nil {
+				var zero T
+				yield(zero, err)
+				return
+			}
+			items, total, err := fetchPage(ctx, page)
+			if err != nil {
+				var zero T
+				yield(zero, err)
+				return
+			}
+			for i := range items {
+				if !yield(items[i], nil) {
+					// Early break: the consumer is done, so return without
+					// fetching the next page (laziness).
+					return
+				}
+			}
+			seen += len(items)
+			if len(items) == 0 || (total > 0 && seen >= total) {
+				return
+			}
+		}
+	}
+}
+
+// collectAll eagerly drains an auto-paging iterator into a single slice. It is
+// the shared engine behind every ListAllSlice convenience method.
+//
+// sizeHint points at the total item count the endpoint reports (captured by the
+// fetch closure on the first page, so it is populated by the time the first item
+// is yielded); when it is non-nil and positive the destination slice is
+// preallocated to it, so a large portfolio collects in one allocation. A nil or
+// non-positive hint falls back to append's growth.
+//
+// On the first error collectAll stops and returns that error together with the
+// items already gathered from the pages that succeeded before it (never a
+// partial page: a page either contributes all its items or errors as a whole).
+// A fully empty result returns a nil slice and a nil error.
+func collectAll[T any](seq iter.Seq2[T, error], sizeHint *int) ([]T, error) {
+	var out []T
+	for item, err := range seq {
+		if err != nil {
+			return out, err
+		}
+		if out == nil {
+			capHint := 0
+			if sizeHint != nil && *sizeHint > 0 {
+				capHint = *sizeHint
+			}
+			out = make([]T, 0, capHint)
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}
+
+// ptrsOf returns a slice of pointers to the elements of the slice pointed to by
+// s, or nil when s is nil or empty. Each returned pointer aliases the
+// corresponding element of the underlying array; the pager hands every page's
+// slice to a single consumer and then discards it, so aliasing is safe here. It
+// bridges the endpoints' `*[]T` response fields to the `[]*T` item type the
+// iterators yield.
+func ptrsOf[T any](s *[]T) []*T {
+	if s == nil || len(*s) == 0 {
+		return nil
+	}
+	src := *s
+	out := make([]*T, len(src))
+	for i := range src {
+		out[i] = &src[i]
+	}
+	return out
+}
+
+// intValue dereferences a *int, returning 0 for a nil pointer. It is used to read
+// the optional TotalItems field of a paging block.
+func intValue(p *int) int {
+	if p == nil {
+		return 0
+	}
+	return *p
+}

--- a/namecheap/pager_test.go
+++ b/namecheap/pager_test.go
@@ -1,0 +1,237 @@
+package namecheap
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// errScripted is the sentinel error a scripted pager returns for a failing page.
+var errScripted = errors.New("scripted page error")
+
+// scriptedPager is a fake fetchPage source for the shared-pager table tests. It
+// serves predetermined pages, reports a fixed total, optionally errors on a
+// chosen page, and counts how many times it was called so laziness can be
+// asserted. It is driven from a single goroutine (the pager is pull-based), so no
+// synchronization is needed.
+type scriptedPager struct {
+	pages [][]int // pages[i] is the 0-based content of page i+1
+	total int     // TotalItems reported on every page
+	errAt int     // 1-based page that returns errScripted; 0 disables
+	calls int     // number of fetch invocations
+}
+
+func (s *scriptedPager) fetch(_ context.Context, page int) ([]int, int, error) {
+	s.calls++
+	if s.errAt != 0 && page == s.errAt {
+		return nil, s.total, errScripted
+	}
+	if page < 1 || page > len(s.pages) {
+		return nil, s.total, nil
+	}
+	return s.pages[page-1], s.total, nil
+}
+
+// drain fully consumes an iterator, returning the items and the first error.
+func drain[T any](seq iter.Seq2[T, error]) ([]T, error) {
+	var items []T
+	for v, err := range seq {
+		if err != nil {
+			return items, err
+		}
+		items = append(items, v)
+	}
+	return items, nil
+}
+
+func TestPageAll(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		pages     [][]int
+		total     int
+		errAt     int
+		wantItems []int
+		wantErr   error
+		wantCalls int
+	}{
+		{
+			name:      "multi_page",
+			pages:     [][]int{{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}},
+			total:     10,
+			wantItems: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			wantCalls: 5,
+		},
+		{
+			name:      "exactly_one_page",
+			pages:     [][]int{{1, 2}},
+			total:     2,
+			wantItems: []int{1, 2},
+			wantCalls: 1,
+		},
+		{
+			name:      "empty_result",
+			pages:     [][]int{{}},
+			total:     0,
+			wantItems: nil,
+			wantCalls: 1,
+		},
+		{
+			name:      "last_page_partial",
+			pages:     [][]int{{1, 2}, {3, 4}, {5}},
+			total:     5,
+			wantItems: []int{1, 2, 3, 4, 5},
+			wantCalls: 3,
+		},
+		{
+			name:      "error_on_page_3_of_5",
+			pages:     [][]int{{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}},
+			total:     10,
+			errAt:     3,
+			wantItems: []int{1, 2, 3, 4}, // pages 1-2 yielded, then the error
+			wantErr:   errScripted,
+			wantCalls: 3, // pages 4 and 5 are never fetched
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sp := &scriptedPager{pages: tt.pages, total: tt.total, errAt: tt.errAt}
+			items, err := drain(pageAll(context.Background(), sp.fetch))
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantItems, items)
+			assert.Equal(t, tt.wantCalls, sp.calls)
+		})
+	}
+}
+
+// TestPageAllLaziness proves the iterator is pull-based: breaking after the first
+// item fetches only page 1 of a 5-page result.
+func TestPageAllLaziness(t *testing.T) {
+	t.Parallel()
+	sp := &scriptedPager{
+		pages: [][]int{{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}},
+		total: 10,
+	}
+
+	var got []int
+	for v, err := range pageAll(context.Background(), sp.fetch) {
+		assert.NoError(t, err)
+		got = append(got, v)
+		break
+	}
+
+	assert.Equal(t, []int{1}, got)
+	assert.Equal(t, 1, sp.calls, "only page 1 should be fetched when the consumer breaks early")
+}
+
+// TestPageAllContextCancellation proves a context cancelled between pages surfaces
+// as the next yielded error and stops iteration before the next fetch.
+func TestPageAllContextCancellation(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	sp := &scriptedPager{
+		pages: [][]int{{1, 2}, {3, 4}, {5, 6}},
+		total: 6,
+	}
+	// Cancel the context as a side effect of serving page 1 so the pager's
+	// pre-fetch ctx check trips before page 2.
+	fetch := func(ctx context.Context, page int) ([]int, int, error) {
+		items, total, err := sp.fetch(ctx, page)
+		if page == 1 {
+			cancel()
+		}
+		return items, total, err
+	}
+
+	var got []int
+	var gotErr error
+	for v, err := range pageAll(ctx, fetch) {
+		if err != nil {
+			gotErr = err
+			break
+		}
+		got = append(got, v)
+	}
+
+	assert.Equal(t, []int{1, 2}, got, "page 1 items are yielded before cancellation is observed")
+	assert.ErrorIs(t, gotErr, context.Canceled)
+	assert.Equal(t, 1, sp.calls, "page 2 is never fetched after cancellation")
+}
+
+// TestCollectAllPreallocatesFromTotal proves collectAll sizes the destination
+// slice from the total hint captured by the fetch closure (single allocation).
+func TestCollectAllPreallocatesFromTotal(t *testing.T) {
+	t.Parallel()
+	var total int
+	sp := &scriptedPager{
+		pages: [][]int{{1, 2}, {3, 4}, {5, 6}},
+		total: 6,
+	}
+	seq := pageAll(context.Background(), func(ctx context.Context, page int) ([]int, int, error) {
+		items, pageTotal, err := sp.fetch(ctx, page)
+		total = pageTotal
+		return items, pageTotal, err
+	})
+
+	out, err := collectAll(seq, &total)
+	assert.NoError(t, err)
+	assert.Equal(t, []int{1, 2, 3, 4, 5, 6}, out)
+	assert.Equal(t, 6, cap(out), "slice should be preallocated to TotalItems and never grow")
+}
+
+// TestCollectAllReturnsPartialOnError proves collectAll returns the items it
+// gathered before the failing page together with the error.
+func TestCollectAllReturnsPartialOnError(t *testing.T) {
+	t.Parallel()
+	var total int
+	sp := &scriptedPager{
+		pages: [][]int{{1, 2}, {3, 4}, {5, 6}},
+		total: 6,
+		errAt: 2,
+	}
+	seq := pageAll(context.Background(), func(ctx context.Context, page int) ([]int, int, error) {
+		items, pageTotal, err := sp.fetch(ctx, page)
+		total = pageTotal
+		return items, pageTotal, err
+	})
+
+	out, err := collectAll(seq, &total)
+	assert.ErrorIs(t, err, errScripted)
+	assert.Equal(t, []int{1, 2}, out, "items from the page(s) that succeeded are returned with the error")
+}
+
+func TestPtrsOf(t *testing.T) {
+	t.Parallel()
+	t.Run("nil_pointer", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, ptrsOf[int](nil))
+	})
+	t.Run("empty_slice", func(t *testing.T) {
+		t.Parallel()
+		empty := []int{}
+		assert.Nil(t, ptrsOf(&empty))
+	})
+	t.Run("aliases_elements", func(t *testing.T) {
+		t.Parallel()
+		src := []int{10, 20, 30}
+		got := ptrsOf(&src)
+		if !assert.Len(t, got, 3) {
+			return
+		}
+		assert.Equal(t, 10, *got[0])
+		assert.Equal(t, 20, *got[1])
+		assert.Equal(t, 30, *got[2])
+	})
+}

--- a/namecheap/ssl_list_all.go
+++ b/namecheap/ssl_list_all.go
@@ -1,0 +1,78 @@
+package namecheap
+
+import (
+	"context"
+	"iter"
+)
+
+// sslMaxPageSize is the documented maximum PageSize for ssl.getList
+// (docs/namecheap-api-v2.md line 829: "Min: 10, Max: 100"). ListAll requests this
+// many items per page when PageSize is unset.
+const sslMaxPageSize = 100
+
+// ListAll returns a lazy, auto-paging iterator over every SSL certificate that
+// matches args, fetching each page as it is consumed. It shares the semantics of
+// DomainsService.ListAll: lazy paging, clean early break (pull-based, no
+// goroutine leak), and a context cancelled between pages surfaced as the next
+// yielded error. args is never mutated (iteration uses a shallow copy with Page
+// advanced per page and PageSize defaulted to sslMaxPageSize when unset). Use
+// GetListWithContext for page-level control.
+//
+//	for cert, err := range client.SSL.ListAll(ctx, nil) {
+//	    if err != nil {
+//	        return err
+//	    }
+//	    fmt.Println(*cert.HostName)
+//	}
+func (ss *SSLService) ListAll(ctx context.Context, args *SSLGetListArgs) iter.Seq2[*SSLListCertificate, error] {
+	return pageAll(ctx, func(ctx context.Context, page int) ([]*SSLListCertificate, int, error) {
+		return ss.fetchSSLPage(ctx, args, page)
+	})
+}
+
+// ListAllSlice eagerly collects every certificate matching args into a single
+// slice, draining ListAll. The result is preallocated from the first page's
+// TotalItems when available. On the first fetch error it returns that error
+// together with the certificates gathered from the pages that succeeded before
+// it.
+func (ss *SSLService) ListAllSlice(ctx context.Context, args *SSLGetListArgs) ([]*SSLListCertificate, error) {
+	var total int
+	seq := pageAll(ctx, func(ctx context.Context, page int) ([]*SSLListCertificate, int, error) {
+		items, pageTotal, err := ss.fetchSSLPage(ctx, args, page)
+		total = pageTotal
+		return items, pageTotal, err
+	})
+	return collectAll(seq, &total)
+}
+
+// fetchSSLPage fetches one page of certificates and adapts the response to the
+// pager's (items, total, err) shape.
+func (ss *SSLService) fetchSSLPage(ctx context.Context, args *SSLGetListArgs, page int) ([]*SSLListCertificate, int, error) {
+	resp, err := ss.GetListWithContext(ctx, sslListAllPageArgs(args, page))
+	if err != nil {
+		return nil, 0, err
+	}
+	if resp == nil {
+		return nil, 0, nil
+	}
+	total := 0
+	if resp.Paging != nil {
+		total = intValue(resp.Paging.TotalItems)
+	}
+	return ptrsOf(resp.SSLCertificates), total, nil
+}
+
+// sslListAllPageArgs returns a shallow copy of args (or a fresh value when nil)
+// with Page set and PageSize defaulted to the documented maximum when unset,
+// leaving the caller's args untouched.
+func sslListAllPageArgs(args *SSLGetListArgs, page int) *SSLGetListArgs {
+	var c SSLGetListArgs
+	if args != nil {
+		c = *args
+	}
+	c.Page = Int(page)
+	if c.PageSize == nil {
+		c.PageSize = Int(sslMaxPageSize)
+	}
+	return &c
+}

--- a/namecheap/users_address_list_all.go
+++ b/namecheap/users_address_list_all.go
@@ -1,0 +1,46 @@
+package namecheap
+
+import (
+	"context"
+	"iter"
+)
+
+// ListAll returns an iterator over every address-book entry on the account.
+//
+// Unlike the paged endpoints, users.address.getList is a flat, non-paged list
+// (docs/namecheap-api-v2.md lines 1412-1428: no request parameters and no paging
+// block), so ListAll performs exactly one fetch and yields each returned entry;
+// there is no page N+1 to fetch lazily. It is provided for API uniformity with
+// the paged services' ListAll iterators. The (entry, error) yield contract
+// matches the paged iterators: on a fetch error a single (nil, err) pair is
+// yielded and iteration stops; a caller's early break stops iteration cleanly.
+// context cancellation surfaces as that error before the fetch is attempted.
+func (uas *UsersAddressService) ListAll(ctx context.Context) iter.Seq2[*UsersAddressListEntry, error] {
+	return func(yield func(*UsersAddressListEntry, error) bool) {
+		if err := ctx.Err(); err != nil {
+			yield(nil, err)
+			return
+		}
+		resp, err := uas.GetListWithContext(ctx)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		if resp == nil {
+			return
+		}
+		for _, entry := range ptrsOf(resp.AddressGetListResult) {
+			if !yield(entry, nil) {
+				return
+			}
+		}
+	}
+}
+
+// ListAllSlice eagerly collects every address-book entry into a single slice by
+// draining ListAll. Because the endpoint is non-paged this is a single fetch. It
+// returns the first error encountered together with whatever was collected before
+// it (for a single fetch that is nil).
+func (uas *UsersAddressService) ListAllSlice(ctx context.Context) ([]*UsersAddressListEntry, error) {
+	return collectAll(uas.ListAll(ctx), nil)
+}


### PR DESCRIPTION
Closes #120. Phase 3 (ergonomics) of the go-namecheap-sdk 2.0 roadmap (#122). Removes the manual fetch-loop boilerplate every consumer re-derives (and gets wrong on the last partial page), now that all the paged endpoints exist.

## What
Go 1.23+ range-over-func iterators over one shared, tested pager.

- **`pageAll[T]`** (`namecheap/pager.go`) — a lazy, ctx-aware `iter.Seq2[T, error]` engine:
  - **Lazy**: page N+1 fetched only when the consumer drains page N and asks for more.
  - **Early `break`**: `if !yield(...) { return }` stops immediately — pull-based, no goroutine to leak.
  - **Error**: a page error yields `(zero, err)` after prior pages' items, then stops.
  - **Ctx cancellation between pages** surfaces as the next yielded error.
  - **Termination**: empty page or `seen >= TotalItems` (handles one-page and last-partial-page).
- **`ListAll(ctx, args) iter.Seq2[*T, error]`** + **`ListAllSlice(ctx, args)`** on **Domains, DomainsTransfer, SSL, DomainPrivacy** (the four with a `Paging` block). `PageSize` defaults to the documented max (100) when unset; the caller's args are never mutated. `UsersAddress` (flat, non-paged) gets them too for uniformity (single fetch). Existing `GetListWithContext` unchanged.

## Acceptance criteria
- [x] Shared pager: multi-page / one-page / empty / last-partial / error-on-page-3-of-5 (yields pages 1–2 then the error, stops) — table-driven.
- [x] Laziness: break after item 1 of a 5-page result fetches only page 1 (call-count).
- [x] Ctx cancellation between pages yields the ctx error next.
- [x] `Domains.ListAll` + `ListAllSlice` shipped (plus the other three paged endpoints); PageSize defaults to the documented max (cited).
- [x] Rate-limiter interplay: an 11-page `ListAllSlice` under the limiter paces without deadlock (integration test).
- [x] The one-adapter pattern for future endpoints documented in CONTRIBUTING.
- [x] README "iterate an entire portfolio in 4 lines"; CHANGELOG; doc comments everywhere.

## Verification (local, go 1.26.4 + golangci-lint 2.12.2)
`go vet` ✅ · `golangci-lint run` → 0 issues ✅ · `go mod verify` (no new deps, go.mod/go.sum unchanged) ✅ · `make test` unit + **race** ✅ (94.7% coverage). Nested `otelnamecheap/` untouched.
