### PR TITLE
fix(otelnamecheap): correct the submodule module path (drop erroneous /v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,7 +945,7 @@ extract the command name — never a secret.
 ```go
 import (
     "github.com/namecheap/go-namecheap-sdk/v2/namecheap"
-    "github.com/namecheap/go-namecheap-sdk/v2/otelnamecheap"
+    "github.com/namecheap/go-namecheap-sdk/otelnamecheap"
 )
 
 client := namecheap.NewClient(&namecheap.ClientOptions{
@@ -959,7 +959,7 @@ client := namecheap.NewClient(&namecheap.ClientOptions{
 Add it to your project with:
 
 ```sh
-go get github.com/namecheap/go-namecheap-sdk/v2/otelnamecheap
+go get github.com/namecheap/go-namecheap-sdk/otelnamecheap
 ```
 
 #### Why no wire-level HTTP dumps

--- a/otelnamecheap/example_test.go
+++ b/otelnamecheap/example_test.go
@@ -2,7 +2,7 @@ package otelnamecheap_test
 
 import (
 	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
-	"github.com/namecheap/go-namecheap-sdk/v2/otelnamecheap"
+	"github.com/namecheap/go-namecheap-sdk/otelnamecheap"
 )
 
 // ExampleNewTransport shows how to enable OpenTelemetry tracing for the SDK by

--- a/otelnamecheap/go.mod
+++ b/otelnamecheap/go.mod
@@ -1,4 +1,4 @@
-module github.com/namecheap/go-namecheap-sdk/v2/otelnamecheap
+module github.com/namecheap/go-namecheap-sdk/otelnamecheap
 
 go 1.26.3
 

--- a/otelnamecheap/transport.go
+++ b/otelnamecheap/transport.go
@@ -7,7 +7,7 @@
 //
 //	import (
 //	    "github.com/namecheap/go-namecheap-sdk/v2/namecheap"
-//	    "github.com/namecheap/go-namecheap-sdk/v2/otelnamecheap"
+//	    "github.com/namecheap/go-namecheap-sdk/otelnamecheap"
 //	)
 //
 //	client := namecheap.NewClient(&namecheap.ClientOptions{
@@ -38,7 +38,7 @@ import (
 
 // instrumentationName is the tracer name reported for spans created by this
 // package.
-const instrumentationName = "github.com/namecheap/go-namecheap-sdk/v2/otelnamecheap"
+const instrumentationName = "github.com/namecheap/go-namecheap-sdk/otelnamecheap"
 
 // Attribute keys set on every span.
 const (


### PR DESCRIPTION
Fixes the `otelnamecheap` submodule module path so it's actually consumable. Follow-up to #136 — caught by a clean-module `go get` test.

## Bug
The submodule declared `module github.com/namecheap/go-namecheap-sdk/v2/otelnamecheap`. That `/v2` is the **core** module's major-version suffix; a separate **v0** submodule must not carry it. With that path Go derives the subdir as `v2/otelnamecheap` and looks for a `v2/otelnamecheap/v0.1.0` tag, so:
```
go get github.com/namecheap/go-namecheap-sdk/v2/otelnamecheap@v0.1.0
→ invalid version: unknown revision v2/otelnamecheap/v0.1.0
```

## Fix
Correct path for a v0 module at `otelnamecheap/` → **`github.com/namecheap/go-namecheap-sdk/otelnamecheap`** (tag `otelnamecheap/v0.1.0`). Updated: the `module` line, the self-import in `example_test.go`, the doc-comment example + OTel instrumentation-scope name in `transport.go`, and the README install/import snippets. The core dependency stays `github.com/namecheap/go-namecheap-sdk/v2 v2.7.0`.

## Verified (clean consumer module, against the published core)
`go mod tidy` / `go build ./...` / `go vet ./...` / `go test ./...` / `go mod verify` — all clean. After merge, the `otelnamecheap/v0.1.0` tag is re-pointed to this commit and consumption re-tested.
