### PR TITLE
fix(observability): don't source log/stats command from secret-bearing request map

### DIFF
--- a/namecheap/domains_transfer_create.go
+++ b/namecheap/domains_transfer_create.go
@@ -95,7 +95,10 @@ func (dts *DomainsTransferService) CreateWithContext(ctx context.Context, args *
 
 	var response DomainsTransferCreateResponse
 	// idempotent=false: never retry a charge-bearing call on an ambiguous error.
-	_, err := dts.client.doXML(ctx, args.params(), &response, false)
+	// Pass the command literal explicitly: the params map holds EPPCode, so the
+	// command value used for logging and stats must not be read back out of it.
+	// See Client.doXMLWithCommand.
+	_, err := dts.client.doXMLWithCommand(ctx, "namecheap.domains.transfer.create", args.params(), &response, false)
 	if err != nil {
 		return nil, err
 	}

--- a/namecheap/namecheap.go
+++ b/namecheap/namecheap.go
@@ -220,9 +220,11 @@ func (c *Client) DoXMLWithContext(ctx context.Context, body map[string]string, o
 	return c.doXML(ctx, body, obj, true)
 }
 
-// doXML is the shared engine behind DoXMLWithContext. It performs the API call
-// described by body, decoding the XML response into obj, and threads idempotent
-// into the retry driver.
+// doXML performs the API call described by body, decoding the XML response into
+// obj, and threads idempotent into the retry driver. It takes the command name
+// from body["Command"] and delegates to doXMLWithCommand. Callers whose body
+// carries a per-call secret should call doXMLWithCommand directly with the
+// command literal instead.
 //
 // idempotent must be true for safely-repeatable calls (every read and every
 // non-charge-bearing write) and false for charge-bearing, non-idempotent calls
@@ -231,8 +233,21 @@ func (c *Client) DoXMLWithContext(ctx context.Context, body map[string]string, o
 // charged the account — is never resent; only Namecheap's pre-execution HTTP 405
 // rate-limit signal is retried. See shouldRetry.
 func (c *Client) doXML(ctx context.Context, body map[string]string, obj any, idempotent bool) (*http.Response, error) {
-	command := body["Command"]
+	return c.doXMLWithCommand(ctx, body["Command"], body, obj, idempotent)
+}
 
+// doXMLWithCommand is the shared engine behind doXML. command is the API command
+// name used for observability (hooks and slog), the per-command stats key, and
+// error attribution.
+//
+// command is deliberately a separate argument rather than being read back out of
+// body inside this function: callers whose body also carries a per-call secret
+// (users.changePassword, domains.transfer.create) pass the trusted command
+// literal directly. That keeps the command value — which is logged and used as a
+// map key — provably free of any secret, since it never originates from an index
+// into the same map that holds the secret. Do not reintroduce a body["Command"]
+// read here.
+func (c *Client) doXMLWithCommand(ctx context.Context, command string, body map[string]string, obj any, idempotent bool) (*http.Response, error) {
 	// The redacted view handed to observers must reflect exactly what goes on the
 	// wire, including the credentials NewRequestWithContext injects per attempt.
 	// Build it only when an observer is configured so the hot path stays clean.
@@ -270,7 +285,7 @@ func (c *Client) doXML(ctx context.Context, body map[string]string, obj any, ide
 			return response.StatusCode, parseErr
 		}
 
-		return response.StatusCode, parseAPIError(data, body["Command"])
+		return response.StatusCode, parseAPIError(data, command)
 	})
 
 	return requestResponse, err

--- a/namecheap/users_change_password.go
+++ b/namecheap/users_change_password.go
@@ -69,7 +69,10 @@ func (us *UsersService) ChangePasswordWithContext(ctx context.Context, args *Use
 	}
 
 	var response UsersChangePasswordResponse
-	_, err := us.client.DoXMLWithContext(ctx, args.params(), &response)
+	// Pass the command literal explicitly (idempotent=true): the params map holds
+	// OldPassword/ResetCode/NewPassword, so the command value used for logging and
+	// stats must not be read back out of it. See Client.doXMLWithCommand.
+	_, err := us.client.doXMLWithCommand(ctx, "namecheap.users.changePassword", args.params(), &response, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Resolves all four open [`go/clear-text-logging`](https://github.com/namecheap/go-namecheap-sdk/security/code-scanning) code-scanning alerts (#1–#4, high severity, `namecheap/observability.go:257,269,285,309`).

They are a single root cause, not four bugs. The parameters that are actually logged (`RequestInfo.Params`) are already redacted; the flagged value in every case is the **command** string. `namecheap.go` did `command := body["Command"]`, and CodeQL models map reads without key sensitivity — so reading *any* value out of a `body` map that also holds a per-call secret (`NewPassword`/`OldPassword` for `users.changePassword`, `EPPCode` for `domains.transfer.create`) yields a value it treats as sensitive. That tainted `command` then flowed into every `slog` call, directly (`logRequestStart`, `logLimiterWait`) and via `ResponseInfo.Command` (`logResponse`).

## Changes

- **`namecheap/namecheap.go`** — split `doXML` into a thin wrapper plus a new `doXMLWithCommand` engine that takes `command` as an explicit argument and never reads it back out of the body map (also used for the `parseAPIError` attribution).
- **`namecheap/users_change_password.go`** — call `doXMLWithCommand` with the command literal (`namecheap.users.changePassword`, idempotent=true) since the params map carries `OldPassword`/`ResetCode`/`NewPassword`.
- **`namecheap/domains_transfer_create.go`** — call `doXMLWithCommand` with the command literal (`namecheap.domains.transfer.create`, idempotent=false) since the params map carries `EPPCode`.

The command value used for logging, stats keys and error attribution can no longer originate from the map that holds a secret. Secrets are still sent on the wire and still redacted on every observability surface exactly as before — **no behavior change**.

## Type of change

- [x] Bug fix
- [ ] New API method
- [ ] Refactor
- [ ] Documentation
- [ ] CI / tooling

## Checklist

- [x] Tests added or updated <!-- existing suite covers the paths; no behavior change -->
- [x] `make format && make check && make lint && make test-unit-quiet` passes locally
- [x] All commits have a `Signed-off-by:` trailer (`git commit -s`)

## Verification

Reproduced locally with the same analyzer the workflow uses (CodeQL **2.26.1**, `go-code-scanning` suite):

| | `go/clear-text-logging` | total alerts |
|---|---|---|
| before (master) | 4 | 4 |
| after (this branch) | 0 | 0 |

No new alerts introduced.