### PR TITLE
feat(users): parse Currency and PromotionPrice on getPricing Price tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,11 @@ single-tier lookup. Money is never parsed to `float64`: every amount is an
 `Amount` (the exact server decimal string). `Price.EffectivePrice()` resolves the
 documented precedence — server-resolved `Price` (which already reflects any
 promo/special), then `YourPrice` (account price), then `RegularPrice` (list
-price). The sheet is large and slow-changing, so fetch it once and cache it.
+price). A tier also exposes the `Currency` it is denominated in and a
+`PromotionPrice`, both of which the server may omit; `Price.Promo()` reports the
+promotion as an explicit "(amount, present)" so an absent attribute is not
+confused with a zero one. The sheet is large and slow-changing, so fetch it once
+and cache it.
 
 ```go
 // Example: check the balance before a bulk renew.

--- a/docs/namecheap-api-v2.md
+++ b/docs/namecheap-api-v2.md
@@ -1130,6 +1130,8 @@ Returns pricing information for a requested product type.
 | Price | Final price (from regular, userprice, special, promo, or tier price) |
 | RegularPrice | Regular price |
 | YourPrice | User's price |
+| Currency | Currency in which the price is listed |
+| PromotionPrice | Promotional price, when a promotion applies to the tier |
 
 ---
 

--- a/namecheap/domainprivacy.go
+++ b/namecheap/domainprivacy.go
@@ -37,9 +37,9 @@ type DomainPrivacyService service
 // subscription's lifecycle/allotment state.
 //
 // Grounding and the documented gap. docs/namecheap-api-v2.md (domainprivacy
-// section, getlist lines 1551-1575) does NOT enumerate the values of the getList
+// section, getlist lines 1553-1577) does NOT enumerate the values of the getList
 // Status field; it only documents the getList ListType filter vocabulary — ALL |
-// ALLOTED | FREE | DISCARD (line 1567). This SDK therefore does NOT invent a
+// ALLOTED | FREE | DISCARD (line 1563). This SDK therefore does NOT invent a
 // status code table. Instead it always exposes the raw Status verbatim on every
 // entry (see DomainPrivacyGetListEntry.Status) and offers this small state whose
 // constants are grounded in that documented ListType vocabulary.
@@ -70,7 +70,7 @@ const (
 
 // ClassifyPrivacyStatus maps a getList Status description onto a PrivacyState by
 // case-insensitive keyword matching against the documented getList ListType
-// category vocabulary (ALL | ALLOTED | FREE | DISCARD, line 1567).
+// category vocabulary (ALL | ALLOTED | FREE | DISCARD, line 1563).
 //
 // Because the doc enumerates no Status values, classification keys off the
 // free-text description rather than a fabricated code table:

--- a/namecheap/domainprivacy_change_email_address.go
+++ b/namecheap/domainprivacy_change_email_address.go
@@ -25,7 +25,7 @@ type DomainPrivacyChangeEmailAddressCommandResponse struct {
 
 // DomainPrivacyChangeEmailAddressResult is the outcome of changing the privacy
 // email address. Fields follow the changeemailaddress response table in
-// docs/namecheap-api-v2.md (lines 1500-1505): ID, IsSuccess, WGEmail and
+// docs/namecheap-api-v2.md (lines 1502-1507): ID, IsSuccess, WGEmail and
 // WGOldEmail.
 type DomainPrivacyChangeEmailAddressResult struct {
 	// ID is the unique integer identifying the subscription. Typed int.

--- a/namecheap/domainprivacy_disable.go
+++ b/namecheap/domainprivacy_disable.go
@@ -23,7 +23,7 @@ type DomainPrivacyDisableCommandResponse struct {
 }
 
 // DomainPrivacyDisableResult is the outcome of disabling privacy. Fields follow
-// the disable response table in docs/namecheap-api-v2.md (lines 1545-1548): the
+// the disable response table in docs/namecheap-api-v2.md (lines 1547-1550): the
 // doc's "Domainname" column and IsSuccess. It is modeled as the idiomatic
 // DomainName wire attribute.
 type DomainPrivacyDisableResult struct {
@@ -35,7 +35,7 @@ type DomainPrivacyDisableResult struct {
 }
 
 // DisableWithContext turns off domain-privacy protection for the subscription
-// identified by privacyID (docs/namecheap-api-v2.md lines 1530-1549; req
+// identified by privacyID (docs/namecheap-api-v2.md lines 1532-1551; req
 // WhoisguardID). The subscription stays attached to its domain — disable only
 // toggles protection off, it does not detach (that is UnallotWithContext).
 //

--- a/namecheap/domainprivacy_enable.go
+++ b/namecheap/domainprivacy_enable.go
@@ -23,7 +23,7 @@ type DomainPrivacyEnableCommandResponse struct {
 }
 
 // DomainPrivacyEnableResult is the outcome of enabling privacy. Fields follow
-// the enable response table in docs/namecheap-api-v2.md (lines 1524-1527):
+// the enable response table in docs/namecheap-api-v2.md (lines 1526-1529):
 // DomainName and IsSuccess.
 type DomainPrivacyEnableResult struct {
 	// DomainName is the domain for which privacy was enabled.
@@ -34,7 +34,7 @@ type DomainPrivacyEnableResult struct {
 
 // EnableWithContext turns on domain-privacy protection for the subscription
 // identified by privacyID and sets forwardedToEmail as the address privacy
-// emails are forwarded to. Per docs/namecheap-api-v2.md (lines 1508-1528) BOTH
+// emails are forwarded to. Per docs/namecheap-api-v2.md (lines 1510-1530) BOTH
 // WhoisguardID and ForwardedToEmail are required; note that enable takes a
 // forwarding EMAIL address, not a domain.
 //

--- a/namecheap/domainprivacy_get_list.go
+++ b/namecheap/domainprivacy_get_list.go
@@ -9,7 +9,7 @@ import (
 )
 
 // allowedPrivacyListTypeValues is the documented ListType filter vocabulary for
-// namecheap.whoisguard.getlist (docs/namecheap-api-v2.md line 1567). The
+// namecheap.whoisguard.getlist (docs/namecheap-api-v2.md line 1563). The
 // "ALLOTED" spelling is the API's own (nonstandard) token and is sent verbatim.
 var allowedPrivacyListTypeValues = []string{"ALL", "ALLOTED", "FREE", "DISCARD"}
 
@@ -43,7 +43,7 @@ type DomainPrivacyGetListPaging struct {
 
 // DomainPrivacyGetListEntry is a single domain-privacy subscription in a getList
 // page. Fields follow the getList response table in docs/namecheap-api-v2.md
-// (lines 1569-1575): the doc's "Whoisguard ID" column is the numeric ID (typed
+// (lines 1571-1577): the doc's "Whoisguard ID" column is the numeric ID (typed
 // int, not string), and its "Domainname" column is the domain the subscription
 // is attached to, modeled here as the idiomatic DomainName wire attribute.
 type DomainPrivacyGetListEntry struct {
@@ -89,7 +89,7 @@ func (e DomainPrivacyGetListEntry) IsEnabled() bool {
 
 // DomainPrivacyGetListArgs are the arguments for GetListWithContext. Field names
 // and constraints follow the getList request table in docs/namecheap-api-v2.md
-// (lines 1559-1565). A nil arg (or a nil field) leaves the API default.
+// (lines 1561-1567). A nil arg (or a nil field) leaves the API default.
 type DomainPrivacyGetListArgs struct {
 	// ListType filters by category. Possible values: ALL, ALLOTED, FREE, DISCARD.
 	// Default: ALL.

--- a/namecheap/domainprivacy_list_all.go
+++ b/namecheap/domainprivacy_list_all.go
@@ -6,7 +6,7 @@ import (
 )
 
 // privacyMaxPageSize is the documented maximum PageSize for whoisguard.getlist
-// (docs/namecheap-api-v2.md line 1563: "Min: 2, Max: 100"). ListAll requests this
+// (docs/namecheap-api-v2.md line 1565: "Min: 2, Max: 100"). ListAll requests this
 // many items per page when PageSize is unset.
 const privacyMaxPageSize = 100
 

--- a/namecheap/users_add_funds.go
+++ b/namecheap/users_add_funds.go
@@ -7,10 +7,10 @@ import (
 
 // AddFundsStatus is the state of an add-funds request as reported by
 // namecheap.users.getAddFundsStatus. The documented values are listed in
-// docs/namecheap-api-v2.md (line 1256).
+// docs/namecheap-api-v2.md (line 1258).
 type AddFundsStatus string
 
-// Documented add-funds statuses (docs/namecheap-api-v2.md line 1256).
+// Documented add-funds statuses (docs/namecheap-api-v2.md line 1258).
 const (
 	// AddFundsStatusCreated means the request was created but not yet submitted.
 	AddFundsStatusCreated AddFundsStatus = "CREATED"
@@ -25,7 +25,7 @@ const (
 )
 
 // PaymentTypeCreditcard is the only documented PaymentType for
-// createaddfundsrequest (docs/namecheap-api-v2.md line 1224).
+// createaddfundsrequest (docs/namecheap-api-v2.md line 1226).
 const PaymentTypeCreditcard = "Creditcard"
 
 // UsersCreateAddFundsRequestResponse is the raw envelope for
@@ -46,7 +46,7 @@ type UsersCreateAddFundsRequestCommandResponse struct {
 }
 
 // UsersCreateAddFundsRequestResult is the outcome of an add-funds request. Field
-// names follow the response table in docs/namecheap-api-v2.md (lines 1230-1234).
+// names follow the response table in docs/namecheap-api-v2.md (lines 1232-1236).
 type UsersCreateAddFundsRequestResult struct {
 	// TokenID is the unique ID used to redirect the user to the add-funds page and
 	// to poll GetAddFundsStatusWithContext.
@@ -59,7 +59,7 @@ type UsersCreateAddFundsRequestResult struct {
 
 // UsersCreateAddFundsRequestArgs are the arguments for
 // CreateAddFundsRequestWithContext. Field names and required status follow the
-// request table in docs/namecheap-api-v2.md (lines 1221-1226).
+// request table in docs/namecheap-api-v2.md (lines 1223-1228).
 //
 // The doc's "Username" parameter is not exposed here: the transport reserves the
 // "Username" request parameter for the authenticated account (ClientOptions.
@@ -151,7 +151,7 @@ type UsersGetAddFundsStatusCommandResponse struct {
 }
 
 // UsersGetAddFundsStatusResult is the status of an add-funds request. Field names
-// follow the response table in docs/namecheap-api-v2.md (lines 1252-1256).
+// follow the response table in docs/namecheap-api-v2.md (lines 1254-1258).
 type UsersGetAddFundsStatusResult struct {
 	// TransactionID is the unique integer identifying the transaction.
 	TransactionID *int `xml:"TransactionID,attr"`

--- a/namecheap/users_address.go
+++ b/namecheap/users_address.go
@@ -15,8 +15,8 @@ type UsersAddressService service
 
 // UsersAddressDetails holds the mutable fields of an address-book entry shared by
 // create and update. Field names and required/optional status follow the
-// address.create request table in docs/namecheap-api-v2.md (lines 1347-1365); the
-// same fields (plus AddressId) drive address.update (lines 1460-1477).
+// address.create request table in docs/namecheap-api-v2.md (lines 1349-1367); the
+// same fields (plus AddressId) drive address.update (lines 1462-1479).
 //
 // Field naming differs from the domain ContactInfo shape: the address book uses
 // "Zip" (not "PostalCode") and "Organization" (not "OrganizationName"), and it

--- a/namecheap/users_address_create.go
+++ b/namecheap/users_address_create.go
@@ -17,7 +17,7 @@ type UsersAddressCreateResponse struct {
 }
 
 // UsersAddressCreateCommandResponse wraps the create result. The doc lists no
-// response table for address.create (docs/namecheap-api-v2.md lines 1339-1365);
+// response table for address.create (docs/namecheap-api-v2.md lines 1341-1367);
 // the result element carries the new address id and a Success flag on the wire.
 type UsersAddressCreateCommandResponse struct {
 	AddressCreateResult *UsersAddressCreateResult `xml:"AddressCreateResult"`

--- a/namecheap/users_address_delete.go
+++ b/namecheap/users_address_delete.go
@@ -23,7 +23,7 @@ type UsersAddressDeleteCommandResponse struct {
 }
 
 // UsersAddressDeleteResult is the outcome of an address delete. Field names
-// follow the response table in docs/namecheap-api-v2.md (lines 1383-1387).
+// follow the response table in docs/namecheap-api-v2.md (lines 1385-1389).
 type UsersAddressDeleteResult struct {
 	// Success reports whether the address was deleted.
 	Success *bool `xml:"Success,attr"`

--- a/namecheap/users_address_get_info.go
+++ b/namecheap/users_address_get_info.go
@@ -23,8 +23,8 @@ type UsersAddressGetInfoCommandResponse struct {
 }
 
 // UsersAddressGetInfoResult is the full stored address. The doc gives no response
-// table for address.getInfo (docs/namecheap-api-v2.md lines 1391-1408, only error
-// codes), so the fields mirror the create request fields (lines 1347-1365), which
+// table for address.getInfo (docs/namecheap-api-v2.md lines 1393-1410, only error
+// codes), so the fields mirror the create request fields (lines 1349-1367), which
 // getInfo echoes back; on the wire they are child elements. Every field is a
 // pointer so a field the server omits stays nil rather than an empty value.
 type UsersAddressGetInfoResult struct {

--- a/namecheap/users_address_get_list.go
+++ b/namecheap/users_address_get_list.go
@@ -19,7 +19,7 @@ type UsersAddressGetListResponse struct {
 // UsersAddressGetListCommandResponse wraps the list of address entries.
 //
 // Unlike domains.getList, the doc's address.getList
-// (docs/namecheap-api-v2.md lines 1412-1428) defines no request parameters and no
+// (docs/namecheap-api-v2.md lines 1414-1430) defines no request parameters and no
 // paging block, so none is modeled here: the response is a flat list of every
 // address on the account.
 type UsersAddressGetListCommandResponse struct {
@@ -27,7 +27,7 @@ type UsersAddressGetListCommandResponse struct {
 }
 
 // UsersAddressListEntry is one address-book entry in the list. Field names follow
-// the getList response table in docs/namecheap-api-v2.md (lines 1424-1425).
+// the getList response table in docs/namecheap-api-v2.md (lines 1426-1427).
 type UsersAddressListEntry struct {
 	// AddressID is the unique integer representing the address profile.
 	AddressID *int `xml:"AddressId,attr"`

--- a/namecheap/users_address_list_all.go
+++ b/namecheap/users_address_list_all.go
@@ -8,7 +8,7 @@ import (
 // ListAll returns an iterator over every address-book entry on the account.
 //
 // Unlike the paged endpoints, users.address.getList is a flat, non-paged list
-// (docs/namecheap-api-v2.md lines 1412-1428: no request parameters and no paging
+// (docs/namecheap-api-v2.md lines 1414-1430: no request parameters and no paging
 // block), so ListAll performs exactly one fetch and yields each returned entry;
 // there is no page N+1 to fetch lazily. It is provided for API uniformity with
 // the paged services' ListAll iterators. The (entry, error) yield contract

--- a/namecheap/users_address_set_default.go
+++ b/namecheap/users_address_set_default.go
@@ -23,7 +23,7 @@ type UsersAddressSetDefaultCommandResponse struct {
 }
 
 // UsersAddressSetDefaultResult is the outcome of a setDefault. Field names follow
-// the response table in docs/namecheap-api-v2.md (lines 1443-1446).
+// the response table in docs/namecheap-api-v2.md (lines 1445-1448).
 type UsersAddressSetDefaultResult struct {
 	// Success reports whether the default address was set.
 	Success *bool `xml:"Success,attr"`

--- a/namecheap/users_change_password.go
+++ b/namecheap/users_change_password.go
@@ -22,7 +22,7 @@ type UsersChangePasswordCommandResponse struct {
 }
 
 // UsersChangePasswordResult is the outcome of a password change. Field names
-// follow the response table in docs/namecheap-api-v2.md (lines 1179-1182).
+// follow the response table in docs/namecheap-api-v2.md (lines 1181-1184).
 type UsersChangePasswordResult struct {
 	// Success reports whether the password was changed.
 	Success *bool `xml:"Success,attr"`
@@ -31,7 +31,7 @@ type UsersChangePasswordResult struct {
 }
 
 // UsersChangePasswordArgs are the arguments for ChangePasswordWithContext. It
-// supports both documented methods (docs/namecheap-api-v2.md lines 1163-1175):
+// supports both documented methods (docs/namecheap-api-v2.md lines 1165-1177):
 // old-password (OldPassword + NewPassword) and reset-code (ResetCode +
 // NewPassword). Provide exactly one of OldPassword or ResetCode.
 //

--- a/namecheap/users_get_balances.go
+++ b/namecheap/users_get_balances.go
@@ -21,7 +21,7 @@ type UsersGetBalancesCommandResponse struct {
 }
 
 // UsersGetBalancesResult holds the account funds. Field names follow the
-// getBalances response table in docs/namecheap-api-v2.md (lines 1146-1153). Every
+// getBalances response table in docs/namecheap-api-v2.md (lines 1148-1155). Every
 // monetary field is an Amount (an exact decimal string) so a balance used to gate
 // a charge is never mangled by binary floating point; Currency is a plain string.
 type UsersGetBalancesResult struct {

--- a/namecheap/users_get_pricing.go
+++ b/namecheap/users_get_pricing.go
@@ -30,7 +30,7 @@ type UsersGetPricingCommandResponse struct {
 type UsersGetPricingResult struct {
 	// ProductTypes lists the pricing tree for each product type in the response,
 	// e.g. "domains". Element/attribute names follow the getPricing response table
-	// in docs/namecheap-api-v2.md (lines 1123-1132).
+	// in docs/namecheap-api-v2.md (lines 1123-1134).
 	ProductTypes []PricingProductType `xml:"ProductType"`
 }
 
@@ -63,7 +63,7 @@ type PricingProduct struct {
 }
 
 // Price is a single price tier. Field names and money semantics follow the
-// getPricing response table in docs/namecheap-api-v2.md (lines 1128-1132). Every
+// getPricing response table in docs/namecheap-api-v2.md (lines 1128-1134). Every
 // monetary field is an Amount (an exact decimal string) so a charge-bearing price
 // is never silently mangled by binary floating point.
 type Price struct {
@@ -79,6 +79,17 @@ type Price struct {
 	RegularPrice Amount `xml:"RegularPrice,attr"`
 	// YourPrice is the account/user-specific price (doc line 1132).
 	YourPrice Amount `xml:"YourPrice,attr"`
+	// Currency is the currency the tier's amounts are denominated in, e.g. "USD"
+	// (doc line 1133). It is empty when the server omits the attribute, so a
+	// caller that needs a guaranteed currency should fall back to getBalances.
+	Currency string `xml:"Currency,attr"`
+	// PromotionPrice is the promotional price for this tier (doc line 1134). It
+	// is empty when the server omits the attribute; what a zero value means is
+	// not documented, so it is passed through rather than interpreted. Price
+	// already reflects an active promotion (see EffectivePrice); PromotionPrice
+	// is what makes the discount that produced it identifiable rather than
+	// guessed from Price != RegularPrice. Use Promo to test presence.
+	PromotionPrice Amount `xml:"PromotionPrice,attr"`
 }
 
 // UsersGetPricingArgs are the arguments for GetPricingWithContext. Field names
@@ -201,6 +212,27 @@ func (p Price) EffectivePrice() Amount {
 		}
 	}
 	return p.RegularPrice
+}
+
+// Promo returns the tier's PromotionPrice and whether the server sent the
+// attribute at all: the raw amount and true when present, the zero Amount and
+// false when the response omitted it (or left it blank).
+//
+// Presence is all it reports. The API documentation does not say what a zero
+// PromotionPrice means — a free-first-year promotion and "no promotion" are not
+// distinguishable from the value alone — so this SDK does not decide for the
+// caller: "0.00" is returned as a present promotion, and interpreting it is the
+// caller's policy. The amount is passed through exactly as received, like every
+// other Amount.
+//
+// Promo reports which discount applied; it is not the amount to charge. An
+// active promotion is already folded into Price by the server (doc line 1130),
+// so EffectivePrice remains the answer to "what does this cost".
+func (p Price) Promo() (Amount, bool) {
+	if strings.TrimSpace(string(p.PromotionPrice)) == "" {
+		return "", false
+	}
+	return p.PromotionPrice, true
 }
 
 // isPositiveAmount reports whether a is a present, positive money value. It is

--- a/namecheap/users_get_pricing_test.go
+++ b/namecheap/users_get_pricing_test.go
@@ -14,8 +14,9 @@ import (
 // pricingDomainResponse is a realistic captured-style DOMAIN price sheet. The
 // register tiers for com/net/org are crafted to exercise EffectivePrice
 // precedence: com has a promo Price, net falls through to YourPrice (Price zero),
-// org falls through to RegularPrice (Price empty, YourPrice zero). Extra
-// attributes (Currency, PricingType, ...) mirror the live API and must be ignored.
+// org falls through to RegularPrice (Price empty, YourPrice zero). Currency is
+// parsed; the remaining extra attributes (PricingType, RegularPriceType, ...)
+// mirror the live API and must be ignored.
 const pricingDomainResponse = `<?xml version="1.0" encoding="utf-8"?>
 <ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
 	<Errors />
@@ -38,6 +39,34 @@ const pricingDomainResponse = `<?xml version="1.0" encoding="utf-8"?>
 				<ProductCategory Name="renew">
 					<Product Name="com">
 						<Price Duration="1" DurationType="YEAR" Price="11.00" RegularPrice="12.88" YourPrice="11.50" Currency="USD" />
+					</Product>
+				</ProductCategory>
+			</ProductType>
+		</UserGetPricingResult>
+	</CommandResponse>
+	<Server>PHX01SBAPIEXT06</Server>
+	<GMTTimeDifference>--4:00</GMTTimeDifference>
+	<ExecutionTime>2.345</ExecutionTime>
+</ApiResponse>`
+
+// pricingPromotionResponse exercises the optional per-tier attributes. The
+// 1-year shop tier carries Currency and PromotionPrice, with Price, YourPrice
+// and PromotionPrice deliberately all different so an EffectivePrice assertion
+// on it can only pass for one of them. The 2-year tier omits both optional
+// attributes entirely, and the 3-year tier sends them present-but-empty — the
+// two shapes a server can use to say "nothing here".
+const pricingPromotionResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+	<Errors />
+	<RequestedCommand>namecheap.users.getPricing</RequestedCommand>
+	<CommandResponse Type="namecheap.users.getPricing">
+		<UserGetPricingResult>
+			<ProductType Name="domains">
+				<ProductCategory Name="register">
+					<Product Name="shop">
+						<Price Duration="1" DurationType="YEAR" Price="1.16" RegularPrice="19.99" YourPrice="9.99" Currency="EUR" PromotionPrice="0.99" />
+						<Price Duration="2" DurationType="YEAR" Price="39.98" RegularPrice="39.98" YourPrice="39.98" />
+						<Price Duration="3" DurationType="YEAR" Price="59.97" RegularPrice="59.97" YourPrice="59.97" Currency="" PromotionPrice="" />
 					</Product>
 				</ProductCategory>
 			</ProductType>
@@ -121,6 +150,60 @@ func TestUsersService_GetPricing_Domain(t *testing.T) {
 	assert.Equal(t, Amount("8.88"), comYear1.Price)
 	assert.Equal(t, Amount("10.87"), comYear1.RegularPrice)
 	assert.Equal(t, Amount("9.99"), comYear1.YourPrice)
+	assert.Equal(t, "USD", comYear1.Currency)
+
+	// This sheet carries no promotion, so PromotionPrice stays absent and Promo
+	// reports it rather than returning a fabricated zero amount.
+	assert.Equal(t, Amount(""), comYear1.PromotionPrice)
+	promo, hasPromo := comYear1.Promo()
+	assert.False(t, hasPromo)
+	assert.Equal(t, Amount(""), promo)
+}
+
+// TestUsersService_GetPricing_PromotionAttributes covers the optional Currency
+// and PromotionPrice attributes: present on the promo tier, absent on the tier
+// below it. An absent attribute must unmarshal to the zero value rather than
+// failing the decode, because the live API omits both on some product types.
+func TestUsersService_GetPricing_PromotionAttributes(t *testing.T) {
+	t.Parallel()
+
+	client := usersMockClient(t, pricingPromotionResponse, nil)
+	resp, err := client.Users.GetPricingWithContext(context.Background(), &UsersGetPricingArgs{ProductType: String("DOMAIN")})
+	mustNoError(t, err)
+	result := resp.UserGetPricingResult
+	mustNotNil(t, result)
+
+	discounted, ok := result.PriceFor("REGISTER", "shop", 1)
+	mustTrue(t, ok)
+	assert.Equal(t, "EUR", discounted.Currency)
+	assert.Equal(t, Amount("0.99"), discounted.PromotionPrice)
+	promo, hasPromo := discounted.Promo()
+	mustTrue(t, hasPromo)
+	assert.Equal(t, Amount("0.99"), promo)
+
+	// The promotion is already folded into Price server-side, so Price is what a
+	// caller pays. Price, YourPrice and PromotionPrice all differ on this tier,
+	// so this assertion fails if parsing PromotionPrice ever displaces the
+	// documented precedence.
+	assert.Equal(t, Amount("1.16"), discounted.EffectivePrice())
+
+	// Same product, second year: the optional attributes are absent entirely.
+	plain, ok := result.PriceFor("REGISTER", "shop", 2)
+	mustTrue(t, ok)
+	assert.Equal(t, "", plain.Currency)
+	assert.Equal(t, Amount(""), plain.PromotionPrice)
+	_, hasPromo = plain.Promo()
+	assert.False(t, hasPromo)
+	assert.Equal(t, Amount("39.98"), plain.EffectivePrice())
+
+	// Third year: the attributes are present but empty, which must decode (and
+	// report) identically to being absent.
+	blank, ok := result.PriceFor("REGISTER", "shop", 3)
+	mustTrue(t, ok)
+	assert.Equal(t, "", blank.Currency)
+	assert.Equal(t, Amount(""), blank.PromotionPrice)
+	_, hasPromo = blank.Promo()
+	assert.False(t, hasPromo)
 }
 
 func TestUsersService_GetPricing_PriceForPrecedence(t *testing.T) {
@@ -235,6 +318,74 @@ func TestUsersService_GetPricing_Validation(t *testing.T) {
 		_, hasAction := sent["ActionName"]
 		assert.False(t, hasAction)
 	})
+}
+
+// TestPrice_Promo unit-tests the promotion accessor directly on Price values,
+// independent of parsing. Promo reports presence, not interpretation: only an
+// attribute the server did not send (or sent blank) is "no promotion", and
+// whatever it did send comes back verbatim — including values the API is not
+// documented to produce, which the SDK passes through rather than sanitizing.
+func TestPrice_Promo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		p       Price
+		want    Amount
+		wantHas bool
+	}{
+		{"promotion present", Price{PromotionPrice: "1.16", Price: "1.16", RegularPrice: "19.99"}, "1.16", true},
+		{"attribute absent", Price{Price: "8.88", RegularPrice: "10.87"}, "", false},
+		{"attribute present but empty", Price{PromotionPrice: ""}, "", false},
+		{"whitespace only is absent", Price{PromotionPrice: "  "}, "", false},
+		{"sub-unit promotion", Price{PromotionPrice: "0.01"}, "0.01", true},
+		// A zero promotional price is reported as present: the API does not
+		// document what it means, and a free-first-year promotion is a real
+		// product, so the SDK must not silently call it "no promotion".
+		{"zero decimal is present", Price{PromotionPrice: "0.00"}, "0.00", true},
+		{"short zero is present", Price{PromotionPrice: "0.0"}, "0.0", true},
+		{"bare zero is present", Price{PromotionPrice: "0"}, "0", true},
+		{"many-decimal zero is present", Price{PromotionPrice: "0.000000"}, "0.000000", true},
+		// Values the documented API never returns still round-trip unchanged;
+		// the SDK is not a validator (see the Amount doc comment).
+		{"negative passes through", Price{PromotionPrice: "-1.00"}, "-1.00", true},
+		{"comma decimal passes through", Price{PromotionPrice: "1,16"}, "1,16", true},
+		{"exponent passes through", Price{PromotionPrice: "1e-2"}, "1e-2", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, has := tc.p.Promo()
+			assert.Equal(t, tc.wantHas, has)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestPrice_PromoDoesNotAffectEffectivePrice pins the separation of concerns:
+// PromotionPrice reports which discount applied, EffectivePrice reports what is
+// charged, and adding the former must never move the latter.
+func TestPrice_PromoDoesNotAffectEffectivePrice(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		p    Price
+		want Amount
+	}{
+		// Every case keeps PromotionPrice distinct from the expected result, so a
+		// precedence that wrongly consulted it would fail here.
+		{"promo folded into Price", Price{Price: "1.16", YourPrice: "9.99", RegularPrice: "19.99", PromotionPrice: "0.99"}, "1.16"},
+		{"promo present but Price zero", Price{Price: "0.00", YourPrice: "9.99", RegularPrice: "19.99", PromotionPrice: "0.99"}, "9.99"},
+		{"promo present, only regular set", Price{RegularPrice: "19.99", PromotionPrice: "0.99"}, "19.99"},
+		{"zero promo does not zero the price", Price{Price: "8.88", YourPrice: "9.99", RegularPrice: "10.87", PromotionPrice: "0.00"}, "8.88"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.p.EffectivePrice())
+		})
+	}
 }
 
 // TestPrice_EffectivePrice unit-tests the precedence directly on Price values,

--- a/namecheap/users_update.go
+++ b/namecheap/users_update.go
@@ -16,7 +16,7 @@ type UsersUpdateResponse struct {
 }
 
 // UsersUpdateCommandResponse wraps the update result. The doc lists no response
-// table for users.update (docs/namecheap-api-v2.md lines 1186-1210); the result
+// table for users.update (docs/namecheap-api-v2.md lines 1188-1212); the result
 // element carries a Success flag on the wire.
 type UsersUpdateCommandResponse struct {
 	UserUpdateResult *UsersUpdateResult `xml:"UserUpdateResult"`
@@ -30,7 +30,7 @@ type UsersUpdateResult struct {
 
 // UsersUpdateArgs are the arguments for UpdateWithContext. Field names and
 // required/optional status follow the update request table in
-// docs/namecheap-api-v2.md (lines 1196-1209).
+// docs/namecheap-api-v2.md (lines 1198-1211).
 //
 // Note the field naming differs from the domain ContactInfo shape: this command
 // uses "Zip" (not "PostalCode"), "Organization" (not "OrganizationName") and adds

--- a/namecheaptest/fixtures_test.go
+++ b/namecheaptest/fixtures_test.go
@@ -163,6 +163,26 @@ func TestRepresentativeFixturesDecodeIntoStructs(t *testing.T) {
 		}
 	})
 
+	t.Run("users_getPricing", func(t *testing.T) {
+		t.Parallel()
+		var resp namecheap.UsersGetPricingResponse
+		if err := xml.Unmarshal([]byte(FixtureOK("users_getPricing")), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.CommandResponse == nil || resp.CommandResponse.UserGetPricingResult == nil {
+			t.Fatal("UserGetPricingResult not populated")
+		}
+		price, ok := resp.CommandResponse.UserGetPricingResult.PriceFor("register", "com", 1)
+		if !ok {
+			t.Fatal("register/com/1y tier not found in getPricing fixture")
+		}
+		// Currency is carried by every Price node of the captured response, so a
+		// parse that silently drops it would regress the fixture's own shape.
+		if price.Currency == "" {
+			t.Errorf("Currency not populated: %+v", price)
+		}
+	})
+
 	t.Run("ssl_getInfo", func(t *testing.T) {
 		t.Parallel()
 		var resp namecheap.SSLGetInfoResponse


### PR DESCRIPTION
## Summary

`users.getPricing` shipped in v2.7.0 parsing only `Duration`, `DurationType`, `Price`, `RegularPrice` and `YourPrice`. Two more attributes appear on `<Price>` nodes and were silently discarded:

- **`Currency`** — present on every `Price` node of the committed getPricing fixture, previously in the "extra attributes … must be ignored" bucket.
- **`PromotionPrice`** — documented on the [official method page](https://www.namecheap.com/support/api/methods/users/get-pricing/); zero occurrences in the SDK before this PR.

Without them a caller cannot report the currency a sheet is denominated in without a second `getBalances` call, and cannot distinguish a promotional price from a special/user price — `Price != RegularPrice` is ambiguous across those cases (fixture `com`/register: `Price=8.88`, `RegularPrice=10.87`, `YourPrice=9.99`).

Closes #139. Unblocks the `namecheap_tld_pricing` data source in namecheap/terraform-provider-namecheap#255.

## Verification status of the attribute names — please read

#139 asked for confirmation against the sandbox API before implementing. **That was not possible here** (no sandbox credentials in this environment), so the evidence behind these two names is:

- `Currency` — **empirical**: it is on every `Price` node of `namecheaptest/fixtures/users_getPricing.xml`.
- `PromotionPrice` — **documentary only**: the official method page and third-party API wikis list it; nothing in this repo has observed it on the wire. The sandbox capture in `sandbox_test.go` narrows to `ProductName=com` and returned no `PromotionPrice`.

If a maintainer with sandbox access can run `make update-fixtures` and confirm the spelling, that closes the gap. The parse is harmless if the name is ever wrong — an unmatched attribute simply leaves the field empty.

## `Promo()` semantics

`Promo() (Amount, bool)` reports **presence, not interpretation**: `true` when the server sent a non-blank attribute, `false` when it omitted it or sent `""`. A zero promotional price is reported as **present**, because the API does not document what a zero means and a free-first-year promotion is a real product — deciding that "0.00" means "no promotion" would be inventing semantics, which this repo explicitly avoids elsewhere (see the "does NOT invent a status code table" note in `domainprivacy.go`). The amount is passed through verbatim, like every other `Amount`.

## Compatibility

Additive only. Both attributes are optional, so every existing response — including the SSL and WHOISGUARD sheets that omit them — decodes exactly as before. No signature, no behaviour and no existing field changed; `EffectivePrice`, `PriceFor` and `isPositiveAmount` are byte-for-byte untouched.

## Doc-mirror line references

The getPricing response table gained two rows, which shifts every `(lines N-M)` citation below it. Beyond the mechanical +2:

- `users_address.go:19` and `users_address_get_info.go:27` cite the doc **without naming the file on the same line**, so the first pass missed them; both are corrected here (`1462-1479`, `1349-1367`).
- The whoisguard ListType-vocabulary citation was **already wrong on master** (it pointed at a table header, not the `ListType` row) and the shift split it across three different values in three files. All three now cite `1563`, the row they describe.

Every citation in `namecheap/*.go` — all ~120, not only the shifted ones — was resolved against the post-change doc and eyeballed for content match. Five pre-existing citations overshoot their table by a line (they include a trailing blank line or the next heading); they are left alone as unrelated, and a follow-up issue proposes a CI check so this convention stops depending on manual diligence.

## Fixture handling

`namecheaptest/fixtures/users_getPricing.xml` is **not** hand-edited to inject a `PromotionPrice`. Note for reviewers: that fixture is byte-identical to the `pricingDomainResponse` test const and has never been re-captured since the corpus was seeded, so it is a synthetic stand-in rather than a live capture — which is exactly why it cannot be used as evidence for `PromotionPrice`, and why a fabricated attribute in it would be misleading. Promo coverage therefore lives in crafted response consts, clearly labelled; the fixture backs a `Currency` assertion, which it genuinely carries.

## Type of change

- [x] New API method *(attribute coverage on an existing method)*
- [x] Documentation

## Checklist

- [x] Tests added or updated
- [x] `make format && make check && make lint && make test-unit-quiet` passes locally (lint: 0 issues; coverage 94.7% core / 82.7% namecheaptest; `make test-race` green)
- [x] All commits have a `Signed-off-by:` trailer

## Tests

| Test | Covers |
|---|---|
| `TestUsersService_GetPricing_Domain` | `Currency` parsed from the captured-style sheet; promotion absent |
| `TestUsersService_GetPricing_PromotionAttributes` | both attributes parsed; tiers that omit them and tiers that send them empty; `EffectivePrice` unmoved — `Price`/`YourPrice`/`PromotionPrice` all differ on the promo tier, so the assertion can only pass for `Price` |
| `TestPrice_Promo` | presence semantics — absent, empty, whitespace → false; `0.00`, `0`, `0.000000`, negative, comma-decimal, exponent → present and verbatim |
| `TestPrice_PromoDoesNotAffectEffectivePrice` | precedence regression guard, incl. a zero promo not zeroing the price |
| `TestRepresentativeFixturesDecodeIntoStructs/users_getPricing` | `Currency` survives decode of the committed fixture |

## Out of scope

The live response carries further attributes (`PricingType`, `AdditionalCost`, `RegularPriceType`, `YourAdditonalCost`, `CouponPrice`, …). #139 scopes this to `Currency` and `PromotionPrice`; the rest stay ignored until something needs them.
