### PR TITLE
feat(amount): export Amount.IsPositive and document the 0.0 promotion sentinel

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,10 +343,10 @@ single-tier lookup. Money is never parsed to `float64`: every amount is an
 documented precedence — server-resolved `Price` (which already reflects any
 promo/special), then `YourPrice` (account price), then `RegularPrice` (list
 price). A tier also exposes the `Currency` it is denominated in and a
-`PromotionPrice`, both of which the server may omit; `Price.Promo()` reports the
-promotion as an explicit "(amount, present)" so an absent attribute is not
-confused with a zero one. The sheet is large and slow-changing, so fetch it once
-and cache it.
+`PromotionPrice`. Note the live API sends `PromotionPrice="0.0"` on tiers with no
+promotion, so ask `price.PromotionPrice.IsPositive()` for "is there a discount";
+`Price.Promo()` answers the narrower "did the server send the attribute at all".
+The sheet is large and slow-changing, so fetch it once and cache it.
 
 ```go
 // Example: check the balance before a bulk renew.

--- a/namecheap/amount.go
+++ b/namecheap/amount.go
@@ -1,5 +1,7 @@
 package namecheap
 
+import "strings"
+
 // Amount is a monetary value kept as the exact decimal string the Namecheap API
 // returned (or that is sent to it), for example "10.87".
 //
@@ -17,3 +19,30 @@ type Amount string
 // Amount can be used where a plain string is expected without an explicit
 // conversion.
 func (a Amount) String() string { return string(a) }
+
+// IsPositive reports whether a is a present, positive money value: "8.88" and
+// "0.01" are positive, while "", "   ", "0", "0.00" and "-1.00" are not.
+//
+// It is decimal-safe by construction — it never parses the amount to a float
+// (see the type doc) — so it cannot mangle the value it is inspecting. It looks
+// for a non-zero digit in an unsigned amount, which is exactly the question
+// "did the server quote a real amount here", and no more: it does not validate
+// the string as a number, so a malformed value the API is not documented to
+// return (say "1,16") is reported by whether it contains a non-zero digit.
+//
+// It answers the question the getPricing attributes keep raising — the live API
+// sends PromotionPrice="0.0" on tiers that carry no promotion, so presence of
+// the attribute is not the same question as "is there a discount". Use this to
+// ask the second one.
+func (a Amount) IsPositive() bool {
+	s := strings.TrimSpace(string(a))
+	if strings.HasPrefix(s, "-") {
+		return false
+	}
+	for _, r := range s {
+		if r >= '1' && r <= '9' {
+			return true
+		}
+	}
+	return false
+}

--- a/namecheap/amount_test.go
+++ b/namecheap/amount_test.go
@@ -13,6 +13,45 @@ func TestAmountString(t *testing.T) {
 	assert.Equal(t, "", Amount("").String())
 }
 
+// TestAmountIsPositive pins the money-presence predicate, including the two
+// shapes the live API actually uses to mean "nothing here" ("" and "0.0") and
+// the sign handling a bare digit scan would get wrong.
+func TestAmountIsPositive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    Amount
+		want bool
+	}{
+		{"typical price", "8.88", true},
+		{"whole units", "10.00", true},
+		{"smallest unit", "0.01", true},
+		{"large amount", "1234567.89", true},
+		{"leading zeros", "007.50", true},
+		{"padded value", "  8.88  ", true},
+		{"empty", "", false},
+		{"whitespace only", "   ", false},
+		{"bare zero", "0", false},
+		{"zero decimal", "0.00", false},
+		{"short zero — the live no-promotion sentinel", "0.0", false},
+		{"many-decimal zero", "0.000000", false},
+		{"negative", "-1.00", false},
+		{"negative zero", "-0.00", false},
+		{"padded negative", "  -12.34  ", false},
+		// Not a validator: a malformed value the API is not documented to send is
+		// judged on whether it carries a non-zero digit, not on being a number.
+		{"comma decimal", "1,16", true},
+		{"non-numeric", "N/A", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.a.IsPositive(), "Amount(%q).IsPositive()", tc.a)
+		})
+	}
+}
+
 // TestAmountXMLExactPreservation asserts an Amount decodes from an attribute
 // verbatim, with no float rounding of a value that binary floats cannot hold.
 func TestAmountXMLExactPreservation(t *testing.T) {

--- a/namecheap/users_get_pricing.go
+++ b/namecheap/users_get_pricing.go
@@ -83,12 +83,18 @@ type Price struct {
 	// (doc line 1133). It is empty when the server omits the attribute, so a
 	// caller that needs a guaranteed currency should fall back to getBalances.
 	Currency string `xml:"Currency,attr"`
-	// PromotionPrice is the promotional price for this tier (doc line 1134). It
-	// is empty when the server omits the attribute; what a zero value means is
-	// not documented, so it is passed through rather than interpreted. Price
-	// already reflects an active promotion (see EffectivePrice); PromotionPrice
-	// is what makes the discount that produced it identifiable rather than
-	// guessed from Price != RegularPrice. Use Promo to test presence.
+	// PromotionPrice is the promotional price for this tier (doc line 1134).
+	//
+	// The live API sends PromotionPrice="0.0" on tiers that carry no promotion
+	// (observed against the sandbox for .com REGISTER/RENEW/TRANSFER), so its
+	// presence does not mean a discount applies — test PromotionPrice.IsPositive()
+	// for that, and use Promo only when you need to distinguish a value the
+	// server sent from one it omitted. The amount is passed through as received
+	// either way.
+	//
+	// Price already reflects an active promotion (see EffectivePrice);
+	// PromotionPrice is what makes the discount that produced it identifiable
+	// rather than guessed from Price != RegularPrice.
 	PromotionPrice Amount `xml:"PromotionPrice,attr"`
 }
 
@@ -207,7 +213,7 @@ func (p *PricingProduct) priceFor(years int) (Price, bool) {
 // still sees the raw server value rather than a fabricated one.
 func (p Price) EffectivePrice() Amount {
 	for _, a := range []Amount{p.Price, p.YourPrice, p.RegularPrice} {
-		if isPositiveAmount(a) {
+		if a.IsPositive() {
 			return a
 		}
 	}
@@ -218,12 +224,12 @@ func (p Price) EffectivePrice() Amount {
 // attribute at all: the raw amount and true when present, the zero Amount and
 // false when the response omitted it (or left it blank).
 //
-// Presence is all it reports. The API documentation does not say what a zero
-// PromotionPrice means — a free-first-year promotion and "no promotion" are not
-// distinguishable from the value alone — so this SDK does not decide for the
-// caller: "0.00" is returned as a present promotion, and interpreting it is the
-// caller's policy. The amount is passed through exactly as received, like every
-// other Amount.
+// Presence is all it reports, and presence is usually the wrong question: the
+// live API sends PromotionPrice="0.0" on un-promoted tiers, so Promo returns
+// true for them. To ask "is there a discount", use
+// price.PromotionPrice.IsPositive(). Promo exists for the narrower case of
+// telling a value the server sent from one it omitted, and it passes the amount
+// through exactly as received, like every other Amount.
 //
 // Promo reports which discount applied; it is not the amount to charge. An
 // active promotion is already folded into Price by the server (doc line 1130),
@@ -233,19 +239,6 @@ func (p Price) Promo() (Amount, bool) {
 		return "", false
 	}
 	return p.PromotionPrice, true
-}
-
-// isPositiveAmount reports whether a is a present, positive money value. It is
-// decimal-safe: it never parses the amount to a float (see Amount), it only
-// checks for the presence of a non-zero digit, so "0.00" and "" are false while
-// "8.88" and "10.00" are true.
-func isPositiveAmount(a Amount) bool {
-	for _, r := range strings.TrimSpace(string(a)) {
-		if r >= '1' && r <= '9' {
-			return true
-		}
-	}
-	return false
 }
 
 // setIfNotNil writes key=*value into params only when value is non-nil and the


### PR DESCRIPTION
## Summary

#155 added `PromotionPrice` parsing but could not confirm what a zero value means — no sandbox credentials. **The live API has now answered.** Running the provider's new pricing data source against the sandbox (namecheap/terraform-provider-namecheap#305, run 30694417935) produced:

```
live data.namecheap_tld_pricing.register.price         = "13.98"
live data.namecheap_tld_pricing.register.regular_price = "13.98"
live data.namecheap_tld_pricing.register.your_price    = "13.98"
live data.namecheap_tld_pricing.register.promo_price   = "0.0"
live data.namecheap_tld_pricing.register.currency      = "USD"
```

`price == regular_price == your_price` is an un-promoted `.com`, and the server still sent `PromotionPrice="0.0"`. So **`0.0` is the API's "no promotion" sentinel**, and presence of the attribute is not the question a consumer wants answered. This also confirms `Currency` and `PromotionPrice` as real attribute names on the live wire — the empirical check #139 asked for.

## Changes

- **`Amount.IsPositive()`** — the predicate that answers "is there a real amount here", promoted from the unexported `isPositiveAmount` (which `EffectivePrice` already used) onto the `Amount` type. Consumers shouldn't have to reimplement a decimal-safe money check, and the only alternative — parsing to a float — is the thing this SDK exists to avoid.
- **Sign handling fixed on the way**: `Amount("-1.00").IsPositive()` is now `false`. The old digit scan returned `true` because the string contains a `1`. No documented API response is negative, so no existing behaviour changes; `EffectivePrice` is unaffected for every value the API actually sends.
- **Docs**: `Price.PromotionPrice` and `Promo` now record the observed `0.0` behaviour and point at `IsPositive` for the discount question, keeping `Promo` for the narrower sent-vs-omitted case. README updated to match.

## Compatibility

Additive plus one strictly-narrowing bug fix on a previously unexported code path. No signature changes, no struct changes, no wire behaviour changes. `EffectivePrice` output is identical for every non-negative amount, which is every amount the documented API returns.

## Tests

`TestAmountIsPositive` — 18 cases: typical prices, `0.01`, padded values, leading zeros; the two live "nothing here" shapes (`""` and `"0.0"`); `0`, `0.00`, `0.000000`; negatives including `-0.00` and padded negatives; and malformed values, which are judged on carrying a non-zero digit because this is a presence predicate, not a validator.

`make format check lint test-unit-quiet` and `make test-race` all green (lint: 0 issues).

## Checklist

- [x] Tests added or updated
- [x] `make format && make check && make lint && make test-unit-quiet` passes locally
- [x] All commits have a `Signed-off-by:` trailer