### PR TITLE
feat(dns): add WithEmailType to the record-level operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,44 @@ address ignored, MXPref exact). An empty selector is **rejected** with a typed
 > that) — but it turns a silent data-loss footgun into an explicit, handleable
 > error.
 
+### Mail records and the zone EmailType
+
+`setHosts` couples mail records to the zone's `EmailType`: an `MX` record is
+rejected unless the zone is `EmailType=MX`, an `MXE` record unless it is `MXE`,
+and an `MX` zone must keep at least one `MX` record. The record helpers preserve
+the EmailType they read, which is right for ordinary A/CNAME/TXT changes but
+makes the mail lifecycle impossible — you cannot add the *first* MX record to a
+`NONE` zone, or remove the *last* one from an `MX` zone.
+
+`WithEmailType` writes a different EmailType with the mutation:
+
+```go
+// Add the first MX record and switch mail routing on, in one write.
+_, err := client.DomainsDNS.AddRecordsWithContext(ctx, "example.com", mxRecords,
+    namecheap.WithEmailType(namecheap.EmailTypeMX))
+
+// Remove the last MX record and switch it off.
+_, err = client.DomainsDNS.DeleteRecordsWithContext(ctx, "example.com",
+    namecheap.RecordSelector{RecordType: namecheap.String(namecheap.RecordTypeMX)},
+    namecheap.WithEmailType(namecheap.EmailTypeNone))
+```
+
+The resulting record set is validated against the EmailType before anything is
+sent, so an invalid combination fails early with an error naming the option
+rather than as an opaque API rejection. `Plan` reports the transition up front:
+
+```go
+diff, _ := client.DomainsDNS.PlanWithContext(ctx, "example.com", namecheap.AddOp(mx...))
+if diff.RequiredEmailType != "" && diff.RequiredEmailType != diff.EmailType {
+    // applying this needs WithEmailType(diff.RequiredEmailType)
+}
+```
+
+> **Leave the option off when mail is managed elsewhere.** On an `FWD` zone
+> (alongside `setEmailForwarding`) or an `OX`/`GMAIL` zone pointing at a hosted
+> mailbox, passing an EmailType silently reroutes that mail. Preserving the
+> existing value — the default — is what you want there.
+
 `NormalizeRecord` and `RecordsEqual` are exported so consumers can reuse the same
 comparison logic (TTL defaults to 1799, hostname lower-cased, `@` apex handling,
 trailing-dot handling, record type upper-cased).

--- a/README.md
+++ b/README.md
@@ -304,11 +304,13 @@ address ignored, MXPref exact). An empty selector is **rejected** with a typed
 > that) — but it turns a silent data-loss footgun into an explicit, handleable
 > error.
 
-### Mail records and the zone EmailType
+#### Mail records and the zone EmailType
 
-`setHosts` couples mail records to the zone's `EmailType`: an `MX` record is
-rejected unless the zone is `EmailType=MX`, an `MXE` record unless it is `MXE`,
-and an `MX` zone must keep at least one `MX` record. The record helpers preserve
+The SDK's client-side `setHosts` validation couples mail records to the zone's
+`EmailType`: an `MX` record is rejected unless the zone is `EmailType=MX`, an
+`MXE` record unless it is `MXE`, and an `MX` zone must keep at least one `MX`
+record. (These rules are the SDK's own — the published API reference documents
+none of them.) The record helpers preserve
 the EmailType they read, which is right for ordinary A/CNAME/TXT changes but
 makes the mail lifecycle impossible — you cannot add the *first* MX record to a
 `NONE` zone, or remove the *last* one from an `MX` zone.
@@ -327,20 +329,34 @@ _, err = client.DomainsDNS.DeleteRecordsWithContext(ctx, "example.com",
 ```
 
 The resulting record set is validated against the EmailType before anything is
-sent, so an invalid combination fails early with an error naming the option
-rather than as an opaque API rejection. `Plan` reports the transition up front:
+written — a `getHosts` still happens, since the final set has to be computed
+before it can be checked — so an invalid combination fails with a typed
+`*InvalidArgumentsError` naming the option, rather than an opaque rejection.
+`Plan` reports the transition up front, in both directions:
 
 ```go
 diff, _ := client.DomainsDNS.PlanWithContext(ctx, "example.com", namecheap.AddOp(mx...))
-if diff.RequiredEmailType != "" && diff.RequiredEmailType != diff.EmailType {
-    // applying this needs WithEmailType(diff.RequiredEmailType)
+if !diff.Satisfiable {
+    // no EmailType can carry this set (MX and MXE together, or several MXE)
+}
+if diff.RequiredEmailType != "" {
+    // applying this needs WithEmailType(diff.RequiredEmailType) — this covers
+    // both adding the first MX record and removing the last one
 }
 ```
 
 > **Leave the option off when mail is managed elsewhere.** On an `FWD` zone
-> (alongside `setEmailForwarding`) or an `OX`/`GMAIL` zone pointing at a hosted
-> mailbox, passing an EmailType silently reroutes that mail. Preserving the
-> existing value — the default — is what you want there.
+> (alongside `setEmailForwarding`), passing an EmailType silently reroutes that
+> mail. Preserving the existing value — the default — is what you want there.
+>
+> **Known limitation — `OX` (Private Email) and `GMAIL` zones.** These keep their
+> provider's MX records in the host list while the zone type stays `OX`/`GMAIL`,
+> a combination the SDK's `setHosts` validation rejects. The record helpers
+> therefore cannot mutate such a zone at all, not even to change an unrelated A
+> record, and the error suggests `WithEmailType(EmailTypeMX)` — which would
+> switch the domain off the hosted mailbox. **Do not follow that suggestion on an
+> OX/GMAIL zone.** Use `GetHosts`/`SetHosts` directly there until the rule is
+> verified against the live API.
 
 `NormalizeRecord` and `RecordsEqual` are exported so consumers can reuse the same
 comparison logic (TTL defaults to 1799, hostname lower-cased, `@` apex handling,

--- a/namecheap/domains_dns_records.go
+++ b/namecheap/domains_dns_records.go
@@ -81,16 +81,20 @@ type RecordDiff struct {
 	Keep   []DomainsDNSHostRecord
 	// EmailType is the zone's current EmailType, as read from getHosts.
 	EmailType string
-	// RequiredEmailType is the EmailType the resulting record set demands, which
-	// is not always the current one: setHosts rejects an MX record unless the
-	// zone is EmailType=MX, and an MXE record unless it is MXE. When it differs
-	// from EmailType, applying this diff needs WithEmailType(RequiredEmailType)
-	// — otherwise the write is rejected client-side before it is sent.
+	// RequiredEmailType is the EmailType this change needs the zone to move to,
+	// or "" when the current one already works — so a non-empty value means
+	// "apply this with WithEmailType(RequiredEmailType)".
 	//
-	// It is empty when the record set imposes no requirement, which is the usual
-	// case: any EmailType may carry A/CNAME/TXT records, so the zone's existing
-	// value is preserved.
+	// The requirement runs in both directions, because the SDK's setHosts
+	// validation ties mail records to the zone type: adding the first MX record
+	// requires moving up to MX, and removing the last one requires moving down to
+	// NONE. Ordinary A/CNAME/TXT changes require nothing and leave this empty.
 	RequiredEmailType string
+	// Satisfiable is false when no EmailType can accept the resulting record set
+	// at all — a set holding both MX and MXE records, or more than one MXE — so
+	// an empty RequiredEmailType is not mistaken for "nothing to do". Applying
+	// such a diff fails whatever EmailType is passed.
+	Satisfiable bool
 }
 
 // String renders the diff as a stable, human-readable summary.
@@ -152,12 +156,13 @@ func WithRetryOnConflict(maxAttempts int) RecordOption {
 // WithEmailType sets the zone EmailType to write with this mutation instead of
 // preserving the value read from getHosts.
 //
-// It exists because setHosts couples mail records to the zone EmailType: an MX
-// record is rejected unless the zone is EmailType=MX, an MXE record unless it is
-// MXE, and an MX zone requires at least one MX record. Preserving the existing
-// value — the default, and the right behaviour for ordinary A/CNAME/TXT changes —
-// therefore makes the mail lifecycle unreachable: the first MX record cannot be
-// added to a NONE zone, and the last one cannot be removed from an MX zone.
+// It exists because the SDK's setHosts validation couples mail records to the
+// zone EmailType: an MX record is rejected unless the zone is EmailType=MX, an
+// MXE record unless it is MXE, and an MX zone must keep at least one MX record.
+// Preserving the existing value — the default, and the right behaviour for
+// ordinary A/CNAME/TXT changes — therefore makes the mail lifecycle unreachable:
+// the first MX record cannot be added to a NONE zone, and the last one cannot be
+// removed from an MX zone.
 //
 //	// Add the first MX record to a zone that has no mail routing yet.
 //	AddRecordsWithContext(ctx, domain, mx, WithEmailType(EmailTypeMX))
@@ -166,10 +171,18 @@ func WithRetryOnConflict(maxAttempts int) RecordOption {
 //	DeleteRecordsWithContext(ctx, domain, sel, WithEmailType(EmailTypeNone))
 //
 // Use it only when the mutation is meant to change mail routing. On a zone whose
-// mail is managed elsewhere — EmailTypeForward alongside setEmailForwarding, or
-// EmailTypePrivate/EmailTypeGmail pointing at a hosted mailbox — passing an
-// EmailType silently reroutes that mail, so leave the option off and let the
-// value be preserved.
+// mail is managed elsewhere — EmailTypeForward alongside setEmailForwarding —
+// passing an EmailType silently reroutes that mail, so leave the option off and
+// let the value be preserved.
+//
+// Known limitation on EmailTypePrivate (OX) and EmailTypeGmail zones: those
+// carry their provider's MX records in the host list while the zone type stays
+// OX/GMAIL, a combination the SDK's setHosts validation rejects. The record
+// helpers therefore cannot mutate such a zone at all — not even to change an
+// unrelated A record — and the resulting error suggests WithEmailType(MX), which
+// would switch the domain off the hosted mailbox. Do not follow that suggestion
+// on an OX/GMAIL zone; use GetHosts/SetHosts directly until the validation rule
+// is verified against the live API.
 //
 // The resulting record set is validated against the requested EmailType before
 // anything is written; see PlanWithContext to preview the transition.
@@ -488,55 +501,93 @@ func recordSetsEqual(a, b []DomainsDNSHostRecord) bool {
 	return true
 }
 
-// requiredEmailType reports the EmailType that records demand of the zone, or ""
-// when they impose none. setHosts accepts an MX record only on an MX zone and an
-// MXE record only on an MXE zone, so a set containing either pins the EmailType;
-// everything else is compatible with any value.
+// requiredEmailType reports the EmailType the zone must carry for records to be
+// writable, given the EmailType it currently has. It returns "" when the current
+// value already works, and false when no EmailType can accept the set.
 //
-// A set containing both MX and MXE records is unsatisfiable — no single
-// EmailType admits both — and is reported as such by validateEmailType rather
-// than here.
-func requiredEmailType(records []DomainsDNSHostRecord) string {
-	var hasMX, hasMXE bool
+// The SDK's setHosts validation accepts an MX record only on an MX zone and an
+// MXE record only on an MXE zone, and additionally requires an MX zone to keep
+// at least one MX record and an MXE zone exactly one. So the requirement runs in
+// both directions: adding the first MX record demands a move up to MX, and
+// removing the last one demands a move down to NONE.
+func requiredEmailType(records []DomainsDNSHostRecord, current string) (string, bool) {
+	var mxCount, mxeCount int
 	for _, r := range records {
 		switch normRecordType(derefStr(r.RecordType)) {
 		case RecordTypeMX:
-			hasMX = true
-		case RecordTypeMXE:
-			hasMXE = true
-		}
-	}
-	switch {
-	case hasMX && hasMXE:
-		return "" // unsatisfiable; validateEmailType explains it
-	case hasMX:
-		return EmailTypeMX
-	case hasMXE:
-		return EmailTypeMXE
-	default:
-		return ""
-	}
-}
-
-// validateEmailType checks the resulting record set against the EmailType the
-// write will carry, before any request is sent. setHosts enforces the same rules
-// server-side and the SDK's own SetHosts validator repeats them, but neither can
-// say what a record-level caller should do about it — these errors name
-// WithEmailType, because that is the fix.
-func validateEmailType(records []DomainsDNSHostRecord, emailType string, explicit bool) error {
-	var hasMX, mxeCount int
-	for _, r := range records {
-		switch normRecordType(derefStr(r.RecordType)) {
-		case RecordTypeMX:
-			hasMX++
+			mxCount++
 		case RecordTypeMXE:
 			mxeCount++
 		}
 	}
 
-	if hasMX > 0 && mxeCount > 0 {
-		return fmt.Errorf("record set contains both MX and MXE records, which no EmailType accepts: "+
-			"MX records require EmailType=%s and MXE records require EmailType=%s", EmailTypeMX, EmailTypeMXE)
+	switch {
+	case mxCount > 0 && mxeCount > 0:
+		// No single EmailType admits both.
+		return "", false
+	case mxCount > 0:
+		return transitionTo(EmailTypeMX, current), true
+	case mxeCount != 1 && current == EmailTypeMXE:
+		// An MXE zone requires exactly one MXE record; without it, mail routing
+		// has to come down.
+		return EmailTypeNone, true
+	case mxeCount == 1:
+		return transitionTo(EmailTypeMXE, current), true
+	case mxeCount > 1:
+		return "", false
+	case current == EmailTypeMX:
+		// The set has no MX record left, which an MX zone cannot be.
+		return EmailTypeNone, true
+	default:
+		return "", true
+	}
+}
+
+// transitionTo returns want when it differs from current, and "" when the zone
+// is already there — so callers can treat a non-empty value as "you must pass
+// WithEmailType".
+func transitionTo(want, current string) string {
+	if want == current {
+		return ""
+	}
+	return want
+}
+
+// validateEmailType checks the resulting record set against the EmailType the
+// write will carry, before anything is written.
+//
+// These are the SDK's client-side setHosts rules (see
+// validateDomainsDNSSetHostsArgs), which SetHosts would enforce a moment later
+// anyway — but its message cannot tell a record-level caller what to do about
+// it. These errors name WithEmailType, because that is the fix. They are
+// *InvalidArgumentsError so a caller can tell "your request is invalid, fail
+// fast" from "the API call failed, maybe retry".
+func validateEmailType(records []DomainsDNSHostRecord, emailType string, explicit bool) error {
+	if explicit && !isValidEmailType(emailType) {
+		return &InvalidArgumentsError{
+			Fields: []string{"EmailType"},
+			Reason: fmt.Sprintf("WithEmailType(%q) is not a valid EmailType; allowed values are %s",
+				emailType, strings.Join(AllowedEmailTypeValues, ", ")),
+		}
+	}
+
+	var mxCount, mxeCount int
+	for _, r := range records {
+		switch normRecordType(derefStr(r.RecordType)) {
+		case RecordTypeMX:
+			mxCount++
+		case RecordTypeMXE:
+			mxeCount++
+		}
+	}
+
+	invalid := func(format string, args ...any) error {
+		return &InvalidArgumentsError{Fields: []string{"EmailType"}, Reason: fmt.Sprintf(format, args...)}
+	}
+
+	if mxCount > 0 && mxeCount > 0 {
+		return invalid("record set contains both MX and MXE records, which no EmailType accepts: "+
+			"MX records need EmailType=%s and MXE records need EmailType=%s", EmailTypeMX, EmailTypeMXE)
 	}
 
 	source := "the zone's current EmailType"
@@ -544,22 +595,22 @@ func validateEmailType(records []DomainsDNSHostRecord, emailType string, explici
 		source = "the EmailType passed to WithEmailType"
 	}
 
-	if hasMX > 0 && emailType != EmailTypeMX {
-		return fmt.Errorf("the resulting record set has %d MX record(s), which setHosts accepts only on an "+
-			"EmailType=%s zone, but %s is %q: pass WithEmailType(EmailTypeMX)", hasMX, EmailTypeMX, source, emailType)
-	}
-	if mxeCount > 0 && emailType != EmailTypeMXE {
-		return fmt.Errorf("the resulting record set has %d MXE record(s), which setHosts accepts only on an "+
-			"EmailType=%s zone, but %s is %q: pass WithEmailType(EmailTypeMXE)", mxeCount, EmailTypeMXE, source, emailType)
-	}
-	if emailType == EmailTypeMX && hasMX == 0 {
-		return fmt.Errorf("%s is %s, which setHosts requires at least one MX record for, but the resulting "+
-			"record set has none: pass WithEmailType(EmailTypeNone) to turn mail routing off in the same write",
-			source, EmailTypeMX)
-	}
-	if emailType == EmailTypeMXE && mxeCount != 1 {
-		return fmt.Errorf("%s is %s, which setHosts requires exactly one MXE record for, but the resulting "+
-			"record set has %d", source, EmailTypeMXE, mxeCount)
+	switch {
+	case mxCount > 0 && emailType != EmailTypeMX:
+		return invalid("the resulting record set has %d MX record(s), which the SDK's setHosts validation "+
+			"accepts only on an EmailType=%s zone, but %s is %q: pass WithEmailType(EmailTypeMX)",
+			mxCount, EmailTypeMX, source, emailType)
+	case mxeCount > 0 && emailType != EmailTypeMXE:
+		return invalid("the resulting record set has %d MXE record(s), which the SDK's setHosts validation "+
+			"accepts only on an EmailType=%s zone, but %s is %q: pass WithEmailType(EmailTypeMXE)",
+			mxeCount, EmailTypeMXE, source, emailType)
+	case emailType == EmailTypeMX && mxCount == 0:
+		return invalid("%s is %s, which the SDK's setHosts validation requires at least one MX record for, "+
+			"but the resulting record set has none: pass WithEmailType(EmailTypeNone) to turn mail routing "+
+			"off in the same write", source, EmailTypeMX)
+	case emailType == EmailTypeMXE && mxeCount != 1:
+		return invalid("%s is %s, which the SDK's setHosts validation requires exactly one MXE record for, "+
+			"but the resulting record set has %d", source, EmailTypeMXE, mxeCount)
 	}
 	return nil
 }
@@ -588,7 +639,8 @@ func recordsFromResult(resp *DomainsDNSGetHostsCommandResponse) ([]DomainsDNSHos
 }
 
 // buildSetHostsArgs assembles the setHosts arguments for a full-zone write,
-// always carrying the (preserved) EmailType so email routing is not disturbed.
+// always carrying an explicit EmailType: the value read from getHosts unless the
+// caller overrode it with WithEmailType.
 func buildSetHostsArgs(domain string, records []DomainsDNSHostRecord, emailType string) *DomainsDNSSetHostsArgs {
 	return &DomainsDNSSetHostsArgs{
 		Domain:    &domain,
@@ -642,7 +694,9 @@ func (dds *DomainsDNSService) PlanWithContext(ctx context.Context, domain string
 	current, emailType := recordsFromResult(getResp)
 	diff, final := computeDiff(current, ops)
 	diff.EmailType = emailType
-	diff.RequiredEmailType = requiredEmailType(final)
+	required, satisfiable := requiredEmailType(final, emailType)
+	diff.RequiredEmailType = required
+	diff.Satisfiable = satisfiable
 	return diff, nil
 }
 
@@ -701,8 +755,12 @@ func (dds *DomainsDNSService) attemptRecordOps(ctx context.Context, domain strin
 	if err != nil {
 		return nil, false, err
 	}
-	got, _ := recordsFromResult(verifyResp)
-	if !recordSetsEqual(got, final) {
+	got, gotEmailType := recordsFromResult(verifyResp)
+	// The EmailType is part of what this write set, so a concurrent writer that
+	// reverted it has to count as a conflict — otherwise WithEmailType's own
+	// effect would sit outside the guarantee this layer advertises, and the
+	// caller would be told the mail transition succeeded when it did not.
+	if !recordSetsEqual(got, final) || gotEmailType != emailType {
 		return nil, true, nil
 	}
 

--- a/namecheap/domains_dns_records.go
+++ b/namecheap/domains_dns_records.go
@@ -79,12 +79,27 @@ type RecordDiff struct {
 	Add    []DomainsDNSHostRecord
 	Remove []DomainsDNSHostRecord
 	Keep   []DomainsDNSHostRecord
+	// EmailType is the zone's current EmailType, as read from getHosts.
+	EmailType string
+	// RequiredEmailType is the EmailType the resulting record set demands, which
+	// is not always the current one: setHosts rejects an MX record unless the
+	// zone is EmailType=MX, and an MXE record unless it is MXE. When it differs
+	// from EmailType, applying this diff needs WithEmailType(RequiredEmailType)
+	// — otherwise the write is rejected client-side before it is sent.
+	//
+	// It is empty when the record set imposes no requirement, which is the usual
+	// case: any EmailType may carry A/CNAME/TXT records, so the zone's existing
+	// value is preserved.
+	RequiredEmailType string
 }
 
 // String renders the diff as a stable, human-readable summary.
 func (d RecordDiff) String() string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "RecordDiff: +%d -%d =%d", len(d.Add), len(d.Remove), len(d.Keep))
+	if d.RequiredEmailType != "" && d.RequiredEmailType != d.EmailType {
+		fmt.Fprintf(&b, "\n  EmailType: %s -> %s", d.EmailType, d.RequiredEmailType)
+	}
 	for _, r := range d.Add {
 		fmt.Fprintf(&b, "\n  + %s", recordString(r))
 	}
@@ -115,6 +130,9 @@ type RecordOption func(*recordOptions)
 
 type recordOptions struct {
 	maxAttempts int
+	// emailType, when non-nil, replaces the zone EmailType read from getHosts
+	// instead of preserving it.
+	emailType *string
 }
 
 // WithRetryOnConflict enables automatic retry of the whole
@@ -128,6 +146,36 @@ func WithRetryOnConflict(maxAttempts int) RecordOption {
 			maxAttempts = 1
 		}
 		o.maxAttempts = maxAttempts
+	}
+}
+
+// WithEmailType sets the zone EmailType to write with this mutation instead of
+// preserving the value read from getHosts.
+//
+// It exists because setHosts couples mail records to the zone EmailType: an MX
+// record is rejected unless the zone is EmailType=MX, an MXE record unless it is
+// MXE, and an MX zone requires at least one MX record. Preserving the existing
+// value — the default, and the right behaviour for ordinary A/CNAME/TXT changes —
+// therefore makes the mail lifecycle unreachable: the first MX record cannot be
+// added to a NONE zone, and the last one cannot be removed from an MX zone.
+//
+//	// Add the first MX record to a zone that has no mail routing yet.
+//	AddRecordsWithContext(ctx, domain, mx, WithEmailType(EmailTypeMX))
+//
+//	// Remove the last MX record and turn mail routing off in the same write.
+//	DeleteRecordsWithContext(ctx, domain, sel, WithEmailType(EmailTypeNone))
+//
+// Use it only when the mutation is meant to change mail routing. On a zone whose
+// mail is managed elsewhere — EmailTypeForward alongside setEmailForwarding, or
+// EmailTypePrivate/EmailTypeGmail pointing at a hosted mailbox — passing an
+// EmailType silently reroutes that mail, so leave the option off and let the
+// value be preserved.
+//
+// The resulting record set is validated against the requested EmailType before
+// anything is written; see PlanWithContext to preview the transition.
+func WithEmailType(emailType string) RecordOption {
+	return func(o *recordOptions) {
+		o.emailType = &emailType
 	}
 }
 
@@ -440,6 +488,82 @@ func recordSetsEqual(a, b []DomainsDNSHostRecord) bool {
 	return true
 }
 
+// requiredEmailType reports the EmailType that records demand of the zone, or ""
+// when they impose none. setHosts accepts an MX record only on an MX zone and an
+// MXE record only on an MXE zone, so a set containing either pins the EmailType;
+// everything else is compatible with any value.
+//
+// A set containing both MX and MXE records is unsatisfiable — no single
+// EmailType admits both — and is reported as such by validateEmailType rather
+// than here.
+func requiredEmailType(records []DomainsDNSHostRecord) string {
+	var hasMX, hasMXE bool
+	for _, r := range records {
+		switch normRecordType(derefStr(r.RecordType)) {
+		case RecordTypeMX:
+			hasMX = true
+		case RecordTypeMXE:
+			hasMXE = true
+		}
+	}
+	switch {
+	case hasMX && hasMXE:
+		return "" // unsatisfiable; validateEmailType explains it
+	case hasMX:
+		return EmailTypeMX
+	case hasMXE:
+		return EmailTypeMXE
+	default:
+		return ""
+	}
+}
+
+// validateEmailType checks the resulting record set against the EmailType the
+// write will carry, before any request is sent. setHosts enforces the same rules
+// server-side and the SDK's own SetHosts validator repeats them, but neither can
+// say what a record-level caller should do about it — these errors name
+// WithEmailType, because that is the fix.
+func validateEmailType(records []DomainsDNSHostRecord, emailType string, explicit bool) error {
+	var hasMX, mxeCount int
+	for _, r := range records {
+		switch normRecordType(derefStr(r.RecordType)) {
+		case RecordTypeMX:
+			hasMX++
+		case RecordTypeMXE:
+			mxeCount++
+		}
+	}
+
+	if hasMX > 0 && mxeCount > 0 {
+		return fmt.Errorf("record set contains both MX and MXE records, which no EmailType accepts: "+
+			"MX records require EmailType=%s and MXE records require EmailType=%s", EmailTypeMX, EmailTypeMXE)
+	}
+
+	source := "the zone's current EmailType"
+	if explicit {
+		source = "the EmailType passed to WithEmailType"
+	}
+
+	if hasMX > 0 && emailType != EmailTypeMX {
+		return fmt.Errorf("the resulting record set has %d MX record(s), which setHosts accepts only on an "+
+			"EmailType=%s zone, but %s is %q: pass WithEmailType(EmailTypeMX)", hasMX, EmailTypeMX, source, emailType)
+	}
+	if mxeCount > 0 && emailType != EmailTypeMXE {
+		return fmt.Errorf("the resulting record set has %d MXE record(s), which setHosts accepts only on an "+
+			"EmailType=%s zone, but %s is %q: pass WithEmailType(EmailTypeMXE)", mxeCount, EmailTypeMXE, source, emailType)
+	}
+	if emailType == EmailTypeMX && hasMX == 0 {
+		return fmt.Errorf("%s is %s, which setHosts requires at least one MX record for, but the resulting "+
+			"record set has none: pass WithEmailType(EmailTypeNone) to turn mail routing off in the same write",
+			source, EmailTypeMX)
+	}
+	if emailType == EmailTypeMXE && mxeCount != 1 {
+		return fmt.Errorf("%s is %s, which setHosts requires exactly one MXE record for, but the resulting "+
+			"record set has %d", source, EmailTypeMXE, mxeCount)
+	}
+	return nil
+}
+
 // recordsFromResult extracts the settable record set and the zone EmailType from
 // a getHosts response. A nil or empty EmailType defaults to EmailTypeNone so a
 // partial update never silently clears email routing.
@@ -474,7 +598,8 @@ func buildSetHostsArgs(domain string, records []DomainsDNSHostRecord, emailType 
 }
 
 // AddRecordsWithContext appends records to domain's zone, preserving every
-// existing record (and the zone EmailType), then verifies the result by
+// existing record (and, unless WithEmailType is supplied, the zone EmailType),
+// then verifies the result by
 // re-reading the zone. It returns ErrConcurrentModification if the zone changed
 // under it, unless WithRetryOnConflict is supplied. See the package README on
 // the non-transactional setHosts API.
@@ -483,7 +608,8 @@ func (dds *DomainsDNSService) AddRecordsWithContext(ctx context.Context, domain 
 }
 
 // DeleteRecordsWithContext removes every record matching selector from domain's
-// zone, preserving the rest (and the zone EmailType), then verifies the result.
+// zone, preserving the rest (and, unless WithEmailType is supplied, the zone
+// EmailType), then verifies the result.
 // An empty selector is rejected before any request; use
 // RecordSelector{MatchAll: true} to intentionally delete all records. It returns
 // ErrConcurrentModification on a detected race unless WithRetryOnConflict is
@@ -493,8 +619,8 @@ func (dds *DomainsDNSService) DeleteRecordsWithContext(ctx context.Context, doma
 }
 
 // UpsertRecordsWithContext replaces exactly the records matching selector with
-// records, preserving all other records (and the zone EmailType), then verifies
-// the result. An empty selector is rejected before any request. It returns
+// records, preserving all other records (and, unless WithEmailType is supplied,
+// the zone EmailType), then verifies the result. An empty selector is rejected before any request. It returns
 // ErrConcurrentModification on a detected race unless WithRetryOnConflict is
 // supplied.
 func (dds *DomainsDNSService) UpsertRecordsWithContext(ctx context.Context, domain string, selector RecordSelector, records []DomainsDNSHostRecord, opts ...RecordOption) (*RecordChangeResult, error) {
@@ -513,8 +639,10 @@ func (dds *DomainsDNSService) PlanWithContext(ctx context.Context, domain string
 	if err != nil {
 		return RecordDiff{}, err
 	}
-	current, _ := recordsFromResult(getResp)
-	diff, _ := computeDiff(current, ops)
+	current, emailType := recordsFromResult(getResp)
+	diff, final := computeDiff(current, ops)
+	diff.EmailType = emailType
+	diff.RequiredEmailType = requiredEmailType(final)
 	return diff, nil
 }
 
@@ -529,7 +657,7 @@ func (dds *DomainsDNSService) applyRecordOps(ctx context.Context, domain string,
 
 	var lastErr error
 	for attempt := 0; attempt < cfg.maxAttempts; attempt++ {
-		result, conflict, err := dds.attemptRecordOps(ctx, domain, ops)
+		result, conflict, err := dds.attemptRecordOps(ctx, domain, ops, cfg)
 		if err != nil {
 			return nil, err
 		}
@@ -545,7 +673,7 @@ func (dds *DomainsDNSService) applyRecordOps(ctx context.Context, domain string,
 // conflict (second return value) when the verifying re-read does not match the
 // record set it intended to write; a conflict is not an error so the caller can
 // decide whether to retry.
-func (dds *DomainsDNSService) attemptRecordOps(ctx context.Context, domain string, ops []RecordOp) (*RecordChangeResult, bool, error) {
+func (dds *DomainsDNSService) attemptRecordOps(ctx context.Context, domain string, ops []RecordOp, cfg recordOptions) (*RecordChangeResult, bool, error) {
 	getResp, err := dds.GetHostsWithContext(ctx, domain)
 	if err != nil {
 		return nil, false, err
@@ -553,6 +681,16 @@ func (dds *DomainsDNSService) attemptRecordOps(ctx context.Context, domain strin
 	current, emailType := recordsFromResult(getResp)
 
 	diff, final := computeDiff(current, ops)
+
+	// WithEmailType replaces the preserved value; without it the zone keeps the
+	// EmailType it already had.
+	explicitEmailType := cfg.emailType != nil
+	if explicitEmailType {
+		emailType = *cfg.emailType
+	}
+	if err := validateEmailType(final, emailType, explicitEmailType); err != nil {
+		return nil, false, err
+	}
 
 	setResp, err := dds.SetHostsWithContext(ctx, buildSetHostsArgs(domain, final, emailType))
 	if err != nil {

--- a/namecheap/domains_dns_records_test.go
+++ b/namecheap/domains_dns_records_test.go
@@ -664,3 +664,261 @@ func TestRecordsEqual(t *testing.T) {
 	d := DomainsDNSHostRecord{HostName: String("www"), RecordType: String(RecordTypeA), Address: String("target.com"), TTL: Int(60)}
 	assert.False(t, RecordsEqual(b, d))
 }
+
+// --- EmailType control (issue #138) -----------------------------------------
+//
+// setHosts couples mail records to the zone EmailType, so preserving the value
+// read from getHosts — the default — makes the mail lifecycle unreachable
+// through the record-level API. These tests pin both halves: the lifecycle works
+// with WithEmailType, and without it the caller gets an error that names the fix
+// before anything is written.
+
+// TestAddFirstMXRecordWithEmailType covers the case the record-level API could
+// not express at all: creating the first MX record on a zone with no mail
+// routing, which requires flipping EmailType in the same write.
+func TestAddFirstMXRecordWithEmailType(t *testing.T) {
+	t.Parallel()
+	m := newDNSMock(EmailTypeNone, []DomainsDNSHostRecordDetailed{
+		detailed("@", RecordTypeA, "10.0.0.1", nil, 1800),
+	})
+	client, server := mockedClient(m)
+	defer server.Close()
+
+	res, err := client.DomainsDNS.AddRecordsWithContext(context.Background(), "domain.net",
+		[]DomainsDNSHostRecord{
+			{HostName: String("@"), RecordType: String(RecordTypeMX), Address: String("mail.example.com"), MXPref: UInt8(10), TTL: Int(1800)},
+		}, WithEmailType(EmailTypeMX))
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.Equal(t, 1, res.Added)
+
+	assert.Len(t, m.setParams, 1)
+	assert.Equal(t, EmailTypeMX, m.setParams[0].Get("EmailType"), "the write must carry the requested EmailType")
+	assertRequestHasRecord(t, m.setParams[0], "@", RecordTypeMX, "mail.example.com", "1800", "10")
+	// The pre-existing record is untouched by the EmailType change.
+	assertRequestHasRecord(t, m.setParams[0], "@", RecordTypeA, "10.0.0.1", "1800", "")
+}
+
+// TestDeleteLastMXRecordWithEmailType is the mirror case: removing the last MX
+// record requires turning mail routing off in the same write, because an MX zone
+// must keep at least one MX record.
+func TestDeleteLastMXRecordWithEmailType(t *testing.T) {
+	t.Parallel()
+	m := newDNSMock(EmailTypeMX, []DomainsDNSHostRecordDetailed{
+		detailed("@", RecordTypeA, "10.0.0.1", nil, 1800),
+		detailed("@", RecordTypeMX, "mail.example.com", Int(10), 1800),
+	})
+	client, server := mockedClient(m)
+	defer server.Close()
+
+	res, err := client.DomainsDNS.DeleteRecordsWithContext(context.Background(), "domain.net",
+		RecordSelector{RecordType: String(RecordTypeMX)}, WithEmailType(EmailTypeNone))
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.Equal(t, 1, res.Removed)
+
+	assert.Len(t, m.setParams, 1)
+	assert.Equal(t, EmailTypeNone, m.setParams[0].Get("EmailType"))
+	assert.False(t, zoneHas(m, "@", RecordTypeMX, "mail.example.com"))
+	assert.True(t, zoneHas(m, "@", RecordTypeA, "10.0.0.1"), "unrelated records survive")
+}
+
+// TestMXERecordLifecycleWithEmailType covers MXE, which was entirely unreachable
+// through the conflict-safe layer.
+func TestMXERecordLifecycleWithEmailType(t *testing.T) {
+	t.Parallel()
+	m := newDNSMock(EmailTypeNone, []DomainsDNSHostRecordDetailed{
+		detailed("@", RecordTypeA, "10.0.0.1", nil, 1800),
+	})
+	client, server := mockedClient(m)
+	defer server.Close()
+
+	_, err := client.DomainsDNS.AddRecordsWithContext(context.Background(), "domain.net",
+		[]DomainsDNSHostRecord{
+			{HostName: String("@"), RecordType: String(RecordTypeMXE), Address: String("10.0.0.5"), TTL: Int(1800)},
+		}, WithEmailType(EmailTypeMXE))
+	assert.NoError(t, err)
+	assert.Equal(t, EmailTypeMXE, m.setParams[0].Get("EmailType"))
+
+	_, err = client.DomainsDNS.DeleteRecordsWithContext(context.Background(), "domain.net",
+		RecordSelector{RecordType: String(RecordTypeMXE)}, WithEmailType(EmailTypeNone))
+	assert.NoError(t, err)
+	assert.Equal(t, EmailTypeNone, m.setParams[1].Get("EmailType"))
+	assert.False(t, zoneHas(m, "@", RecordTypeMXE, "10.0.0.5"))
+}
+
+// TestEmailTypeMismatchRejectedBeforeWrite is the usability half: without the
+// option the mutation still cannot happen, but it fails with an error naming
+// WithEmailType, and — critically — before any setHosts is sent, so a rejected
+// change never half-applies.
+func TestEmailTypeMismatchRejectedBeforeWrite(t *testing.T) {
+	t.Parallel()
+
+	t.Run("first MX on a NONE zone", func(t *testing.T) {
+		t.Parallel()
+		m := newDNSMock(EmailTypeNone, []DomainsDNSHostRecordDetailed{
+			detailed("@", RecordTypeA, "10.0.0.1", nil, 1800),
+		})
+		client, server := mockedClient(m)
+		defer server.Close()
+
+		_, err := client.DomainsDNS.AddRecordsWithContext(context.Background(), "domain.net",
+			[]DomainsDNSHostRecord{
+				{HostName: String("@"), RecordType: String(RecordTypeMX), Address: String("mail.example.com"), MXPref: UInt8(10), TTL: Int(1800)},
+			})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "WithEmailType(EmailTypeMX)")
+		assert.Empty(t, m.setParams, "nothing may be written when the combination is invalid")
+	})
+
+	t.Run("last MX off an MX zone", func(t *testing.T) {
+		t.Parallel()
+		m := newDNSMock(EmailTypeMX, []DomainsDNSHostRecordDetailed{
+			detailed("@", RecordTypeMX, "mail.example.com", Int(10), 1800),
+		})
+		client, server := mockedClient(m)
+		defer server.Close()
+
+		_, err := client.DomainsDNS.DeleteRecordsWithContext(context.Background(), "domain.net",
+			RecordSelector{RecordType: String(RecordTypeMX)})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "WithEmailType(EmailTypeNone)")
+		assert.Empty(t, m.setParams)
+	})
+
+	t.Run("explicit EmailType that the records contradict", func(t *testing.T) {
+		t.Parallel()
+		m := newDNSMock(EmailTypeNone, nil)
+		client, server := mockedClient(m)
+		defer server.Close()
+
+		_, err := client.DomainsDNS.AddRecordsWithContext(context.Background(), "domain.net",
+			[]DomainsDNSHostRecord{
+				{HostName: String("@"), RecordType: String(RecordTypeMX), Address: String("mail.example.com"), MXPref: UInt8(10), TTL: Int(1800)},
+			}, WithEmailType(EmailTypeForward))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "WithEmailType", "the error should point at the option the caller used")
+		assert.Contains(t, err.Error(), EmailTypeForward)
+		assert.Empty(t, m.setParams)
+	})
+}
+
+// TestEmailTypePreservedByDefault is the regression guard for every existing
+// caller: an ordinary record change must still leave mail routing exactly as it
+// found it.
+func TestEmailTypePreservedByDefault(t *testing.T) {
+	t.Parallel()
+	for _, emailType := range []string{EmailTypeNone, EmailTypeMX, EmailTypeForward, EmailTypePrivate, EmailTypeGmail} {
+		t.Run(emailType, func(t *testing.T) {
+			t.Parallel()
+			zone := []DomainsDNSHostRecordDetailed{detailed("@", RecordTypeA, "10.0.0.1", nil, 1800)}
+			if emailType == EmailTypeMX {
+				zone = append(zone, detailed("@", RecordTypeMX, "mail.example.com", Int(10), 1800))
+			}
+			m := newDNSMock(emailType, zone)
+			client, server := mockedClient(m)
+			defer server.Close()
+
+			_, err := client.DomainsDNS.AddRecordsWithContext(context.Background(), "domain.net",
+				[]DomainsDNSHostRecord{
+					{HostName: String("www"), RecordType: String(RecordTypeA), Address: String("10.0.0.2"), TTL: Int(1800)},
+				})
+			assert.NoError(t, err)
+			assert.Len(t, m.setParams, 1)
+			assert.Equal(t, emailType, m.setParams[0].Get("EmailType"),
+				"an A-record change must not disturb mail routing")
+		})
+	}
+}
+
+// TestPlanSurfacesEmailTypeTransition proves a caller can see the transition
+// before writing, which is what makes the requirement discoverable rather than
+// something you learn from an error.
+func TestPlanSurfacesEmailTypeTransition(t *testing.T) {
+	t.Parallel()
+	m := newDNSMock(EmailTypeNone, []DomainsDNSHostRecordDetailed{
+		detailed("@", RecordTypeA, "10.0.0.1", nil, 1800),
+	})
+	client, server := mockedClient(m)
+	defer server.Close()
+
+	diff, err := client.DomainsDNS.PlanWithContext(context.Background(), "domain.net",
+		AddOp(DomainsDNSHostRecord{
+			HostName: String("@"), RecordType: String(RecordTypeMX), Address: String("mail.example.com"), MXPref: UInt8(10), TTL: Int(1800),
+		}))
+	assert.NoError(t, err)
+	assert.Equal(t, EmailTypeNone, diff.EmailType)
+	assert.Equal(t, EmailTypeMX, diff.RequiredEmailType)
+	assert.Contains(t, diff.String(), "EmailType: NONE -> MX")
+	assert.Zero(t, m.setCount, "Plan never writes")
+
+	// A change that imposes no requirement leaves RequiredEmailType empty, so a
+	// caller can treat non-empty-and-different as "you must pass WithEmailType".
+	plain, err := client.DomainsDNS.PlanWithContext(context.Background(), "domain.net",
+		AddOp(DomainsDNSHostRecord{
+			HostName: String("www"), RecordType: String(RecordTypeA), Address: String("10.0.0.2"), TTL: Int(1800),
+		}))
+	assert.NoError(t, err)
+	assert.Equal(t, EmailTypeNone, plain.EmailType)
+	assert.Empty(t, plain.RequiredEmailType)
+	assert.NotContains(t, plain.String(), "EmailType:")
+}
+
+// TestValidateEmailType unit-tests the rule table directly, including the
+// combination no EmailType can satisfy.
+func TestValidateEmailType(t *testing.T) {
+	t.Parallel()
+
+	mx := DomainsDNSHostRecord{HostName: String("@"), RecordType: String(RecordTypeMX), Address: String("mail.example.com"), MXPref: UInt8(10)}
+	mxe := DomainsDNSHostRecord{HostName: String("@"), RecordType: String(RecordTypeMXE), Address: String("10.0.0.5")}
+	a := DomainsDNSHostRecord{HostName: String("@"), RecordType: String(RecordTypeA), Address: String("10.0.0.1")}
+
+	tests := []struct {
+		name      string
+		records   []DomainsDNSHostRecord
+		emailType string
+		wantErr   string
+	}{
+		{"plain records on any type", []DomainsDNSHostRecord{a}, EmailTypeNone, ""},
+		{"plain records on a forwarding zone", []DomainsDNSHostRecord{a}, EmailTypeForward, ""},
+		{"MX on an MX zone", []DomainsDNSHostRecord{a, mx}, EmailTypeMX, ""},
+		{"one MXE on an MXE zone", []DomainsDNSHostRecord{a, mxe}, EmailTypeMXE, ""},
+		{"MX on a NONE zone", []DomainsDNSHostRecord{mx}, EmailTypeNone, "pass WithEmailType(EmailTypeMX)"},
+		{"MX on a forwarding zone", []DomainsDNSHostRecord{mx}, EmailTypeForward, "pass WithEmailType(EmailTypeMX)"},
+		{"MXE on a NONE zone", []DomainsDNSHostRecord{mxe}, EmailTypeNone, "pass WithEmailType(EmailTypeMXE)"},
+		{"MX zone with no MX record", []DomainsDNSHostRecord{a}, EmailTypeMX, "at least one MX record"},
+		{"MXE zone with two MXE records", []DomainsDNSHostRecord{mxe, mxe}, EmailTypeMXE, "exactly one MXE record"},
+		{"MXE zone with no MXE record", []DomainsDNSHostRecord{a}, EmailTypeMXE, "exactly one MXE record"},
+		{"MX and MXE together", []DomainsDNSHostRecord{mx, mxe}, EmailTypeMX, "no EmailType accepts"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateEmailType(tc.records, tc.emailType, false)
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// TestRequiredEmailType pins what a record set demands of the zone.
+func TestRequiredEmailType(t *testing.T) {
+	t.Parallel()
+
+	mx := DomainsDNSHostRecord{RecordType: String(RecordTypeMX)}
+	mxe := DomainsDNSHostRecord{RecordType: String(RecordTypeMXE)}
+	a := DomainsDNSHostRecord{RecordType: String(RecordTypeA)}
+
+	assert.Empty(t, requiredEmailType(nil))
+	assert.Empty(t, requiredEmailType([]DomainsDNSHostRecord{a}))
+	assert.Equal(t, EmailTypeMX, requiredEmailType([]DomainsDNSHostRecord{a, mx}))
+	assert.Equal(t, EmailTypeMXE, requiredEmailType([]DomainsDNSHostRecord{a, mxe}))
+	// Unsatisfiable sets impose no single requirement; validateEmailType explains.
+	assert.Empty(t, requiredEmailType([]DomainsDNSHostRecord{mx, mxe}))
+	// Record type matching is case-insensitive, like the rest of the layer.
+	assert.Equal(t, EmailTypeMX, requiredEmailType([]DomainsDNSHostRecord{{RecordType: String("mx")}}))
+}

--- a/namecheap/domains_dns_records_test.go
+++ b/namecheap/domains_dns_records_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -905,7 +906,7 @@ func TestValidateEmailType(t *testing.T) {
 	}
 }
 
-// TestRequiredEmailType pins what a record set demands of the zone.
+// TestRequiredEmailType pins the transition a change needs, in both directions.
 func TestRequiredEmailType(t *testing.T) {
 	t.Parallel()
 
@@ -913,12 +914,148 @@ func TestRequiredEmailType(t *testing.T) {
 	mxe := DomainsDNSHostRecord{RecordType: String(RecordTypeMXE)}
 	a := DomainsDNSHostRecord{RecordType: String(RecordTypeA)}
 
-	assert.Empty(t, requiredEmailType(nil))
-	assert.Empty(t, requiredEmailType([]DomainsDNSHostRecord{a}))
-	assert.Equal(t, EmailTypeMX, requiredEmailType([]DomainsDNSHostRecord{a, mx}))
-	assert.Equal(t, EmailTypeMXE, requiredEmailType([]DomainsDNSHostRecord{a, mxe}))
-	// Unsatisfiable sets impose no single requirement; validateEmailType explains.
-	assert.Empty(t, requiredEmailType([]DomainsDNSHostRecord{mx, mxe}))
-	// Record type matching is case-insensitive, like the rest of the layer.
-	assert.Equal(t, EmailTypeMX, requiredEmailType([]DomainsDNSHostRecord{{RecordType: String("mx")}}))
+	tests := []struct {
+		name            string
+		records         []DomainsDNSHostRecord
+		current         string
+		want            string
+		wantSatisfiable bool
+	}{
+		{"no records, NONE zone", nil, EmailTypeNone, "", true},
+		{"plain records need nothing", []DomainsDNSHostRecord{a}, EmailTypeNone, "", true},
+		{"first MX moves up", []DomainsDNSHostRecord{a, mx}, EmailTypeNone, EmailTypeMX, true},
+		{"MX on an MX zone is already there", []DomainsDNSHostRecord{a, mx}, EmailTypeMX, "", true},
+		// The direction the first version missed entirely.
+		{"last MX removed moves down", []DomainsDNSHostRecord{a}, EmailTypeMX, EmailTypeNone, true},
+		{"first MXE moves up", []DomainsDNSHostRecord{a, mxe}, EmailTypeNone, EmailTypeMXE, true},
+		{"MXE on an MXE zone is already there", []DomainsDNSHostRecord{mxe}, EmailTypeMXE, "", true},
+		{"last MXE removed moves down", []DomainsDNSHostRecord{a}, EmailTypeMXE, EmailTypeNone, true},
+		// Unsatisfiable sets must be distinguishable from "nothing to do".
+		{"MX and MXE together", []DomainsDNSHostRecord{mx, mxe}, EmailTypeMX, "", false},
+		{"two MXE records", []DomainsDNSHostRecord{mxe, mxe}, EmailTypeNone, "", false},
+		// Matching is case-insensitive, like the rest of the layer.
+		{"lower-case type", []DomainsDNSHostRecord{{RecordType: String("mx")}}, EmailTypeNone, EmailTypeMX, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, satisfiable := requiredEmailType(tc.records, tc.current)
+			assert.Equal(t, tc.want, got)
+			assert.Equal(t, tc.wantSatisfiable, satisfiable)
+		})
+	}
+}
+
+// TestPlanSurfacesDownTransition covers the mirror of the add case: Plan must
+// tell a caller that removing the last MX record needs WithEmailType too.
+func TestPlanSurfacesDownTransition(t *testing.T) {
+	t.Parallel()
+	m := newDNSMock(EmailTypeMX, []DomainsDNSHostRecordDetailed{
+		detailed("@", RecordTypeA, "10.0.0.1", nil, 1800),
+		detailed("@", RecordTypeMX, "mail.example.com", Int(10), 1800),
+	})
+	client, server := mockedClient(m)
+	defer server.Close()
+
+	diff, err := client.DomainsDNS.PlanWithContext(context.Background(), "domain.net",
+		DeleteOp(RecordSelector{RecordType: String(RecordTypeMX)}))
+	assert.NoError(t, err)
+	assert.Equal(t, EmailTypeMX, diff.EmailType)
+	assert.Equal(t, EmailTypeNone, diff.RequiredEmailType, "removing the last MX record must surface the move down")
+	assert.True(t, diff.Satisfiable)
+	assert.Contains(t, diff.String(), "EmailType: MX -> NONE")
+}
+
+// TestPlanReportsUnsatisfiableSet guards the third state: a set no EmailType can
+// carry must not read as "no transition needed".
+func TestPlanReportsUnsatisfiableSet(t *testing.T) {
+	t.Parallel()
+	m := newDNSMock(EmailTypeMX, []DomainsDNSHostRecordDetailed{
+		detailed("@", RecordTypeMX, "mail.example.com", Int(10), 1800),
+	})
+	client, server := mockedClient(m)
+	defer server.Close()
+
+	diff, err := client.DomainsDNS.PlanWithContext(context.Background(), "domain.net",
+		AddOp(DomainsDNSHostRecord{HostName: String("@"), RecordType: String(RecordTypeMXE), Address: String("10.0.0.5"), TTL: Int(1800)}))
+	assert.NoError(t, err)
+	assert.False(t, diff.Satisfiable, "MX + MXE cannot be written under any EmailType")
+	assert.Empty(t, diff.RequiredEmailType)
+}
+
+// TestDiffStringOmitsUnchangedEmailType pins that a zone already carrying the
+// required type renders no transition line — without this, every ordinary MX
+// zone would print a bogus "MX -> MX".
+func TestDiffStringOmitsUnchangedEmailType(t *testing.T) {
+	t.Parallel()
+	diff := RecordDiff{EmailType: EmailTypeMX, RequiredEmailType: EmailTypeMX, Satisfiable: true}
+	assert.NotContains(t, diff.String(), "EmailType:")
+
+	moved := RecordDiff{EmailType: EmailTypeNone, RequiredEmailType: EmailTypeMX, Satisfiable: true}
+	assert.Contains(t, moved.String(), "EmailType: NONE -> MX")
+}
+
+// TestEmailTypeErrorsAreTyped pins that a caller can distinguish an invalid
+// request from a failed API call without matching on strings.
+func TestEmailTypeErrorsAreTyped(t *testing.T) {
+	t.Parallel()
+	m := newDNSMock(EmailTypeNone, nil)
+	client, server := mockedClient(m)
+	defer server.Close()
+
+	_, err := client.DomainsDNS.AddRecordsWithContext(context.Background(), "domain.net",
+		[]DomainsDNSHostRecord{
+			{HostName: String("@"), RecordType: String(RecordTypeMX), Address: String("mail.example.com"), MXPref: UInt8(10), TTL: Int(1800)},
+		})
+	assert.Error(t, err)
+	var invalid *InvalidArgumentsError
+	assert.ErrorAs(t, err, &invalid, "record-level validation must return a typed error, like the rest of the package")
+	assert.Contains(t, invalid.Fields, "EmailType")
+}
+
+// TestWithEmailTypeRejectsUnknownValue covers the most likely caller mistake:
+// the argument itself being wrong. It must fail naming the option, not die later
+// inside SetHosts with a message that never mentions it.
+func TestWithEmailTypeRejectsUnknownValue(t *testing.T) {
+	t.Parallel()
+	for _, value := range []string{"", "mx", "bogus", "NONE "} {
+		t.Run(fmt.Sprintf("%q", value), func(t *testing.T) {
+			t.Parallel()
+			m := newDNSMock(EmailTypeNone, []DomainsDNSHostRecordDetailed{
+				detailed("@", RecordTypeA, "10.0.0.1", nil, 1800),
+			})
+			client, server := mockedClient(m)
+			defer server.Close()
+
+			_, err := client.DomainsDNS.AddRecordsWithContext(context.Background(), "domain.net",
+				[]DomainsDNSHostRecord{
+					{HostName: String("www"), RecordType: String(RecordTypeA), Address: String("10.0.0.2"), TTL: Int(1800)},
+				}, WithEmailType(value))
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "WithEmailType", "the error must name the option that is wrong")
+			assert.Empty(t, m.setParams, "an invalid EmailType must not be written")
+		})
+	}
+}
+
+// TestEmailTypeConflictOnConcurrentRevert is the guarantee WithEmailType has to
+// carry: if another writer reverts the EmailType between the write and the
+// verifying re-read, that is a conflict, not a success. Without this the caller
+// is told mail routing was switched on when it was not — and the zone is left
+// holding an MX record the layer then refuses to touch.
+func TestEmailTypeConflictOnConcurrentRevert(t *testing.T) {
+	t.Parallel()
+	m := newDNSMock(EmailTypeNone, []DomainsDNSHostRecordDetailed{
+		detailed("@", RecordTypeA, "10.0.0.1", nil, 1800),
+	})
+	m.afterSet = func(m *dnsMock, _ int) { m.emailType = EmailTypeNone }
+	client, server := mockedClient(m)
+	defer server.Close()
+
+	_, err := client.DomainsDNS.AddRecordsWithContext(context.Background(), "domain.net",
+		[]DomainsDNSHostRecord{
+			{HostName: String("@"), RecordType: String(RecordTypeMX), Address: String("mail.example.com"), MXPref: UInt8(10), TTL: Int(1800)},
+		}, WithEmailType(EmailTypeMX))
+	assert.ErrorIs(t, err, ErrConcurrentModification,
+		"a reverted EmailType must be detected, not reported as a successful transition")
 }


### PR DESCRIPTION
## Summary

The SDK's client-side `setHosts` validation couples mail records to the zone `EmailType`: an `MX` record is rejected unless the zone is `EmailType=MX`, an `MXE` record unless it is `MXE`, and an `MX` zone must keep at least one `MX` record. (Whose rules these are turns out to matter — see below.)

The record-level layer from #119 always **preserves** the EmailType it reads. That is correct for ordinary A/CNAME/TXT changes and wrong for mail: you cannot add the *first* MX record to a `NONE` zone, cannot remove the *last* one from an `MX` zone, and MXE is unreachable entirely. The only workaround was dropping to raw `GetHosts`/`SetHosts` — which forfeits exactly the `ErrConcurrentModification` detection these helpers exist to provide.

Closes #138. Unblocks the `namecheap_dns_record` resource in namecheap/terraform-provider-namecheap#248, whose per-record model needs the MX lifecycle.

## Change

```go
// Add the first MX record and switch mail routing on, in one conflict-checked write.
AddRecordsWithContext(ctx, domain, mx, WithEmailType(EmailTypeMX))

// Remove the last MX record and switch it off.
DeleteRecordsWithContext(ctx, domain, sel, WithEmailType(EmailTypeNone))
```

**Validation before the write.** The resulting record set is checked against the EmailType the write will carry. `SetHosts` enforces the same rules a moment later, but its message cannot tell a record-level caller what to *do* about it — these errors name `WithEmailType`, because that is the fix, and they are typed `*InvalidArgumentsError` so a caller can distinguish an invalid request from a failed call:

```
the resulting record set has 1 MX record(s), which the SDK's setHosts validation
accepts only on an EmailType=MX zone, but the zone's current EmailType is "NONE":
pass WithEmailType(EmailTypeMX)
```

Note a `getHosts` still happens first — the final set has to be computed before it can be checked — but nothing is *written*.

**Plan surfaces the transition in both directions**, making the requirement discoverable rather than something you learn from an error. `RecordDiff` gains `EmailType` (what the zone has), `RequiredEmailType` (what the change needs it moved to, covering both adding the first MX record and removing the last), and `Satisfiable` (false when no EmailType can carry the set at all). `String()` renders `EmailType: NONE -> MX` when a move is needed.

## Compatibility

Additive. No signature changes; the two new `RecordDiff` fields are zero-valued for existing callers, and preserving remains the default for every existing call site.

`TestEmailTypePreservedByDefault` pins that across `NONE`/`MX`/`FWD`/`OX`/`GMAIL`: an A-record change must never disturb mail routing.

## Whose rules are these? (please read before merging)

The rules this validates are **the SDK's own client-side invention** — the published API reference documents no MX/EmailType coupling at all. The first version of this PR restated them in docs and error strings as facts about the server; that has been corrected throughout to say whose rule it is.

That matters because at least one of them looks **wrong**. An `OX` (Private Email) or `GMAIL` zone keeps its provider's MX records in the host list while the zone type stays `OX`/`GMAIL` — so `getHosts` returns a record set that `setHosts` validation then refuses to write back. The consequence is not limited to mail: **no record-level mutation works on such a zone**, including changing an unrelated A record, and the error suggests `WithEmailType(EmailTypeMX)`, which would switch the domain off its hosted mailbox.

This is pre-existing `SetHosts` behaviour, not introduced here, but this PR is the first place it is documented — so it ships a plain limitation note and an explicit "do not follow that suggestion on an OX/GMAIL zone" rather than a fix, because the correct rule is unknown without live verification. Filed as #162, which needs a sandbox round-trip against a real Private Email domain.

On an `FWD` zone (alongside `setEmailForwarding`) the original guidance stands: leave the option off and let the value be preserved, or the mail is silently rerouted.

## Review round 1

One reviewer approved after killing all six mutations it tried; the other found three defects that would have shipped a wrong public contract, all fixed in the second commit:

- **`Plan` only surfaced the up-transition.** `requiredEmailType` looked at the final record set alone, so "remove the last MX record" — this PR's own mirror example — reported nothing, and the README's documented predicate then said "nothing to do" for a change that fails. It now takes the current EmailType and answers in both directions, and `RecordDiff.Satisfiable` distinguishes "no EmailType can carry this set" from "nothing to do".
- **The verify step ignored EmailType.** A concurrent writer reverting it was reported as a clean success, leaving an MX record on a `NONE` zone that this same layer then refuses to touch. Now compared, and `TestEmailTypeConflictOnConcurrentRevert` pins it.
- **The OX/GMAIL guidance was wrong in a way that could cost someone their mail** — see the section above.
- Errors are now `*InvalidArgumentsError` (matching `validateOps` fifteen lines away), `WithEmailType` validates its own argument, and three surviving mutations got tests — including a `Required == EmailType` case that would otherwise have rendered a bogus `EmailType: MX -> MX` on every ordinary MX zone.

## Tests

34 new cases:

| Test | Covers |
|---|---|
| `TestAddFirstMXRecordWithEmailType` | the case that was impossible: first MX on a `NONE` zone, with the write carrying `EmailType=MX` and unrelated records intact |
| `TestDeleteLastMXRecordWithEmailType` | the mirror: last MX off an `MX` zone, mail switched off in the same write |
| `TestMXERecordLifecycleWithEmailType` | MXE add *and* delete — previously unreachable through this layer |
| `TestEmailTypeMismatchRejectedBeforeWrite` | 3 cases: each fails with an error naming `WithEmailType`, and **`setParams` is empty** — nothing was sent |
| `TestEmailTypePreservedByDefault` | 5 cases: the regression guard for every existing caller |
| `TestPlanSurfacesEmailTypeTransition` / `...DownTransition` / `...UnsatisfiableSet` | the diff reports `NONE -> MX` and `MX -> NONE`, flags an unwritable set, stays quiet when nothing is needed, and writes nothing |
| `TestEmailTypeConflictOnConcurrentRevert` | a reverted EmailType is a conflict, not a silent success |
| `TestEmailTypeErrorsAreTyped` | `errors.As` to `*InvalidArgumentsError` |
| `TestWithEmailTypeRejectsUnknownValue` | 4 cases: a bad argument fails naming the option, nothing written |
| `TestValidateEmailType` | 11-case rule table including the unsatisfiable MX+MXE set |
| `TestRequiredEmailType` | 11-case table covering both transition directions and unsatisfiable sets |
| `TestDiffStringOmitsUnchangedEmailType` | no bogus `MX -> MX` line on an ordinary MX zone |

`make format check lint test-unit-quiet` and `make test-race` all green (lint: 0 issues).

## Checklist

- [x] Tests added or updated
- [x] `make format && make check && make lint && make test-unit-quiet` passes locally
- [x] All commits have a `Signed-off-by:` trailer
