### PR TITLE
feat(dns): record-level operations accept an explicit EmailType

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,8 +39,28 @@ Supporting configuration:
 
 - PR title must follow Conventional Commits; `pr-title.yml` fails the PR
   otherwise.
-- PRs are squash-merged, so the PR title becomes the commit message that
+- PRs are squash-merged, so the PR title becomes the commit subject that
   release-please classifies.
+- **The PR *body* becomes the commit body, and release-please parses that too.**
+  A body line that begins with an identifier immediately followed by `(` — a Go
+  call at the start of a line in a fenced example, say — is read as a
+  `type(scope)` header, and a nested parenthesis makes the whole commit
+  unparseable:
+
+  ```
+  commit could not be parsed: 8f94f7a feat(dns): add WithEmailType ... (#161)
+  error message: Error: unexpected token '(' at 27:53, valid tokens [)]
+  Considering: 0 commits — No commits for path: ., skipping
+  ```
+
+  release-please then opens **no release PR at all** and the change silently does
+  not ship. It happened to #161. Either indent such lines inside the fence so
+  they do not start at column 0, or pass an explicit body when merging:
+
+  ```shell
+  gh pr merge <n> --squash --body "Short prose summary, no code."
+  ```
+
 - `ci.yml` runs on the PR and again on the resulting merge commit.
 
 At this point nothing is released — the commit simply sits on `master`.


### PR DESCRIPTION
The WithEmailType feature merged in #161 will not ship, because release-please could not parse its commit and therefore opened no release PR at all.

The squash commit took its message from that PR body, which contains a Go example whose line begins with an identifier followed by an opening parenthesis. The conventional-commit parser reads such a line as a type-and-scope header and fails on the nested parenthesis. The versioning run reported: commit could not be parsed, unexpected token at 27:53, considering 0 commits, no commits for path, skipping.

A silent no-op is the worst possible outcome here: CI was green, the merge succeeded, the issue closed, and nothing would have been released.

This PR carries a parseable subject so release-please classifies the change as a minor feature and cuts the release, and it adds the failure mode to RELEASE.md with both remedies: indent code inside fences so no line starts at column zero, or pass an explicit body when squash-merging.

No code changes — the feature itself is already on master. Note this PR body deliberately contains no fenced code, for the obvious reason.