### PR TITLE
ci: drop the removed vendor key from the Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,9 @@ updates:
     commit-message:
       prefix: fix
       include: scope
-    # Dependencies are vendored; without this a bump PR would leave vendor/
-    # out of sync with go.mod and fail CI.
-    vendor: true
+    # Dependencies are vendored; Dependabot auto-detects the vendor/ tree for
+    # gomod and updates it in bump PRs. (The explicit `vendor` key was removed
+    # from the config schema and now fails validation.)
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
GitHub removed the `vendor` property from the Dependabot config schema, so config validation now fails on every push, on master and PRs alike:

```
The property '#/updates/0/' contains additional properties ["vendor"] outside of the schema when none are allowed
```

Dependabot auto-detects the vendored tree for gomod and updates it in bump PRs regardless, so the key was already redundant — removing it changes no behavior. The comment now records why the key is absent.