### PR TITLE
fix: expose DomainDetails on the domains.renew result and accept non-padded API dates

### DIFF
--- a/docs/namecheap-api-v2.md
+++ b/docs/namecheap-api-v2.md
@@ -318,7 +318,7 @@ Renews an expiring domain.
 | OrderID | Unique integer representing the order |
 | TransactionID | Unique integer representing the transaction |
 | DomainDetails/ExpiredDate | New expiration date after the renewal (child element; may be non-zero-padded, e.g. 2/20/2019) |
-| DomainDetails/NumYears | Number of years reflected in the renewal details (child element) |
+| DomainDetails/NumYears | Number of years reflected in the renewal details (child element; the live API frequently returns 0) |
 
 ---
 

--- a/docs/namecheap-api-v2.md
+++ b/docs/namecheap-api-v2.md
@@ -317,6 +317,8 @@ Renews an expiring domain.
 | ChargedAmount | Total amount charged for renewal |
 | OrderID | Unique integer representing the order |
 | TransactionID | Unique integer representing the transaction |
+| DomainDetails/ExpiredDate | New expiration date after the renewal (child element; may be non-zero-padded, e.g. 2/20/2019) |
+| DomainDetails/NumYears | Number of years reflected in the renewal details (child element) |
 
 ---
 

--- a/namecheap/datetime.go
+++ b/namecheap/datetime.go
@@ -14,7 +14,8 @@ func (dt DateTime) String() string {
 	return dt.Time.String()
 }
 
-// UnmarshalText parses an API date in MM/DD/YYYY form, ignoring surrounding
+// UnmarshalText parses an API date in MM/DD/YYYY or M/D/YYYY form (the API is
+// inconsistent about zero-padding across endpoints), ignoring surrounding
 // whitespace. Empty or whitespace-only input yields the zero time without
 // error: the API omits or empties date elements for domains that lack them,
 // and failing there would abort decoding of the entire response.
@@ -25,7 +26,7 @@ func (dt *DateTime) UnmarshalText(text []byte) (err error) {
 		return nil
 	}
 
-	dt.Time, err = time.Parse("01/02/2006", trimmed)
+	dt.Time, err = time.Parse("1/2/2006", trimmed)
 	return err
 }
 

--- a/namecheap/datetime_test.go
+++ b/namecheap/datetime_test.go
@@ -76,6 +76,14 @@ func TestDateTimeUnmarshalText(t *testing.T) {
 		assert.True(t, dt.Equal(DateTime{Time: time.Date(2021, 11, 26, 0, 0, 0, 0, time.UTC)}))
 	})
 
+	t.Run("non_padded_date_parses", func(t *testing.T) {
+		t.Parallel()
+		dt := &DateTime{}
+		err := dt.UnmarshalText([]byte("2/20/2019"))
+		assert.NoError(t, err)
+		assert.True(t, dt.Equal(DateTime{Time: time.Date(2019, 2, 20, 0, 0, 0, 0, time.UTC)}))
+	})
+
 	t.Run("iso_timestamp_returns_error", func(t *testing.T) {
 		t.Parallel()
 		dt := &DateTime{}

--- a/namecheap/domains_renew.go
+++ b/namecheap/domains_renew.go
@@ -22,7 +22,7 @@ type DomainsRenewCommandResponse struct {
 }
 
 // DomainsRenewResult is the outcome of a renewal. Fields follow the renew
-// response table in docs/namecheap-api-v2.md (lines 311-319).
+// response table in docs/namecheap-api-v2.md (lines 311-321).
 type DomainsRenewResult struct {
 	// DomainName is the domain that was renewed.
 	DomainName *string `xml:"DomainName,attr"`
@@ -37,6 +37,9 @@ type DomainsRenewResult struct {
 	OrderID *int `xml:"OrderID,attr"`
 	// TransactionID is the unique integer identifying the transaction.
 	TransactionID *int `xml:"TransactionID,attr"`
+	// DomainDetails carries the post-renewal registration dates (ExpiredDate,
+	// NumYears); the renew response does not include CreatedDate.
+	DomainDetails *DomainDetails `xml:"DomainDetails"`
 }
 
 // DomainsRenewArgs are the arguments for RenewWithContext. Field names and

--- a/namecheap/domains_renew_test.go
+++ b/namecheap/domains_renew_test.go
@@ -71,6 +71,10 @@ func TestDomainsService_Renew(t *testing.T) {
 		assert.Equal(t, 987654, *result.OrderID)
 		assert.Equal(t, 112233, *result.TransactionID)
 		assert.Equal(t, Amount("9.56"), *result.ChargedAmount)
+		if assert.NotNil(t, result.DomainDetails) {
+			assert.True(t, result.DomainDetails.ExpiredDate.Equal(DateTime{Time: time.Date(2027, 10, 13, 0, 0, 0, 0, time.UTC)}))
+			assert.Equal(t, 0, *result.DomainDetails.NumYears)
+		}
 	})
 
 	t.Run("nil_args", func(t *testing.T) {

--- a/namecheap/domains_renew_test.go
+++ b/namecheap/domains_renew_test.go
@@ -23,7 +23,7 @@ const domainsRenewOKResponse = `
 		<CommandResponse Type="namecheap.domains.renew">
 			<DomainRenewResult DomainName="example.com" DomainID="1234567" Renew="true" OrderID="987654" TransactionID="112233" ChargedAmount="9.56">
 				<DomainDetails>
-					<ExpiredDate>10/13/2027</ExpiredDate>
+					<ExpiredDate>2/1/2027</ExpiredDate>
 					<NumYears>0</NumYears>
 				</DomainDetails>
 			</DomainRenewResult>
@@ -71,8 +71,12 @@ func TestDomainsService_Renew(t *testing.T) {
 		assert.Equal(t, 987654, *result.OrderID)
 		assert.Equal(t, 112233, *result.TransactionID)
 		assert.Equal(t, Amount("9.56"), *result.ChargedAmount)
+		// The fixture's ExpiredDate is deliberately non-padded (2/1/2027), the
+		// form the official renew docs show: this pins the full chain — a
+		// charge-bearing, non-retried response must not fail decoding on a
+		// non-padded date — against reverting DateTime to a strict layout.
 		if assert.NotNil(t, result.DomainDetails) {
-			assert.True(t, result.DomainDetails.ExpiredDate.Equal(DateTime{Time: time.Date(2027, 10, 13, 0, 0, 0, 0, time.UTC)}))
+			assert.True(t, result.DomainDetails.ExpiredDate.Equal(DateTime{Time: time.Date(2027, 2, 1, 0, 0, 0, 0, time.UTC)}))
 			assert.Equal(t, 0, *result.DomainDetails.NumYears)
 		}
 	})


### PR DESCRIPTION
## Summary

The `namecheap.domains.renew` response carries a `DomainDetails` child element with the post-renewal `ExpiredDate` and `NumYears`, but `DomainsRenewResult` only mapped the result attributes, so the block was silently dropped and consumers had to make an extra `getInfo` round trip to learn the new expiration date.

- Map `DomainDetails` on `DomainsRenewResult`, reusing the existing `DomainDetails` type from `domains_get_info.go` (`CreatedDate` is simply `nil` — renew does not return it).
- Parse API dates with the flexible-width `1/2/2006` layout: the documented renew response formats dates without zero padding (e.g. `2/20/2019`), which the strict `MM/DD/YYYY` layout rejected. A `DateTime` parse failure aborts decoding of the entire response, and renew is deliberately never retried (double-charge risk), so a cosmetic format mismatch would have turned a successful charge-bearing renewal into an SDK error. The new layout accepts both padded and non-padded forms — a strict superset, nothing that parsed before breaks.
- Add the missing `DomainDetails` rows to the renew response table in `docs/namecheap-api-v2.md`.

## Testing

- New `non_padded_date_parses` case in `datetime_test.go` pins the `2/20/2019` form.
- The renew success test now asserts `DomainDetails.ExpiredDate` and `NumYears` from the fixture (which already contained the block).
- `make format`, `make check`, `make lint`, `make test-unit-quiet` (94.9% coverage), `make test-race` — all green.

Fixes #166
Jira: DEVOPS-21956