### PR TITLE
chore: require go1.26.6, the first patch carrying the stdlib fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,9 @@ jobs:
       # were reachable from this code when this job was added. govulncheck
       # reports only vulnerabilities with a call path into our packages and
       # exits 3 for them, so a failure here is always reachable, never
-      # advisory: fix it by bumping `toolchain` in go.mod (standard library)
-      # or the dependency itself (module).
+      # advisory: fix it by bumping `toolchain` in go.mod (standard library,
+      # and the `go` floor too if the advisory is reachable from this SDK's own
+      # call paths -- see SECURITY.md) or the dependency itself (module).
       - name: govulncheck (root module)
         run: govulncheck -mode=source ./...
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,15 +6,18 @@ Only the latest release of `github.com/namecheap/go-namecheap-sdk/v2` receives s
 
 ## Go toolchain
 
-Build with **go1.26.6 or newer**. Earlier Go 1.26 patch releases carry standard-library
-advisories that are reachable through this SDK's own call paths, for example
+This module **requires go1.26.6 or newer** — that is the `go` directive in `go.mod`, and 1.26.6 is
+the first Go 1.26 patch carrying the standard-library fixes for advisories reachable through this
+SDK's own call paths, for example
 [GO-2026-6088](https://pkg.go.dev/vuln/GO-2026-6088) (`encoding/xml`, reached from response
 decoding) and [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026) (`net/http`, reached from the
 request path used by every API call).
 
 Standard-library fixes ship in the Go toolchain, not in this module: they reach your binaries only
 when *you* build with a patched toolchain, so this is not something an SDK release can do for you.
-The `go` directive in `go.mod` is a minimum, not a recommendation.
+The `go` directive is the one lever that does reach your build, which is why it is set to a patch
+release rather than a bare `1.26` — and it is a floor, not a ceiling. Newer patches are always
+preferred; the floor moves only when an advisory is found reachable from this SDK's own code.
 
 This repository builds and tests itself with the version in the `toolchain` directive of `go.mod`,
 and runs [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) over both modules on

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,25 @@
 module github.com/namecheap/go-namecheap-sdk/v2
 
-go 1.26.3
+// The floor every consumer must meet. 1.26.6 is the first Go 1.26 patch that
+// carries the standard-library fixes for advisories govulncheck finds
+// reachable from this SDK's own call paths -- encoding/xml from decodeBody,
+// encoding/asn1, net/http from doXMLWithCommand. A library cannot fix those
+// for its consumers: standard-library fixes ship in the toolchain that
+// compiles the final binary, so the only lever that reaches a consumer's build
+// is this line. See SECURITY.md.
+//
+// Raising it is consumer-visible. A consumer on an older patch gets
+// "requires go >= 1.26.6" from `go build` until they re-run `go get` /
+// `go mod tidy` (which switches toolchain and rewrites their own `go` line),
+// and one running GOTOOLCHAIN=local must install a newer Go by hand. Raise it
+// only for a reachable advisory, and only in its own release.
+go 1.26.6
 
-// Build and test this module with a patched toolchain. Every Go patch release
-// after 1.26.3 carries standard-library security fixes that govulncheck finds
-// reachable from this code (encoding/xml via decodeBody, encoding/asn1,
-// net/http via doXMLWithCommand). `toolchain` applies only when this module is
-// the main module, so it does not raise the minimum Go version for consumers
-// -- that is still the `go` directive above. actions/setup-go reads this line
-// in preference to `go`, so CI compiles against it too. Bump it when
-// govulncheck reports a new standard-library advisory.
+// What this repository's own builds and CI use: the newest patch, chosen
+// independently of the floor above. It applies only while this module is the
+// main module, so it imposes nothing on consumers. actions/setup-go reads it
+// in preference to `go`, and `go mod tidy` keeps it only while it is newer
+// than the `go` line -- if the floor ever catches up, this line disappears.
 toolchain go1.26.7
 
 require (

--- a/otelnamecheap/go.mod
+++ b/otelnamecheap/go.mod
@@ -1,8 +1,8 @@
 module github.com/namecheap/go-namecheap-sdk/otelnamecheap
 
-go 1.26.3
+// Both directives kept in step with the root go.mod; the reasoning is there.
+go 1.26.6
 
-// Kept in step with the root go.mod; see the comment there.
 toolchain go1.26.7
 
 require (


### PR DESCRIPTION
> **#180 has merged**, so this is now a single commit rebased onto `master` — no conflicts, nothing stacked. Re-verified after the rebase: tidy clean in both modules with both directives surviving, vendor gate passes, tests and `govulncheck` green.

Raises the module's minimum Go version so the standard-library security fixes actually reach **consumers**, which #180 deliberately did not do.

## Why this is needed at all

#180 added `toolchain go1.26.7`, which fixed *this repository's* builds — CI and `govulncheck` are clean. But the `toolchain` directive applies only while a module is the **main** module, so it is ignored entirely when someone imports this SDK. I verified that against the #180 branch with a scratch consumer module:

| consumer setup | result |
| --- | --- |
| go1.26.5, SDK with `toolchain go1.26.7` (#180 as merged) | builds fine, binary built by **go1.26.5** → still ships the vulnerable stdlib |

Those six advisories are reachable through *this SDK's own call paths* — `encoding/xml` from `decodeBody`, `net/http` from `doXMLWithCommand` — so the reachability is something we hand consumers. Standard-library fixes ship in the toolchain that compiles the final binary, and the `go` directive is the only lever in our control that reaches it.

## Why 1.26.6 and not 1.26.7

**1.26.6 is the first patch carrying all six fixes** (every advisory reads `Fixed in: ...@go1.26.6`), so it is the least restrictive floor that achieves the goal. Making the floor 1.26.7 would impose a stricter requirement for no additional security benefit.

The two directives then do distinct jobs, which is the point:

```
go 1.26.6         // the floor consumers must meet
toolchain go1.26.7 // what this repo's own builds/CI use — imposes nothing on consumers
```

`go mod tidy` preserves `toolchain` while it is newer than `go` (verified; it strips it the moment the two are equal, which would silently break the tidy gate in #180 — that gate caught this while writing the PR).

## Consumer effect, measured against this branch

| consumer setup | result |
| --- | --- |
| `GOTOOLCHAIN=auto` (the default), `go build` | **exit 1** — `requires go >= 1.26.6`; no silent auto-switch on a plain build |
| `GOTOOLCHAIN=auto`, then `go get` / `go mod tidy` | switches toolchain, rewrites *their* `go` line to **1.26.6**, binary then built by **go1.26.6** → patched |
| `GOTOOLCHAIN=local` on an older patch (pinned/air-gapped/distro Go) | **hard failure**, must install a newer Go by hand |

Note the third row is the real cost, and the second row's detail matters: the consumer lands on **1.26.6**, *not* dragged to our 1.26.7 — the `toolchain` line stays ours.

## Precedent and release semantics

`git log` on `go.mod` shows this directive has only ever moved as its own deliberate change — `go 1.23.0` → `1.24.0` (#65) → `1.25.0` (#67) → `1.26.3` (#68), each a standalone `chore:` PR, never folded into a dependency or CI change. This follows that shape.

**One thing to decide:** `chore` is non-releasing under `.release-please-config.json`, so as titled this floor raise would ship silently inside whatever `fix`/`feat` release comes next, with no changelog line. Given a consumer on an older patch gets a hard build error, you may prefer to retitle this to `fix:` so it cuts its own release and appears in the changelog. I kept `chore:` to match the four prior Go bumps — say the word and I will retitle.

## Also included

- `SECURITY.md`: the Go-toolchain section added in #180 is updated from "build with 1.26.6+" (advice) to the now-enforced requirement, with a note that the floor moves only when an advisory is found reachable from this SDK's own code.
- `otelnamecheap/go.mod`: same two directives, kept in step.
- One comment in `ci.yml` made precise: a govulncheck failure on a *reachable* stdlib advisory means bumping the `go` floor too, not just `toolchain`.

## Verification

Run locally on this branch (go1.26.7, darwin/arm64):

- `go mod tidy` in both modules — no diff; **both** directives survive
- `go mod vendor` + `git diff --exit-code -- vendor` — clean
- `make check`, `make test` (unit + `-race`) — pass
- `govulncheck -mode=source ./...` — clean in both modules
- `otelnamecheap`: tidy, `go vet`, `go test -race`, govulncheck — all pass
- Consumer-impact table above reproduced with a scratch module using a `replace` onto this checkout
